### PR TITLE
Add flag --cert-dir and --tls-verify to kpod login 

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/containers/image/docker"
@@ -28,6 +29,14 @@ var (
 		cli.StringFlag{
 			Name:  "authfile",
 			Usage: "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
+		cli.StringFlag{
+			Name:  "cert-dir",
+			Usage: "Pathname of a directory containing TLS certificates and keys",
+		},
+		cli.BoolTFlag{
+			Name:  "tls-verify",
+			Usage: "Require HTTPS and verify certificates when contacting registries (default: true)",
 		},
 	}
 	loginDescription = "Login to a container registry on a specified server."
@@ -63,6 +72,10 @@ func loginCmd(c *cli.Context) error {
 	username, password, err := getUserAndPass(c.String("username"), c.String("password"), userFromAuthFile)
 	if err != nil {
 		return errors.Wrapf(err, "error getting username and password")
+	}
+	sc.DockerInsecureSkipTLSVerify = !c.BoolT("tls-verify")
+	if c.String("cert-dir") != "" {
+		sc.DockerCertPath = filepath.Join(c.String("cert-dir"), server)
 	}
 
 	if err = docker.CheckAuth(context.TODO(), sc, username, password, server); err == nil {

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -37,6 +37,12 @@ Username for registry
 **--authfile**
 Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
 
+**--cert-dir**
+Pathname of a directory containing TLS certificates and keys
+
+**--tls-verify**
+Require HTTPS and verify certificates when contacting registries (default: true)
+
 ## EXAMPLES
 
 ```
@@ -55,6 +61,16 @@ Login Succeeded!
 # podman login --authfile authdir/myauths.json docker.io
 Username: umohnani
 Password:
+Login Succeeded!
+```
+
+```
+$ kpod login --tls-verify=false -u test -p test localhost:5000
+Login Succeeded!
+```
+
+```
+$ kpod login --cert-dir /etc/containers/certs.d/ -u foo -p bar localhost:5000
 Login Succeeded!
 ```
 


### PR DESCRIPTION
This commit adds a mechanism to override the default certs dir by using
command line flag `--cert-dir` for kpod login.

Another flag `--tls-verify` is also added which lets you skip certificate
validation when contacting container registry.

Signed-off-by: Suraj Deshmukh <surajd.service@gmail.com>

Fixes #38