### PR TITLE
Add docker transport to push image before final failure

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -53,7 +53,7 @@ var (
 	defaultRuntimeConfig = RuntimeConfig{
 		// Leave this empty so containers/storage will use its defaults
 		StorageConfig:         storage.StoreOptions{},
-		ImageDefaultTransport: "docker://",
+		ImageDefaultTransport: DefaultTransport,
 		InMemoryState:         false,
 		RuntimePath:           "/usr/bin/runc",
 		ConmonPath:            "/usr/local/libexec/crio/conmon",

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -4,7 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
+)
+
+// Runtime API constants
+const (
+	// DefaultTransport is a prefix that we apply to an image name
+	// to check docker hub first for the image
+	DefaultTransport = "docker://"
 )
 
 // WriteFile writes a provided string to a provided path
@@ -41,4 +49,9 @@ func StringInSlice(s string, sl []string) bool {
 func FuncTimer(funcName string) {
 	elapsed := time.Since(time.Now())
 	fmt.Printf("%s executed in %d ms\n", funcName, elapsed)
+}
+
+// hasTransport determines if the image string contains '://', returns bool
+func hasTransport(image string) bool {
+	return strings.Contains(image, "://")
 }

--- a/test/kpod_push.bats
+++ b/test/kpod_push.bats
@@ -72,3 +72,15 @@ function setup() {
     echo "$output"
     [ "$status" -eq 0 ]
 }
+
+@test "kpod push without transport" {
+    run ${KPOD_BINARY} $KPOD_OPTIONS pull "$ALPINE"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    # TODO: The following should fail until a registry is running in Travis CI.
+    run ${KPOD_BINARY} $KPOD_OPTIONS push "$ALPINE" localhost:5000/my-alpine
+    echo "$output"
+    [ "$status" -ne 0 ]
+    run ${KPOD_BINARY} $KPOD_OPTIONS rmi "$ALPINE"
+    echo "$output"
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add the transport "docker://" to the destination image if it fails and there's no transport specified.  Then retry the lookup and finally fail if still not found.  Also renamed the variable DefaultRegistry to DefaultTransport and replaced a few "docker://" in the code with the variable.