### PR TITLE
Fix path for OCI specs, and make kpod create initialize runc

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -280,7 +280,7 @@ func (c *Container) MountPoint() (string, error) {
 // The path to the container's root filesystem - where the OCI spec will be
 // placed, amongst other things
 func (c *Container) bundlePath() string {
-	return c.state.RunDir
+	return c.config.StaticDir
 }
 
 // The path to the container's logs file

--- a/libpod/container_attach.go
+++ b/libpod/container_attach.go
@@ -53,7 +53,7 @@ func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSi
 		term.SetRawTerminal(inputStream.Fd())
 	}
 
-	controlPath := filepath.Join(c.state.RunDir, "ctl")
+	controlPath := filepath.Join(c.bundlePath(), "ctl")
 	controlFile, err := os.OpenFile(controlPath, unix.O_WRONLY, 0)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open container ctl file: %v")

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -169,8 +169,6 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string) (err e
 	args = append(args, "-r", r.path)
 	args = append(args, "-b", ctr.bundlePath())
 	args = append(args, "-p", filepath.Join(ctr.state.RunDir, "pidfile"))
-	// TODO container log location should be configurable
-	// The default also likely shouldn't be this
 	args = append(args, "-l", ctr.logPath())
 	args = append(args, "--exit-dir", r.exitsDir)
 	args = append(args, "--socket-dir-path", r.socketsDir)
@@ -190,7 +188,7 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string) (err e
 	}).Debugf("running conmon: %s", r.conmonPath)
 
 	cmd := exec.Command(r.conmonPath, args...)
-	cmd.Dir = ctr.state.RunDir
+	cmd.Dir = ctr.bundlePath()
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}


### PR DESCRIPTION
The OCI path fix makes us durable across reboot. The 'kpod create' change allows us to do things like logs, exec, etc to containers that have been created but are not running.