### PR TITLE
Fix --volume flag for kpod create and run

### DIFF
--- a/cmd/kpod/create.go
+++ b/cmd/kpod/create.go
@@ -343,6 +343,10 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime) (*createConfig, er
 		blkioWeight = uint16(u)
 	}
 
+	if err = parseVolumes(c.StringSlice("volume")); err != nil {
+		return nil, err
+	}
+
 	// Because we cannot do a non-terminal attach, we need to set tty to true
 	// if detach is not false
 	// TODO Allow non-terminal attach

--- a/cmd/kpod/spec_test.go
+++ b/cmd/kpod/spec_test.go
@@ -18,7 +18,8 @@ func TestCreateConfig_GetVolumeMounts(t *testing.T) {
 	config := createConfig{
 		volumes: []string{"foobar:/foobar:ro"},
 	}
-	specMount := config.GetVolumeMounts()
+	specMount, err := config.GetVolumeMounts()
+	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(data, specMount[0]))
 }
 

--- a/docs/kpod-create.1.md
+++ b/docs/kpod-create.1.md
@@ -484,26 +484,18 @@ standard input.
      **host**: use the host's UTS namespace inside the container.
      Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
 
-**-v**|**--volume**[=*[[HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
+**-v**|**--volume**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, kpod
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the kpod
-   container. If 'HOST-DIR' is omitted,  kpod automatically creates the new
-   volume on the host.  The `OPTIONS` are a comma delimited list and can be:
+   container. The `OPTIONS` are a comma delimited list and can be:
 
    * [rw|ro]
    * [z|Z]
    * [`[r]shared`|`[r]slave`|`[r]private`]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
-can be an absolute path or a `name` value. A `name` value must start with an
-alphanumeric character, followed by `a-z0-9`, `_` (underscore), `.` (period) or
-`-` (hyphen). An absolute path starts with a `/` (forward slash).
-
-If you supply a `HOST-DIR` that is an absolute path,  kpod bind-mounts to the
-path you specify. If you supply a `name`, kpod creates a named volume by that
-`name`. For example, you can specify either `/foo` or `foo` for a `HOST-DIR`
-value. If you supply the `/foo` value, kpod creates a bind-mount. If you
-supply the `foo` specification, kpod creates a named volume.
+must be an absolute path as well. kpod bind-mounts the `HOST-DIR` to the
+path you specify. For example, if you supply the `/foo` value, kpod creates a bind-mount.
 
 You can specify multiple  **-v** options to mount one or more mounts to a
 container. To use these same mounts in other containers, specify the

--- a/docs/kpod-run.1.md
+++ b/docs/kpod-run.1.md
@@ -489,27 +489,18 @@ standard input.
      **host**: use the host's UTS namespace inside the container.
      Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
 
-**-v**|**--volume**[=*[[HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
+**-v**|**--volume**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, kpod
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the kpod
-   container. If 'HOST-DIR' is omitted,  kpod automatically creates the new
-   volume on the host.  The `OPTIONS` are a comma delimited list and can be:
+   container. The `OPTIONS` are a comma delimited list and can be:
 
    * [rw|ro]
    * [z|Z]
    * [`[r]shared`|`[r]slave`|`[r]private`]
-   * [nocopy]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
-can be an absolute path or a `name` value. A `name` value must start with an
-alphanumeric character, followed by `a-z0-9`, `_` (underscore), `.` (period) or
-`-` (hyphen). An absolute path starts with a `/` (forward slash).
-
-If you supply a `HOST-DIR` that is an absolute path,  kpod bind-mounts to the
-path you specify. If you supply a `name`, kpod creates a named volume by that
-`name`. For example, you can specify either `/foo` or `foo` for a `HOST-DIR`
-value. If you supply the `/foo` value, kpod creates a bind-mount. If you
-supply the `foo` specification, kpod creates a named volume.
+must be an absolute path as well. kpod bind-mounts the `HOST-DIR` to the
+path you specify. For example, if you supply the `/foo` value, kpod creates a bind-mount.
 
 You can specify multiple  **-v** options to mount one or more mounts to a
 container. To use these same mounts in other containers, specify the

--- a/test/kpod_run.bats
+++ b/test/kpod_run.bats
@@ -120,3 +120,18 @@ IMAGE="docker.io/library/fedora:latest"
     [ "$output" = 100 ]
 
 }
+
+@test "kpod run with volume flag" {
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime'"
+    echo $output
+    [ "$status" -eq 0 ]
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:ro ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test ro,relatime'"
+    echo $output
+    [ "$status" -eq 0 ]
+    #run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:shared ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime shared:'"
+    #echo $output
+    #[ "$status" -eq 0 ]
+    #run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:rslave ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime master:'"
+    #echo $output
+    #[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Enable the --volume flag to validate user input
and add functionality for :z and :Z options

Signed-off-by: umohnani8 <umohnani@redhat.com>