### PR TITLE
kpod create should not do an OCI Init

### DIFF
--- a/cmd/kpod/create.go
+++ b/cmd/kpod/create.go
@@ -211,10 +211,6 @@ func createCmd(c *cli.Context) error {
 	}
 
 	logrus.Debug("new container created ", ctr.ID())
-	if err := ctr.Init(); err != nil {
-		return err
-	}
-	logrus.Debug("container storage created for %q", ctr.ID())
 
 	if c.String("cidfile") != "" {
 		libpod.WriteFile(ctr.ID(), c.String("cidfile"))

--- a/cmd/kpod/start.go
+++ b/cmd/kpod/start.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/libpod"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"os"
@@ -80,6 +81,10 @@ func startCmd(c *cli.Context) error {
 			}
 			lastError = errors.Wrapf(err, "unable to find container %s", container)
 			continue
+		}
+
+		if err := ctr.Init(); err != nil && errors.Cause(err) != libpod.ErrCtrExists {
+			return err
 		}
 
 		// We can only be interactive if both the config and the command-line say so

--- a/test/kpod_pause.bats
+++ b/test/kpod_pause.bats
@@ -23,7 +23,7 @@ function teardown() {
 }
 
 @test "pause a created container by id" {
-    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} create $BB ls"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} run -d $BB sleep 60"
     echo "$output"
     [ "$status" -eq 0 ]
     ctr_id="$output"
@@ -33,7 +33,7 @@ function teardown() {
     run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} unpause $ctr_id"
     echo "$output"
     [ "$status" -eq 0 ]
-    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} rm $ctr_id"
+    run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} rm -f $ctr_id"
     echo "$output"
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
We need to differentiate between a kpod create and a kpod start
kpod create should create all of the data for libpod, but kpod start should
generate content for OCI Runtime (runc) in order to run.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>