### PR TITLE
Move containers to file locks from c/storage

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"sync"
 	"syscall"
 	"time"
 
@@ -61,9 +60,8 @@ type Container struct {
 
 	state *containerRuntimeInfo
 
-	// TODO move to storage.Locker from sync.Mutex
 	valid   bool
-	lock    sync.Mutex
+	lock    storage.Locker
 	runtime *Runtime
 }
 
@@ -340,7 +338,7 @@ func (c *Container) syncContainer() error {
 }
 
 // Make a new container
-func newContainer(rspec *spec.Spec) (*Container, error) {
+func newContainer(rspec *spec.Spec, logDir string) (*Container, error) {
 	if rspec == nil {
 		return nil, errors.Wrapf(ErrInvalidArg, "must provide a valid runtime spec to create container")
 	}
@@ -356,6 +354,20 @@ func newContainer(rspec *spec.Spec) (*Container, error) {
 	deepcopier.Copy(rspec).To(ctr.config.Spec)
 
 	ctr.config.CreatedTime = time.Now()
+
+	// Path our lock file will reside at
+	lockPath := filepath.Join(logDir, ctr.config.ID)
+	// Ensure there is no conflict - file does not exist
+	_, err := os.Stat(lockPath)
+	if err == nil || !os.IsNotExist(err) {
+		return nil, errors.Wrapf(ErrCtrExists, "lockfile for container ID %s already exists", ctr.config.ID)
+	}
+	// Grab a lockfile at the given path
+	lock, err := storage.GetLockfile(lockPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating lockfile for new container")
+	}
+	ctr.lock = lock
 
 	return ctr, nil
 }
@@ -807,8 +819,8 @@ func (c *Container) mountStorage() (err error) {
 		}
 	}()
 
-	if err := c.runtime.state.SaveContainer(c); err != nil {
-		return errors.Wrapf(err, "error saving container %s state", c.ID())
+	if err := c.save(); err != nil {
+		return err
 	}
 
 	return nil
@@ -847,8 +859,8 @@ func (c *Container) cleanupStorage() error {
 	c.state.Mountpoint = ""
 	c.state.Mounted = false
 
-	if err := c.runtime.state.SaveContainer(c); err != nil {
-		return errors.Wrapf(err, "error saving container %s state", c.ID())
+	if err := c.save(); err != nil {
+		return err
 	}
 
 	return nil

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -314,6 +314,8 @@ func (c *Container) attachSocketPath() string {
 
 // Sync this container with on-disk state and runc status
 // Should only be called with container lock held
+// This function should suffice to ensure a container's state is accurate and
+// it is valid for use.
 func (c *Container) syncContainer() error {
 	if err := c.runtime.state.UpdateContainer(c); err != nil {
 		return err

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -819,11 +819,7 @@ func (c *Container) mountStorage() (err error) {
 		}
 	}()
 
-	if err := c.save(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.save()
 }
 
 // CleanupStorage unmounts all mount points in container and cleans up container storage
@@ -859,9 +855,5 @@ func (c *Container) cleanupStorage() error {
 	c.state.Mountpoint = ""
 	c.state.Mounted = false
 
-	if err := c.save(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.save()
 }

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -338,7 +338,7 @@ func (c *Container) syncContainer() error {
 }
 
 // Make a new container
-func newContainer(rspec *spec.Spec, logDir string) (*Container, error) {
+func newContainer(rspec *spec.Spec, lockDir string) (*Container, error) {
 	if rspec == nil {
 		return nil, errors.Wrapf(ErrInvalidArg, "must provide a valid runtime spec to create container")
 	}
@@ -356,7 +356,7 @@ func newContainer(rspec *spec.Spec, logDir string) (*Container, error) {
 	ctr.config.CreatedTime = time.Now()
 
 	// Path our lock file will reside at
-	lockPath := filepath.Join(logDir, ctr.config.ID)
+	lockPath := filepath.Join(lockDir, ctr.config.ID)
 	// Ensure there is no conflict - file does not exist
 	_, err := os.Stat(lockPath)
 	if err == nil || !os.IsNotExist(err) {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -30,7 +30,7 @@ func (r *Runtime) NewContainer(spec *spec.Spec, options ...CtrCreateOption) (c *
 		return nil, ErrRuntimeStopped
 	}
 
-	ctr, err := newContainer(spec)
+	ctr, err := newContainer(spec, r.locksDir)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -30,7 +30,7 @@ func (r *Runtime) NewContainer(spec *spec.Spec, options ...CtrCreateOption) (c *
 		return nil, ErrRuntimeStopped
 	}
 
-	ctr, err := newContainer(spec, r.locksDir)
+	ctr, err := newContainer(spec, r.lockDir)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -22,24 +21,16 @@ const DBSchema = 2
 type SQLState struct {
 	db       *sql.DB
 	specsDir string
-	locksDir string
+	lockDir  string
 	runtime  *Runtime
-	lock     storage.Locker
 	valid    bool
 }
 
 // NewSQLState initializes a SQL-backed state, created the database if necessary
-func NewSQLState(dbPath, lockPath, specsDir, locksDir string, runtime *Runtime) (State, error) {
+func NewSQLState(dbPath, specsDir, lockDir string, runtime *Runtime) (State, error) {
 	state := new(SQLState)
 
 	state.runtime = runtime
-
-	// Make our lock file
-	lock, err := storage.GetLockfile(lockPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error creating lockfile for state")
-	}
-	state.lock = lock
 
 	// Make the directory that will hold JSON copies of container runtime specs
 	if err := os.MkdirAll(specsDir, 0750); err != nil {
@@ -51,17 +42,13 @@ func NewSQLState(dbPath, lockPath, specsDir, locksDir string, runtime *Runtime) 
 	state.specsDir = specsDir
 
 	// Make the directory that will hold container lockfiles
-	if err := os.MkdirAll(locksDir, 0750); err != nil {
+	if err := os.MkdirAll(lockDir, 0750); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return nil, errors.Wrapf(err, "error creating lockfiles dir %s", locksDir)
+			return nil, errors.Wrapf(err, "error creating lockfiles dir %s", lockDir)
 		}
 	}
-	state.locksDir = locksDir
-
-	// Acquire the lock while we open the database and perform initial setup
-	state.lock.Lock()
-	defer state.lock.Unlock()
+	state.lockDir = lockDir
 
 	// TODO add a separate temporary database for per-boot container
 	// state
@@ -97,9 +84,6 @@ func NewSQLState(dbPath, lockPath, specsDir, locksDir string, runtime *Runtime) 
 
 // Close the state's database connection
 func (s *SQLState) Close() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if !s.valid {
 		return ErrDBClosed
 	}
@@ -140,7 +124,7 @@ func (s *SQLState) Container(id string) (*Container, error) {
 
 	row := s.db.QueryRow(query, id)
 
-	ctr, err := ctrFromScannable(row, s.runtime, s.specsDir, s.locksDir)
+	ctr, err := ctrFromScannable(row, s.runtime, s.specsDir, s.lockDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving container %s from database", id)
 	}
@@ -187,7 +171,7 @@ func (s *SQLState) LookupContainer(idOrName string) (*Container, error) {
 		}
 
 		var err error
-		ctr, err = ctrFromScannable(rows, s.runtime, s.specsDir, s.locksDir)
+		ctr, err = ctrFromScannable(rows, s.runtime, s.specsDir, s.lockDir)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error retrieving container %s from database", idOrName)
 		}
@@ -259,9 +243,6 @@ func (s *SQLState) AddContainer(ctr *Container) (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "error marshaling container %s labels to JSON", ctr.ID())
 	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -441,9 +422,6 @@ func (s *SQLState) SaveContainer(ctr *Container) error {
                           Pid=?
                        WHERE Id=?;`
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if !s.valid {
 		return ErrDBClosed
 	}
@@ -500,9 +478,6 @@ func (s *SQLState) RemoveContainer(ctr *Container) error {
 		removeCtr   = "DELETE FROM containers WHERE Id=?;"
 		removeState = "DELETE FROM containerState WHERE ID=?;"
 	)
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
 
 	if !s.valid {
 		return ErrDBClosed
@@ -586,7 +561,7 @@ func (s *SQLState) AllContainers() ([]*Container, error) {
 	containers := []*Container{}
 
 	for rows.Next() {
-		ctr, err := ctrFromScannable(rows, s.runtime, s.specsDir, s.locksDir)
+		ctr, err := ctrFromScannable(rows, s.runtime, s.specsDir, s.lockDir)
 		if err != nil {
 			return nil, err
 		}

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -386,13 +385,8 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 	ctr.valid = true
 	ctr.runtime = runtime
 
-	// Ensure the lockfile exists
-	lockPath := filepath.Join(lockDir, id)
-	_, err = os.Stat(lockPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error performing stat on container %s lockfile", id)
-	}
 	// Open and set the lockfile
+	lockPath := filepath.Join(lockDir, id)
 	lock, err := storage.GetLockfile(lockPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving lockfile for container %s", id)

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -268,7 +268,7 @@ type scannable interface {
 }
 
 // Read a single container from a single row result in the database
-func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, locksDir string) (*Container, error) {
+func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir string) (*Container, error) {
 	var (
 		id                 string
 		name               string
@@ -387,7 +387,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, locksDir
 	ctr.runtime = runtime
 
 	// Ensure the lockfile exists
-	lockPath := filepath.Join(locksDir, id)
+	lockPath := filepath.Join(lockDir, id)
 	_, err = os.Stat(lockPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error performing stat on container %s lockfile", id)


### PR DESCRIPTION
This will help prevent synchronization issues. It does add a lot of open file descriptors (one per container we've read into memory), but we can look into solving that once it becomes an issue.