### PR TITLE
Add fix_gofmt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ lint: .gopathok
 gofmt:
 	@./hack/verify-gofmt.sh
 
+fix_gofmt:
+	@./hack/verify-gofmt.sh -f
+
 conmon:
 	$(MAKE) -C $@
 

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -12,11 +12,27 @@ find_files() {
     \) -name '*.go' \
     -not \( -wholename './_output/*' \)
 }
-
+FIX=0
 GOFMT="gofmt -s"
 bad_files=$(find_files | xargs $GOFMT -l)
+
+while getopts "f?:" opt; do
+    case "$opt" in
+        f) FIX=1
+            ;;
+    esac
+done
+
 if [[ -n "${bad_files}" ]]; then
-  echo "!!! '$GOFMT' needs to be run on the following files: "
-  echo "${bad_files}"
-  exit 1
+    if (($FIX == 1)) ; then
+        echo "Correcting the following files:"
+        echo "${bad_files}"
+        while read -r go_file; do
+            gofmt -s -w $go_file
+        done <<< "${bad_files}"
+    else
+      echo "!!! '$GOFMT' needs to be run on the following files: "
+      echo "${bad_files}"
+      exit 1
+  fi
 fi


### PR DESCRIPTION
fix_gofmt will run gofmt -s -w on files that need to be
formatted.  Useful for developers prior to checking code
in.

Signed-off-by: baude <bbaude@redhat.com>