### PR TITLE
Ensure paused containers can't be force-removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-EPOCH_TEST_COMMIT ?= 5cfd7a3
+EPOCH_TEST_COMMIT ?= 5d52f74
 HEAD ?= HEAD
 PROJECT := github.com/projectatomic/libpod
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -104,7 +104,7 @@ func (r *Runtime) removeContainer(c *Container, force bool) error {
 	}
 
 	if c.state.State == ContainerStatePaused {
-		return errors.Wrapf("container %s is paused, cannot remove until unpaused", c.ID())
+		return errors.Wrapf(ErrCtrStateInvalid, "container %s is paused, cannot remove until unpaused", c.ID())
 	}
 
 	// Check that the container's in a good state to be removed

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -103,6 +103,10 @@ func (r *Runtime) removeContainer(c *Container, force bool) error {
 		return err
 	}
 
+	if c.state.State == ContainerStatePaused {
+		return errors.Wrapf("container %s is paused, cannot remove until unpaused", c.ID())
+	}
+
 	// Check that the container's in a good state to be removed
 	if c.state.State == ContainerStateRunning && force {
 		if err := r.ociRuntime.stopContainer(c, ctrRemoveTimeout); err != nil {


### PR DESCRIPTION
Paused containers must be unpaused before being removed. Right now, if you specify --force when removing a paused container, bad things could happen.