### PR TITLE
Add schema validation to DB

### DIFF
--- a/libpod/errors.go
+++ b/libpod/errors.go
@@ -59,6 +59,9 @@ var (
 	// ErrDBClosed indicates that the connection to the state database has
 	// already been closed
 	ErrDBClosed = errors.New("database connection already closed")
+	// ErrDBBadConfig indicates that the database has a different schema or
+	// was created by a libpod with a different config
+	ErrDBBadConfig = errors.New("database configuration mismatch")
 
 	// ErrNotImplemented indicates that the requested functionality is not
 	// yet present

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -14,6 +14,10 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// DBSchema is the current DB schema version
+// Increments every time a change is made to the database's tables
+const DBSchema = 1
+
 // SQLState is a state implementation backed by a persistent SQLite3 database
 type SQLState struct {
 	db       *sql.DB
@@ -66,6 +70,11 @@ func NewSQLState(dbPath, lockPath, specsDir string, runtime *Runtime) (State, er
 
 	// Prepare database
 	if err := prepareDB(db); err != nil {
+		return nil, err
+	}
+
+	// Ensure that the database matches our config
+	if err := checkDB(db, runtime); err != nil {
 		return nil, err
 	}
 

--- a/libpod/sql_state_test.go
+++ b/libpod/sql_state_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containers/storage"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/stretchr/testify/assert"
 )
@@ -102,7 +103,11 @@ func getEmptyState() (s State, p string, err error) {
 	dbPath := filepath.Join(tmpDir, "db.sql")
 	lockPath := filepath.Join(tmpDir, "db.lck")
 
-	state, err := NewSQLState(dbPath, lockPath, tmpDir, nil)
+	runtime := new(Runtime)
+	runtime.config = new(RuntimeConfig)
+	runtime.config.StorageConfig = storage.StoreOptions{}
+
+	state, err := NewSQLState(dbPath, lockPath, tmpDir, runtime)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
This ensures we don't open a DB with an earlier schema or a config that differs from ours. Fixes an bug I found with @baude this morning.