### PR TITLE
Remove gitvalidation from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ jobs:
   include:
     - stage: Build and Verify
       script:
-        - make .gitvalidation
         - make gofmt
         - make lint
         - make testunit
@@ -42,7 +41,6 @@ jobs:
       go: 1.8.x
     - stage: Build and Verify
       script:
-        - make .gitvalidation
         - make gofmt
         - make lint
         - make testunit


### PR DESCRIPTION
gitvalidation in travis has been problematic.  It is already
being done in Fedora and Centos so we have a reliable test
occuring there.

Signed-off-by: baude <bbaude@redhat.com>