### PR TITLE
\t was not being recognized as tab in --format

### DIFF
--- a/cmd/kpod/formats/formats.go
+++ b/cmd/kpod/formats/formats.go
@@ -1,6 +1,7 @@
 package formats
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	"bytes"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 )

--- a/cmd/kpod/history.go
+++ b/cmd/kpod/history.go
@@ -92,10 +92,7 @@ func historyCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	format := genHistoryFormat(c.Bool("quiet"))
-	if c.IsSet("format") {
-		format = c.String("format")
-	}
+	format := genHistoryFormat(c.String("format"), c.Bool("quiet"))
 
 	args := c.Args()
 	if len(args) == 0 {
@@ -121,7 +118,12 @@ func historyCmd(c *cli.Context) error {
 	return generateHistoryOutput(history, layers, imageID, opts)
 }
 
-func genHistoryFormat(quiet bool) (format string) {
+func genHistoryFormat(format string, quiet bool) string {
+	if format != "" {
+		// "\t" from the command line is not being recognized as a tab
+		// replacing the string "\t" to a tab character if the user passes in "\t"
+		return strings.Replace(format, `\t`, "\t", -1)
+	}
 	if quiet {
 		return formats.IDString
 	}

--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -93,12 +93,7 @@ func imagesCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	var format string
-	if c.IsSet("format") {
-		format = c.String("format")
-	} else {
-		format = genImagesFormat(c.Bool("quiet"), c.Bool("noheading"), c.Bool("digests"))
-	}
+	format := genImagesFormat(c.String("format"), c.Bool("quiet"), c.Bool("noheading"), c.Bool("digests"))
 
 	opts := imagesOptions{
 		quiet:     c.Bool("quiet"),
@@ -137,7 +132,12 @@ func imagesCmd(c *cli.Context) error {
 	return generateImagesOutput(runtime, images, opts)
 }
 
-func genImagesFormat(quiet, noHeading, digests bool) (format string) {
+func genImagesFormat(format string, quiet, noHeading, digests bool) string {
+	if format != "" {
+		// "\t" from the command line is not being recognized as a tab
+		// replacing the string "\t" to a tab character if the user passes in "\t"
+		return strings.Replace(format, `\t`, "\t", -1)
+	}
 	if quiet {
 		return formats.IDString
 	}
@@ -149,7 +149,7 @@ func genImagesFormat(quiet, noHeading, digests bool) (format string) {
 		format += "{{.Digest}}\t"
 	}
 	format += "{{.ID}}\t{{.Created}}\t{{.Size}}\t"
-	return
+	return format
 }
 
 // imagesToGeneric creates an empty array of interfaces for output


### PR DESCRIPTION
When doing kpod images --format "{{.ID}}\t{{.Tag}}"
the "\t" was being passed in as a string of "\" and "t"
instead of as a tab character.

Signed-off-by: umohnani8 <umohnani@redhat.com>