### PR TITLE
Add handling for system restart in libpod

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -413,7 +413,7 @@ func (c *Container) refresh() error {
 	defer c.lock.Unlock()
 
 	if !c.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container %s has been removed from the state", c.ID())
+		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid - may have been removed", c.ID())
 	}
 
 	// We need to get the container's temporary directory from c/storage

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -38,6 +38,12 @@ func (s *InMemoryState) Close() error {
 	return nil
 }
 
+// Refresh clears container and pod stats after a reboot
+// In-memory state won't survive a reboot so this is a no-op
+func (s *InMemoryState) Refresh() error {
+	return nil
+}
+
 // Container retrieves a container from its full ID
 func (s *InMemoryState) Container(id string) (*Container, error) {
 	if id == "" {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -273,7 +273,13 @@ func (r *Runtime) Shutdown(force bool) error {
 // Refreshes the state, recreating temporary files
 // Does not check validity as the runtime is not valid until after this has run
 func (r *Runtime) refresh(alivePath string) error {
-	// We need to refresh the state of all containers
+	// First clear the state in the database
+	if err := r.state.Refresh(); err != nil {
+		return err
+	}
+
+	// Next refresh the state of all containers to recreate dirs and
+	// namespaces
 	ctrs, err := r.state.AllContainers()
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving all containers from state")

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -6,6 +6,9 @@ type State interface {
 	// connections) that may be required
 	Close() error
 
+	// Refresh clears container and pod states after a reboot
+	Refresh() error
+
 	// Accepts full ID of container
 	Container(id string) (*Container, error)
 	// Accepts full or partial IDs (as long as they are unique) and names


### PR DESCRIPTION
Detect system restart with a file in our temporary directory. When restart is detected, refresh the state in the database to accurately reflect that containers are no longer mounted or running, and recreate containers in runc if necessary.