### PR TITLE
Address run/create performance issues

### DIFF
--- a/cmd/kpod/create.go
+++ b/cmd/kpod/create.go
@@ -135,6 +135,7 @@ var createCommand = cli.Command{
 func createCmd(c *cli.Context) error {
 	// TODO should allow user to create based off a directory on the host not just image
 	// Need CLI support for this
+	var imageName string
 	if err := validateFlags(c, createFlags); err != nil {
 		return err
 	}
@@ -151,7 +152,8 @@ func createCmd(c *cli.Context) error {
 
 	// Deal with the image after all the args have been checked
 	createImage := runtime.NewImage(createConfig.image)
-	if !createImage.HasImageLocal() {
+	createImage.LocalName, _ = createImage.GetLocalImageName()
+	if createImage.LocalName == "" {
 		// The image wasnt found by the user input'd name or its fqname
 		// Pull the image
 		fmt.Printf("Trying to pull %s...", createImage.PullName)
@@ -163,7 +165,11 @@ func createCmd(c *cli.Context) error {
 		return err
 	}
 	defer runtime.Shutdown(false)
-	imageName, err := createImage.GetFQName()
+	if createImage.LocalName != "" {
+		imageName = createImage.LocalName
+	} else {
+		imageName, err = createImage.GetFQName()
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/run.go
+++ b/cmd/kpod/run.go
@@ -22,6 +22,7 @@ var runCommand = cli.Command{
 }
 
 func runCmd(c *cli.Context) error {
+	var imageName string
 	if err := validateFlags(c, createFlags); err != nil {
 		return err
 	}
@@ -37,8 +38,8 @@ func runCmd(c *cli.Context) error {
 	}
 
 	createImage := runtime.NewImage(createConfig.image)
-
-	if !createImage.HasImageLocal() {
+	createImage.LocalName, _ = createImage.GetLocalImageName()
+	if createImage.LocalName == "" {
 		// The image wasnt found by the user input'd name or its fqname
 		// Pull the image
 		fmt.Printf("Trying to pull %s...", createImage.PullName)
@@ -52,7 +53,11 @@ func runCmd(c *cli.Context) error {
 	defer runtime.Shutdown(false)
 	logrus.Debug("spec is ", runtimeSpec)
 
-	imageName, err := createImage.GetFQName()
+	if createImage.LocalName != "" {
+		imageName = createImage.LocalName
+	} else {
+		imageName, err = createImage.GetFQName()
+	}
 	if err != nil {
 		return err
 	}

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -1,8 +1,10 @@
 package libpod
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // WriteFile writes a provided string to a provided path
@@ -31,4 +33,12 @@ func StringInSlice(s string, sl []string) bool {
 		}
 	}
 	return false
+}
+
+// FuncTimer helps measure the execution time of a function
+// For debug purposes, do not leave in code
+// used like defer FuncTimer("foo")
+func FuncTimer(funcName string) {
+	elapsed := time.Since(time.Now())
+	fmt.Printf("%s executed in %d ms\n", funcName, elapsed)
 }


### PR DESCRIPTION
Fixed the logic where we observed different performance
results when running an image by its fqname vs a shortname. In
the case of the latter, we resolve the name without using the
network.

Signed-off-by: baude <bbaude@redhat.com>