### PR TITLE
Fix misleading print statement in kpod load

### DIFF
--- a/cmd/kpod/load.go
+++ b/cmd/kpod/load.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -101,16 +102,18 @@ func loadCmd(c *cli.Context) error {
 	}
 
 	src := libpod.DockerArchive + ":" + input
-	if err := runtime.PullImage(src, options); err != nil {
+	imgName, err := runtime.PullImage(src, options)
+	if err != nil {
 		src = libpod.OCIArchive + ":" + input
 		// generate full src name with specified image:tag
 		if image != "" {
 			src = src + ":" + image
 		}
-		if err := runtime.PullImage(src, options); err != nil {
+		imgName, err = runtime.PullImage(src, options)
+		if err != nil {
 			return errors.Wrapf(err, "error pulling %q", src)
 		}
 	}
-
+	fmt.Println("Loaded image: ", imgName)
 	return nil
 }

--- a/cmd/kpod/pull.go
+++ b/cmd/kpod/pull.go
@@ -113,6 +113,8 @@ func pullCmd(c *cli.Context) error {
 		Writer: writer,
 	}
 
-	return runtime.PullImage(image, options)
-
+	if _, err := runtime.PullImage(image, options); err != nil {
+		return errors.Wrapf(err, "error pulling image %q", image)
+	}
+	return nil
 }

--- a/docs/kpod-load.1.md
+++ b/docs/kpod-load.1.md
@@ -56,6 +56,7 @@ Copying config sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d
  0 B / 1.48 KB [---------------------------------------------------------------]
 Writing manifest to image destination
 Storing signatures
+Loaded image:  registry.fedoraproject.org/fedora:latest
 ```
 
 ```
@@ -67,6 +68,7 @@ Copying config sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d
  0 B / 1.48 KB [---------------------------------------------------------------]
 Writing manifest to image destination
 Storing signatures
+Loaded image:  registry.fedoraproject.org/fedora:latest
 ```
 
 ## SEE ALSO

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -105,9 +105,6 @@ func (s *SQLState) Refresh() (err error) {
                              Mountpoint=?,
                              Pid=?;`
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if !s.valid {
 		return ErrDBClosed
 	}


### PR DESCRIPTION
When loading an image, kpod load would print something like
"Trying to pull docker.io/library/alpine...", which is misleading
and makes it sound like its pulling it form the registry.
Fixed this by removing these print statements for kpod load

Signed-off-by: umohnani8 <umohnani@redhat.com>