### PR TITLE
Mention docker login for creds authentication in documentation

### DIFF
--- a/docs/kpod-pull.1.md
+++ b/docs/kpod-pull.1.md
@@ -32,7 +32,7 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set e.g. using `(kpod login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(kpod login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
@@ -56,7 +56,8 @@ Image stored in local container/storage
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir**
 
@@ -129,7 +130,7 @@ Storing signatures
 ```
 
 ## SEE ALSO
-kpod(1), kpod-push(1), crio(8), crio.conf(5)
+kpod(1), kpod-push(1), crio(8), crio.conf(5), docker-login(1)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/kpod-push.1.md
+++ b/docs/kpod-push.1.md
@@ -26,7 +26,7 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set e.g. using `(kpod login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(kpod login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
@@ -44,7 +44,8 @@ Image stored in local container/storage
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--creds="CREDENTIALS"**
 
@@ -113,4 +114,4 @@ Storing signatures
 ```
 
 ## SEE ALSO
-kpod(1), kpod-pull(1), crio(8), crio.conf(5)
+kpod(1), kpod-pull(1), crio(8), crio.conf(5), docker-login(1)


### PR DESCRIPTION
Since we fall back to checking $HOME/.docker/config.json, which is set by docker login,
if the creds are not found in $XDG_RUNTIME_DIR/containers/auth.json, which is set by kpod login

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>