### PR TITLE
kpod_rm: Add option for --all

### DIFF
--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -1213,6 +1213,8 @@ _kpod_run() {
 
 _kpod_rm() {
     local boolean_options="
+    --all
+    -a
     --force
     -f
     "

--- a/docs/kpod-rm.1.md
+++ b/docs/kpod-rm.1.md
@@ -9,7 +9,7 @@ kpod rm - Remove one or more containers
 **kpod** **rm** [*options* [...]] container
 
 ## DESCRIPTION
-Kpod rm will remove one or more containers from the host.  The container name or ID can be used.  This does not remove images.  Running containers will not be removed without the -f option
+kpod rm will remove one or more containers from the host.  The container name or ID can be used.  This does not remove images.  Running containers will not be removed without the -f option
 
 ## OPTIONS
 
@@ -17,12 +17,19 @@ Kpod rm will remove one or more containers from the host.  The container name or
 
 Force the removal of a running container
 
+**--all, a**
+
+Remove all containers.  Can be used in conjunction with -f as well.
 
 ## EXAMPLE
 
 kpod rm mywebserver
 
+kpod rm mywebserver myflaskserver 860a4b23
+
 kpod rm -f 860a4b23
+
+kpod rm -f -a
 
 ## SEE ALSO
 kpod(1), kpod-rmi(1)


### PR DESCRIPTION
Remove all containers with -a, --all.

Enable kpod rm tests which were all set to skip. Add two
tests for -a

Signed-off-by: baude <bbaude@redhat.com>