### PR TITLE
Add Linux Root Propagation to kpod create and run

### DIFF
--- a/cmd/kpod/spec_test.go
+++ b/cmd/kpod/spec_test.go
@@ -13,7 +13,7 @@ func TestCreateConfig_GetVolumeMounts(t *testing.T) {
 		Destination: "/foobar",
 		Type:        "bind",
 		Source:      "foobar",
-		Options:     []string{"ro", "rbind"},
+		Options:     []string{"ro", "rbind", "rprivate"},
 	}
 	config := createConfig{
 		volumes: []string{"foobar:/foobar:ro"},

--- a/test/kpod_run.bats
+++ b/test/kpod_run.bats
@@ -122,16 +122,13 @@ IMAGE="docker.io/library/fedora:latest"
 }
 
 @test "kpod run with volume flag" {
-    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime'"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test ${BB} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime'"
     echo $output
     [ "$status" -eq 0 ]
-    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:ro ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test ro,relatime'"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:ro ${BB} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test ro,relatime'"
     echo $output
     [ "$status" -eq 0 ]
-    #run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:shared ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime shared:'"
-    #echo $output
-    #[ "$status" -eq 0 ]
-    #run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:rslave ${FEDORA_MINIMAL} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime master:'"
-    #echo $output
-    #[ "$status" -eq 0 ]
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -v ${MOUNT_PATH}:/run/test:shared ${BB} cat /proc/self/mountinfo | grep '${MOUNT_PATH} /run/test rw,relatime shared:'"
+    echo $output
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Add [r]shared, [r]private, [r]slave functionality to the --volume flag
for kpod create and kpod run
This sets the root propagation for each bind mount

Signed-off-by: umohnani8 <umohnani@redhat.com>