### PR TITLE
Remove all images

### DIFF
--- a/cmd/kpod/rmi.go
+++ b/cmd/kpod/rmi.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/libpod"
 	"github.com/urfave/cli"
 )
 
 var (
 	rmiDescription = "removes one or more locally stored images."
 	rmiFlags       = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "all, a",
+			Usage: "remove all images",
+		},
 		cli.BoolFlag{
 			Name:  "force, f",
 			Usage: "force removal of the image",
@@ -29,7 +34,7 @@ func rmiCmd(c *cli.Context) error {
 	if err := validateFlags(c, rmiFlags); err != nil {
 		return err
 	}
-
+	removeAll := c.Bool("all")
 	runtime, err := getRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
@@ -37,11 +42,24 @@ func rmiCmd(c *cli.Context) error {
 	defer runtime.Shutdown(false)
 
 	args := c.Args()
-	if len(args) == 0 {
+	if len(args) == 0 && !removeAll {
 		return errors.Errorf("image name or ID must be specified")
 	}
+	if len(args) > 0 && removeAll {
+		return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
+	}
+	imagesToDelete := args[:]
+	if removeAll {
+		localImages, err := runtime.GetImages(&libpod.ImageFilterParams{})
+		if err != nil {
+			return errors.Wrapf(err, "unable to query local images")
+		}
+		for _, image := range localImages {
+			imagesToDelete = append(imagesToDelete, image.ID)
+		}
+	}
 
-	for _, arg := range args {
+	for _, arg := range imagesToDelete {
 		image, err := runtime.GetImage(arg)
 		if err != nil {
 			return errors.Wrapf(err, "could not get image %q", arg)

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -1238,6 +1238,8 @@ _kpod_rmi() {
      -h
      --force
      -f
+     -a
+     --all
   "
 
     case "$cur" in

--- a/docs/kpod-rmi.1.md
+++ b/docs/kpod-rmi.1.md
@@ -13,6 +13,9 @@ Removes one or more locally stored images.
 
 ## OPTIONS
 
+**-all**, **-a**
+
+Remove all of the locally storage images
 **--force, -f**
 
 Executing this command will stop all containers that are using the image and remove them from the system
@@ -24,6 +27,8 @@ kpod rmi imageID
 kpod rmi --force imageID
 
 kpod rmi imageID1 imageID2 imageID3
+
+kpod rmi -a -f
 
 ## SEE ALSO
 kpod(1)

--- a/test/kpod_rmi.bats
+++ b/test/kpod_rmi.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load helpers
+
+IMAGE1="docker.io/library/alpine:latest"
+IMAGE2="docker.io/library/busybox:latest"
+IMAGE3="docker.io/library/busybox:glibc"
+
+function teardown() {
+  cleanup_test
+}
+
+function pullImages() {
+  ${KPOD_BINARY} $KPOD_OPTIONS pull $IMAGE1
+  ${KPOD_BINARY} $KPOD_OPTIONS pull $IMAGE2
+  ${KPOD_BINARY} $KPOD_OPTIONS pull $IMAGE3
+}
+
+@test "kpod rmi bogus image" {
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi debian:6.0.10
+	echo "$output"
+	[ "$status" -eq 1 ]
+}
+
+@test "kpod rmi image with fq name" {
+	pullImages
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE1
+	echo "$output"
+	[ "$status" -eq 0 ]
+}
+
+@test "kpod rmi image with short name" {
+	pullImages
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi alpine
+	echo "$output"
+	[ "$status" -eq 0 ]
+}
+
+@test "kpod rmi all images" {
+	pullImages
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi -a
+	echo "$output"
+	[ "$status" -eq 0 ]
+}
+
+@test "kpod rmi all images forceably" {
+	pullImages
+	${KPOD_BINARY} $KPOD_OPTIONS create ${IMAGE1} ls
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi -a -f
+	echo "$output"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Add -a/--all to rmi so a user can remove
all images quickly.

Signed-off-by: baude <bbaude@redhat.com>