### PR TITLE
Use cached images for integration tests

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -64,7 +64,14 @@ if [[ ! -d "/test.dir" ]]; then
 fi
 
 TESTDIR=$(mktemp -p /test.dir -d)
-#mount -t tmpfs tmpfs ${TESTDIR}
+
+declare -A -g IMAGES
+IMAGES+=(["alpine"]=docker.io/library/alpine:latest ["busybox"]=docker.io/library/busybox:latest)
+
+BB_GLIBC="docker.io/library/busybox:glibc"
+BB="docker.io/library/busybox:latest"
+ALPINE="docker.io/library/alpine:latest"
+FEDORA_MINIMAL="registry.fedoraproject.org/fedora-minimal:latest"
 
 # kpod pull needs a configuration file for shortname pulls
 export REGISTRIES_CONFIG_PATH="$INTEGRATION_ROOT/registries.conf"
@@ -109,68 +116,18 @@ cp "$CONMON_BINARY" "$TESTDIR/conmon"
 
 PATH=$PATH:$TESTDIR
 
-# Make sure we have a copy of the redis:alpine image.
-if ! [ -d "$ARTIFACTS_PATH"/redis-image ]; then
-    mkdir -p "$ARTIFACTS_PATH"/redis-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://redis:alpine --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://redis"
-        rm -fr "$ARTIFACTS_PATH"/redis-image
-        exit 1
+for key in ${!IMAGES[@]}; do
+    if ! [ -d "$ARTIFACTS_PATH"/${key} ]; then
+        mkdir -p "$ARTIFACTS_PATH"/${key}
+        if ! "$COPYIMG_BINARY" --import-from=docker://${IMAGES[${key}]} --export-to=dir:"$ARTIFACTS_PATH"/${key} --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+            echo "Error pulling docker://${IMAGES[${key}]}"
+            rm -fr "$ARTIFACTS_PATH"/${key}
+            exit 1
+        fi
     fi
-fi
 
-# TODO: remove the code below for pulling redis:alpine using a canonical reference once
-#       https://github.com/kubernetes-incubator/cri-o/issues/531 is complete and we can
-#       pull the image using a tagged reference and then subsequently find the image without
-#       having to explicitly record the canonical reference as one of the image's names
-if ! [ -d "$ARTIFACTS_PATH"/redis-image-digest ]; then
-    mkdir -p "$ARTIFACTS_PATH"/redis-image-digest
-    if ! "$COPYIMG_BINARY" --import-from=docker://redis@sha256:03789f402b2ecfb98184bf128d180f398f81c63364948ff1454583b02442f73b --export-to=dir:"$ARTIFACTS_PATH"/redis-image-digest --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://redis@sha256:03789f402b2ecfb98184bf128d180f398f81c63364948ff1454583b02442f73b"
-        rm -fr "$ARTIFACTS_PATH"/redis-image-digest
-        exit 1
-    fi
-fi
+done
 
-# Make sure we have a copy of the runcom/stderr-test image.
-if ! [ -d "$ARTIFACTS_PATH"/stderr-test ]; then
-    mkdir -p "$ARTIFACTS_PATH"/stderr-test
-    if ! "$COPYIMG_BINARY" --import-from=docker://runcom/stderr-test:latest --export-to=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://stderr-test"
-        rm -fr "$ARTIFACTS_PATH"/stderr-test
-        exit 1
-    fi
-fi
-
-# Make sure we have a copy of the busybox:latest image.
-if ! [ -d "$ARTIFACTS_PATH"/busybox-image ]; then
-    mkdir -p "$ARTIFACTS_PATH"/busybox-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://busybox --export-to=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://busybox"
-        rm -fr "$ARTIFACTS_PATH"/busybox-image
-        exit 1
-    fi
-fi
-
-# Make sure we have a copy of the mrunalp/oom:latest image.
-if ! [ -d "$ARTIFACTS_PATH"/oom-image ]; then
-    mkdir -p "$ARTIFACTS_PATH"/oom-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://mrunalp/oom --export-to=dir:"$ARTIFACTS_PATH"/oom-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://mrunalp/oom"
-        rm -fr "$ARTIFACTS_PATH"/oom-image
-        exit 1
-    fi
-fi
-
-# Make sure we have a copy of the mrunalp/image-volume-test:latest image.
-if ! [ -d "$ARTIFACTS_PATH"/image-volume-test-image ]; then
-    mkdir -p "$ARTIFACTS_PATH"/image-volume-test-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://mrunalp/image-volume-test --export-to=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://mrunalp/image-volume-test-image"
-        rm -fr "$ARTIFACTS_PATH"/image-volume-test-image
-        exit 1
-    fi
-fi
 
 # Communicate with Docker on the host machine.
 # Should rarely use this.
@@ -343,4 +300,10 @@ function cleanup_network_conf() {
 
 function temp_sandbox_conf() {
 	sed -e s/\"namespace\":.*/\"namespace\":\ \"$1\",/g "$TESTDATA"/sandbox_config.json > $TESTDIR/sandbox_config_$1.json
+}
+
+function copy_images() {
+    for key in ${!IMAGES[@]}; do
+        "$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=${IMAGES[${key}]} --import-from=dir:"$ARTIFACTS_PATH"/${key} --add-name=${IMAGES[${key}]}
+    done
 }

--- a/test/kpod_create.bats
+++ b/test/kpod_create.bats
@@ -2,21 +2,22 @@
 
 load helpers
 
+function setup() {
+    copy_images
+}
+
 function teardown() {
     cleanup_test
 }
 
-ALPINE="docker.io/library/alpine:latest"
-
 @test "create a container based on local image" {
-    ${KPOD_BINARY} ${KPOD_OPTIONS} pull docker.io/library/busybox:latest
-    run ${KPOD_BINARY} ${KPOD_OPTIONS} create docker.io/library/busybox:latest ls
+    run ${KPOD_BINARY} ${KPOD_OPTIONS} create $BB ls
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "create a container based on a remote image" {
-    run ${KPOD_BINARY} ${KPOD_OPTIONS} create ${ALPINE} ls
+    run ${KPOD_BINARY} ${KPOD_OPTIONS} create ${BB_GLIBC} ls
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/kpod_diff.bats
+++ b/test/kpod_diff.bats
@@ -2,20 +2,16 @@
 
 load helpers
 
-IMAGE="alpine:latest"
+function setup() {
+    copy_images
+}
 
 function teardown() {
     cleanup_test
 }
 
 @test "test diff of image and parent" {
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS pull $IMAGE
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS diff $IMAGE
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+    run ${KPOD_BINARY} $KPOD_OPTIONS diff $BB
     echo "$output"
     [ "$status" -eq 0 ]
 }
@@ -27,14 +23,8 @@ function teardown() {
 }
 
 @test "test diff with json output" {
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS pull $IMAGE
-    echo "$output"
-    [ "$status" -eq 0 ]
-    # run bash -c bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} diff --format json $IMAGE | python -m json.tool"
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS diff --format json $IMAGE
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+    # run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} diff --format json $IMAGE | python -m json.tool"
+    run ${KPOD_BINARY} $KPOD_OPTIONS diff --format json $BB
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/kpod_export.bats
+++ b/test/kpod_export.bats
@@ -3,9 +3,12 @@
 load helpers
 
 IMAGE="redis:alpine"
-
 function teardown() {
     cleanup_test
+}
+
+function setup() {
+    copy_images
 }
 
 @test "kpod export output flag" {

--- a/test/kpod_history.bats
+++ b/test/kpod_history.bats
@@ -2,71 +2,46 @@
 
 load helpers
 
-IMAGE="alpine:latest"
-
 function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "kpod history default" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} history $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} history $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 }
 
 @test "kpod history with Go template format" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} history --format "{{.ID}} {{.Created}}" $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} history --format "{{.ID}} {{.Created}}" $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 }
 
 @test "kpod history human flag" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} history --human=false $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} history --human=false $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 }
 
 @test "kpod history quiet flag" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} history -q $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} history -q $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 }
 
 @test "kpod history no-trunc flag" {
-	${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} history --no-trunc $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} history --no-trunc $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
 }
 
 @test "kpod history json flag" {
-	${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} history --format json $IMAGE | python -m json.tool"
+	run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} history --format json $ALPINE | python -m json.tool"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
 }

--- a/test/kpod_import.bats
+++ b/test/kpod_import.bats
@@ -8,6 +8,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "kpod import with source and reference" {
     skip "Test needs to be converted to kpod run bash -c"
     start_crio

--- a/test/kpod_inspect.bats
+++ b/test/kpod_inspect.bats
@@ -2,22 +2,19 @@
 
 load helpers
 
-IMAGE="docker.io/library/busybox:latest"
-
 function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "kpod inspect image" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull ${IMAGE}
-    run bash -c "${KPOD_BINARY} $KPOD_OPTIONS inspect ${IMAGE} | python -m json.tool"
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi ${IMAGE}
+    run bash -c "${KPOD_BINARY} $KPOD_OPTIONS inspect ${ALPINE} | python -m json.tool"
     echo "$output"
     [ "$status" -eq 0 ]
 }
-
 
 @test "kpod inspect non-existent container" {
     run ${KPOD_BINARY} $KPOD_OPTIONS inspect 14rcole/non-existent
@@ -26,27 +23,20 @@ function teardown() {
 }
 
 @test "kpod inspect with format" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull ${IMAGE}
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS inspect --format {{.ID}} ${IMAGE}
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS inspect --format {{.ID}} ${ALPINE}
     echo "$output"
     [ "$status" -eq 0 ]
     inspectOutput="$output"
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS images --no-trunc --quiet ${IMAGE}
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS images --no-trunc --quiet ${ALPINE}
     echo "$output"
     [ "$status" -eq 0 ]
     [ "$output" = "$inspectOutput" ]
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi ${IMAGE}
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "kpod inspect specified type" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull ${IMAGE}
-    run bash -c "${KPOD_BINARY} $KPOD_OPTIONS inspect --type image ${IMAGE} | python -m json.tool"
-    echo "$output"
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi ${IMAGE}
+    run bash -c "${KPOD_BINARY} $KPOD_OPTIONS inspect --type image ${ALPINE} | python -m json.tool"
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/kpod_kill.bats
+++ b/test/kpod_kill.bats
@@ -6,6 +6,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 function start_sleep_container () {
     pod_id=$(crioctl pod run --config "$TESTDATA"/sandbox_config.json)
     ctr_id=$(crioctl ctr create --config "$TESTDATA"/container_config_sleep.json --pod "$pod_id")

--- a/test/kpod_load.bats
+++ b/test/kpod_load.bats
@@ -2,16 +2,14 @@
 
 load helpers
 
-IMAGE="alpine:latest"
+function setup() {
+    copy_images
+}
 
 function teardown() {
     cleanup_test
 }
-
 @test "kpod load input flag" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $IMAGE
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -22,14 +20,9 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
 }
 
 @test "kpod load oci-archive image" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
 	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
@@ -38,13 +31,9 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
-	[ "$status" -eq 0 ]
 }
 
 @test "kpod load oci-archive image with signature-policy" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
 	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
@@ -55,14 +44,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	rm -f /tmp/policy.json
 	rm -f alpine.tar
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
-	[ "$status" -eq 0 ]
 }
 
 @test "kpod load using quiet flag" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $IMAGE
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -73,8 +57,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
-	[ "$status" -eq 0 ]
 }
 
 @test "kpod load non-existent file" {

--- a/test/kpod_logs.bats
+++ b/test/kpod_logs.bats
@@ -8,6 +8,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "display logs for container" {
     skip "Test needs to be converted to kpod run"
     start_crio

--- a/test/kpod_mount.bats
+++ b/test/kpod_mount.bats
@@ -8,6 +8,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "mount" {
     skip "Test needs to be converted to kpod run"
     start_crio

--- a/test/kpod_pause.bats
+++ b/test/kpod_pause.bats
@@ -4,6 +4,10 @@ load helpers
 
 IMAGE="redis:alpine"
 
+function setup() {
+    copy_images
+}
+
 function teardown() {
     cleanup_test
 }

--- a/test/kpod_ps.bats
+++ b/test/kpod_ps.bats
@@ -3,6 +3,10 @@
 load helpers
 
 IMAGE="redis:alpine"
+function setup() {
+    copy_images
+}
+
 
 @test "kpod ps with no containers" {
     run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} ps

--- a/test/kpod_pull.bats
+++ b/test/kpod_pull.bats
@@ -2,8 +2,6 @@
 
 load helpers
 
-IMAGE="alpine:latest"
-
 function teardown() {
   cleanup_test
 }

--- a/test/kpod_push.bats
+++ b/test/kpod_push.bats
@@ -2,22 +2,22 @@
 
 load helpers
 
-IMAGE="alpine:latest"
-
 function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "kpod push to containers/storage" {
     skip "Issues with bash, skipping"
-    echo # Pull down the image: it gets the name $IMAGE.
-    ${KPOD_BINARY} $KPOD_OPTIONS --log-level=debug pull $IMAGE
     echo # Push the image right back into storage: it now has two names.
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS --log-level=debug push "$IMAGE" containers-storage:busybox:test
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS --log-level=debug push $ALPINE containers-storage:busybox:test
     echo "$output"
     [ "$status" -eq 0 ]
     echo # Try to remove it using the first name.  Should be refused.
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS --log-level=debug rmi $IMAGE
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS --log-level=debug rmi $ALPINE
     echo "$output"
     [ "$status" -ne 0 ]
     echo # Try to remove it using the second name.  Should also be refused.
@@ -31,48 +31,44 @@ function teardown() {
 }
 
 @test "kpod push to directory" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull "$IMAGE"
     mkdir /tmp/busybox
-    run ${KPOD_BINARY} $KPOD_OPTIONS push "$IMAGE" dir:/tmp/busybox
+    run ${KPOD_BINARY} $KPOD_OPTIONS push $ALPINE dir:/tmp/busybox
     echo "$output"
     [ "$status" -eq 0 ]
     rm -rf /tmp/busybox
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi "$IMAGE"
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $ALPINE
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "kpod push to docker archive" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull "$IMAGE"
-    run ${KPOD_BINARY} $KPOD_OPTIONS push "$IMAGE" docker-archive:/tmp/busybox-archive:1.26
+    run ${KPOD_BINARY} $KPOD_OPTIONS push $ALPINE docker-archive:/tmp/busybox-archive:1.26
     echo "$output"
     echo "--->"
     [ "$status" -eq 0 ]
     rm /tmp/busybox-archive
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi "$IMAGE"
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $ALPINE
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "kpod push to oci-archive without compression" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull "$IMAGE"
-    run ${KPOD_BINARY} $KPOD_OPTIONS push "$IMAGE" oci-archive:/tmp/oci-busybox.tar:alpine
+    run ${KPOD_BINARY} $KPOD_OPTIONS push $ALPINE oci-archive:/tmp/oci-busybox.tar:alpine
     echo "$output"
     [ "$status" -eq 0 ]
     rm -f /tmp/oci-busybox.tar
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi "$IMAGE"
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $ALPINE
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "kpod push without signatures" {
-    ${KPOD_BINARY} $KPOD_OPTIONS pull "$IMAGE"
     mkdir /tmp/busybox
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS push --remove-signatures "$IMAGE" dir:/tmp/busybox
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS push --remove-signatures $ALPINE dir:/tmp/busybox
     echo "$output"
     [ "$status" -eq 0 ]
     rm -rf /tmp/busybox
-    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi "$IMAGE"
+    run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $ALPINE
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/kpod_rename.bats
+++ b/test/kpod_rename.bats
@@ -8,6 +8,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "kpod rename successful" {
     skip "Test needs to be converted to kpod run"
     start_crio

--- a/test/kpod_rm.bats
+++ b/test/kpod_rm.bats
@@ -8,6 +8,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "remove a stopped container" {
     skip "Test needs to be converted to kpod run"
     start_crio

--- a/test/kpod_run.bats
+++ b/test/kpod_run.bats
@@ -2,19 +2,18 @@
 
 load helpers
 
-ALPINE="docker.io/library/alpine:latest"
+function setup() {
+    copy_images
+}
 
 @test "run a container based on local image" {
-    run ${KPOD_BINARY} ${KPOD_OPTIONS} pull docker.io/library/busybox:latest
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} run docker.io/library/busybox:latest ls
+    run ${KPOD_BINARY} ${KPOD_OPTIONS} run $BB ls
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "run a container based on a remote image" {
-    run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} run ${ALPINE} ls
+    run ${KPOD_BINARY} ${KPOD_OPTIONS} run ${BB_GLIBC} ls
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/kpod_save.bats
+++ b/test/kpod_save.bats
@@ -2,64 +2,44 @@
 
 load helpers
 
-IMAGE="alpine:latest"
-
 function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "kpod save output flag" {
-	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
 }
 
 @test "kpod save oci flag" {
-	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $ALPINE
 	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
 }
 
 @test "kpod save using stdout" {
-	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save > alpine.tar $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save > alpine.tar $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
 }
 
 @test "kpod save quiet flag" {
-	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -q -o alpine.tar $IMAGE
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -q -o alpine.tar $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
 }
 
 @test "kpod save non-existent image" {
-	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $IMAGE
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar FOOBAR
 	echo "$output"
 	[ "$status" -ne 0 ]
 }

--- a/test/kpod_stats.bats
+++ b/test/kpod_stats.bats
@@ -6,6 +6,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "stats single output" {
     skip "Test needs to be converted to kpod run"
     start_crio

--- a/test/kpod_stop.bats
+++ b/test/kpod_stop.bats
@@ -6,6 +6,10 @@ function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "stop a bogus container" {
     run ${KPOD_BINARY} ${KPOD_OPTIONS} stop foobar
     echo "$output"

--- a/test/kpod_wait.bats
+++ b/test/kpod_wait.bats
@@ -3,6 +3,9 @@
 load helpers
 
 IMAGE="redis:alpine"
+function setup() {
+    copy_images
+}
 
 # Returns the POD ID
 function pod_run_from_template(){


### PR DESCRIPTION
Add alpine and busybox as the two seeded images that can
be put into the tests' storage without the need to pull
it over the network.  Add the following to the kpod_TEST.bats
file:

function setup() {
    copy_images
}

Also, export several image names for shorter reference:

* BB -> docker.io/library/busybox:latest
* BB_GLIBC -> docker.io/library/busybox:glibc
* ALPINE -> docker.io/library/alpine:latest
* FEDORA_MINIMAL -> registry.fedoraproject.org/fedora-minimal:latest

And finally, there were two pervasive changes I made in
tests:

* Because we use temporary storage, we do not need to rmi at the end of each test
* We no longer need to pull most images because they are added via copy_images

Signed-off-by: baude <bbaude@redhat.com>