### PR TITLE
Update man pages and output for kpod images

### DIFF
--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -218,7 +218,7 @@ func getImagesTemplateOutput(runtime *libpod.Runtime, images []*storage.Image, o
 			ID:         imageID,
 			Digest:     imageDigest,
 			Created:    units.HumanDuration(time.Since((createdTime))) + " ago",
-			Size:       units.HumanSize(float64(size)),
+			Size:       units.HumanSizeWithPrecision(float64(size), 3),
 		}
 		imagesOutput = append(imagesOutput, params)
 	}

--- a/docs/kpod-images.1.md
+++ b/docs/kpod-images.1.md
@@ -41,17 +41,82 @@ Lists only the image IDs.
 
 ## EXAMPLE
 
-kpod images
+```
+# kpod images
+REPOSITORY                                   TAG      IMAGE ID       CREATED       SIZE
+docker.io/kubernetes/pause                   latest   e3d42bcaf643   3 years ago   251kB
+<none>                                       <none>   ebb91b73692b   4 weeks ago   27.2MB
+docker.io/library/ubuntu                     latest   4526339ae51c   6 weeks ago   126MB
+```
 
-kpod images --quiet
+```
+# kpod images --quiet
+e3d42bcaf643
+ebb91b73692b
+4526339ae51c
+```
 
-kpod images -q --noheading --notruncate
+```
+# kpod images --noheading
+docker.io/kubernetes/pause                   latest   e3d42bcaf643   3 years ago   251kB
+<none>                                       <none>   ebb91b73692b   4 weeks ago   27.2MB
+docker.io/library/ubuntu                     latest   4526339ae51c   6 weeks ago   126MB
+```
 
-kpod images --format json
+```
+# kpod images --no-trunc
+REPOSITORY                                   TAG      IMAGE ID                                                                  CREATED       SIZE
+docker.io/kubernetes/pause                   latest   sha256:e3d42bcaf643097dd1bb0385658ae8cbe100a80f773555c44690d22c25d16b27   3 years ago   251kB
+<none>                                       <none>   sha256:ebb91b73692bd27890685846412ae338d13552165eacf7fcd5f139bfa9c2d6d9   4 weeks ago   27.2MB
+docker.io/library/ubuntu                     latest   sha256:4526339ae51c3cdc97956a7a961c193c39dfc6bd9733b0d762a36c6881b5583a   6 weeks ago   126MB
+```
 
-kpod images --format "{{.ID}}"
+```
+# kpod images --format "table {{.ID}} {{.Repository}} {{.Tag}}"
+IMAGE ID       REPOSITORY                                   TAG
+e3d42bcaf643   docker.io/kubernetes/pause                   latest
+ebb91b73692b   <none>                                       <none>
+4526339ae51c   docker.io/library/ubuntu                     latest
+```
 
-kpod images --filter dangling=true
+```
+# kpod images --filter dangling=true
+REPOSITORY   TAG      IMAGE ID       CREATED       SIZE
+<none>       <none>   ebb91b73692b   4 weeks ago   27.2MB
+```
+
+```
+# kpod images --format json
+[
+    {
+        "id": "e3d42bcaf643097dd1bb0385658ae8cbe100a80f773555c44690d22c25d16b27",
+        "names": [
+            "docker.io/kubernetes/pause:latest"
+        ],
+        "digest": "sha256:0aecf73ff86844324847883f2e916d3f6984c5fae3c2f23e91d66f549fe7d423",
+        "created": "2014-07-19T07:02:32.267701596Z",
+        "size": 250665
+    },
+    {
+        "id": "ebb91b73692bd27890685846412ae338d13552165eacf7fcd5f139bfa9c2d6d9",
+        "names": [
+            "\u003cnone\u003e"
+        ],
+        "digest": "sha256:ba7e4091d27e8114a205003ca6a768905c3395d961624a2c78873d9526461032",
+        "created": "2017-10-26T03:07:22.796184288Z",
+        "size": 27170520
+    },
+    {
+        "id": "4526339ae51c3cdc97956a7a961c193c39dfc6bd9733b0d762a36c6881b5583a",
+        "names": [
+            "docker.io/library/ubuntu:latest"
+        ],
+        "digest": "sha256:193f7734ddd68e0fb24ba9af8c2b673aecb0227b026871f8e932dab45add7753",
+        "created": "2017-10-10T20:59:05.10196344Z",
+        "size": 126085200
+    }
+]
+```
 
 ## SEE ALSO
 kpod(1)

--- a/vendor.conf
+++ b/vendor.conf
@@ -23,7 +23,7 @@ gopkg.in/yaml.v2 v2
 github.com/docker/docker ce452fb72ffcdb7605ce98bde9302238f47c63c5
 github.com/docker/spdystream ed496381df8283605c435b86d4fdd6f4f20b8c6e
 github.com/docker/distribution 7a8efe719e55bbfaff7bc5718cdf0ed51ca821df
-github.com/docker/go-units v0.3.1
+github.com/docker/go-units v0.3.2
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/libtrust aabc10ec26b754e797f9028f4589c5b7bd90dc20
 github.com/mistifyio/go-zfs v2.1.1

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -12,19 +12,21 @@ import (
 func HumanDuration(d time.Duration) string {
 	if seconds := int(d.Seconds()); seconds < 1 {
 		return "Less than a second"
+	} else if seconds == 1 {
+		return "1 second"
 	} else if seconds < 60 {
 		return fmt.Sprintf("%d seconds", seconds)
 	} else if minutes := int(d.Minutes()); minutes == 1 {
 		return "About a minute"
-	} else if minutes < 60 {
+	} else if minutes < 46 {
 		return fmt.Sprintf("%d minutes", minutes)
-	} else if hours := int(d.Hours()); hours == 1 {
+	} else if hours := int(d.Hours() + 0.5); hours == 1 {
 		return "About an hour"
 	} else if hours < 48 {
 		return fmt.Sprintf("%d hours", hours)
 	} else if hours < 24*7*2 {
 		return fmt.Sprintf("%d days", hours/24)
-	} else if hours < 24*30*3 {
+	} else if hours < 24*30*2 {
 		return fmt.Sprintf("%d weeks", hours/24/7)
 	} else if hours < 24*365*2 {
 		return fmt.Sprintf("%d months", hours/24/30)

--- a/vendor/github.com/docker/go-units/size.go
+++ b/vendor/github.com/docker/go-units/size.go
@@ -37,28 +37,40 @@ var (
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 
-// CustomSize returns a human-readable approximation of a size
-// using custom format.
-func CustomSize(format string, size float64, base float64, _map []string) string {
+func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
 	i := 0
 	unitsLimit := len(_map) - 1
 	for size >= base && i < unitsLimit {
 		size = size / base
 		i++
 	}
-	return fmt.Sprintf(format, size, _map[i])
+	return size, _map[i]
+}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	size, unit := getSizeAndUnit(size, base, _map)
+	return fmt.Sprintf(format, size, unit)
+}
+
+// HumanSizeWithPrecision allows the size to be in any precision,
+// instead of 4 digit precision used in units.HumanSize.
+func HumanSizeWithPrecision(size float64, precision int) string {
+	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
+	return fmt.Sprintf("%.*g%s", precision, size, unit)
 }
 
 // HumanSize returns a human-readable approximation of a size
 // capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
 func HumanSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
+	return HumanSizeWithPrecision(size, 4)
 }
 
 // BytesSize returns a human-readable size in bytes, kibibytes,
 // mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
 func BytesSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1024.0, binaryAbbrs)
+	return CustomSize("%.4g%s", size, 1024.0, binaryAbbrs)
 }
 
 // FromHumanSize returns an integer from a human-readable specification of a


### PR DESCRIPTION
The size had a precision of 4, but wanted a precision of 3
to match the output of docker images
Updated the man page with more examples
Vendored in new version of docker/go-units to allow
for customized precisions

Signed-off-by: umohnani8 <umohnani@redhat.com>
