### PR TITLE
kpod stop -a

### DIFF
--- a/cmd/kpod/stop.go
+++ b/cmd/kpod/stop.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/libpod"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -16,6 +17,10 @@ var (
 			Name:  "timeout, t",
 			Usage: "Seconds to wait for stop before killing the container",
 			Value: defaultTimeout,
+		},
+		cli.BoolFlag{
+			Name:  "all, a",
+			Usage: "stop all running containers",
 		},
 	}
 	stopDescription = `
@@ -39,7 +44,10 @@ var (
 func stopCmd(c *cli.Context) error {
 	args := c.Args()
 	stopTimeout := c.Int64("timeout")
-	if len(args) < 1 {
+	if c.Bool("all") && len(args) > 0 {
+		return errors.Errorf("no arguments are needed with -a")
+	}
+	if len(args) < 1 && !c.Bool("all") {
 		return errors.Errorf("you must provide at least one container name or id")
 	}
 	if err := validateFlags(c, stopFlags); err != nil {
@@ -54,26 +62,43 @@ func stopCmd(c *cli.Context) error {
 
 	logrus.Debugf("Stopping containers with timeout %d", stopTimeout)
 
+	var filterFuncs []libpod.ContainerFilter
+	var containers []*libpod.Container
 	var lastError error
-	for _, container := range c.Args() {
-		ctr, err := runtime.LookupContainer(container)
-		if err != nil {
-			if lastError != nil {
-				fmt.Fprintln(os.Stderr, lastError)
-			}
-			lastError = errors.Wrapf(err, "failed to stop container %v", container)
-			continue
-		}
 
+	if c.Bool("all") {
+		// only get running containers
+		filterFuncs = append(filterFuncs, func(c *libpod.Container) bool {
+			state, _ := c.State()
+			return state == libpod.ContainerStateRunning
+		})
+		containers, err = runtime.GetContainers(filterFuncs...)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get running containers")
+		}
+	} else {
+		for _, i := range args {
+			container, err := runtime.LookupContainer(i)
+			if err != nil {
+				if lastError != nil {
+					fmt.Fprintln(os.Stderr, lastError)
+				}
+				lastError = errors.Wrapf(err, "unable to find container %s", i)
+				continue
+			}
+			containers = append(containers, container)
+		}
+	}
+
+	for _, ctr := range containers {
 		if err := ctr.Stop(stopTimeout); err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}
-			lastError = errors.Wrapf(err, "failed to stop container %v", container)
+			lastError = errors.Wrapf(err, "failed to stop container %v", ctr.ID())
 		} else {
 			fmt.Println(ctr.ID())
 		}
 	}
-
 	return lastError
 }

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -1352,7 +1352,9 @@ _kpod_stop() {
      local options_with_args="
      --timeout -t
      "
-     local boolean_options=""
+     local boolean_options="
+     --all
+     -a"
      _complete_ "$options_with_args" "$boolean_options"
 }
 

--- a/docs/kpod-stop.1.md
+++ b/docs/kpod-stop.1.md
@@ -19,6 +19,10 @@ is issued to the container. The default is 10 seconds.
 
 Timeout to wait before forcibly stopping the container
 
+**--all, -a**
+
+Stop all running containers.  This does not include paused containers.
+
 
 ## EXAMPLE
 
@@ -26,7 +30,11 @@ kpod stop mywebserver
 
 kpod stop 860a4b23
 
+kpod stop mywebserver 860a4b23
+
 kpod stop --timeout 2 860a4b23
+
+kpod stop -a
 
 ## SEE ALSO
 kpod(1), kpod-rm(1)

--- a/test/kpod_stop.bats
+++ b/test/kpod_stop.bats
@@ -38,3 +38,12 @@ function setup() {
     run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} ps"
     [ "$status" -eq 0 ]
 }
+
+@test "stop all containers" {
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run --name test1 -d ${ALPINE} sleep 9999"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run --name test2 -d ${ALPINE} sleep 9999"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run --name test3 -d ${ALPINE} sleep 9999"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} stop -a -t 1"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Stop all running containers with single switch.  Useful for
maintainence of a system or integration tests.

Signed-off-by: baude <bbaude@redhat.com>