### PR TITLE
Add cpu-profiling to kpod

### DIFF
--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -1410,6 +1410,7 @@ _kpod_logout() {
 _kpod_kpod() {
      local options_with_args="
            --config -c
+           --cpu-profile
            --root
            --runroot
            --storage-driver

--- a/docs/kpod.1.md
+++ b/docs/kpod.1.md
@@ -26,6 +26,9 @@ has the capability to debug pods/images created by crio.
 **--config value, -c**=**"config.file"**
    Path of a config file detailing container server configuration options
 
+**--cpu-profile**
+   Path to where the cpu performance results should be written
+
 **--log-level**
    log messages above specified level: debug, info, warn, error (default), fatal or panic
 


### PR DESCRIPTION
Add a global flag for cpu-profiling to allow us to
profile kpod for performance issues.

To parse its results, use:

go tool pprof --text <profile_path>

Signed-off-by: baude <bbaude@redhat.com>