### PR TITLE
Add manifest type conversion to kpod push

### DIFF
--- a/cmd/kpod/login.go
+++ b/cmd/kpod/login.go
@@ -56,7 +56,7 @@ func loginCmd(c *cli.Context) error {
 		server = args[0]
 	}
 
-	sc := common.GetSystemContext("", c.String("authfile"))
+	sc := common.GetSystemContext("", c.String("authfile"), false)
 
 	// username of user logged in to server (if one exists)
 	userFromAuthFile := config.GetUserLoggedIn(sc, server)

--- a/cmd/kpod/logout.go
+++ b/cmd/kpod/logout.go
@@ -46,7 +46,7 @@ func logoutCmd(c *cli.Context) error {
 		server = args[0]
 	}
 
-	sc := common.GetSystemContext("", c.String("authfile"))
+	sc := common.GetSystemContext("", c.String("authfile"), false)
 
 	if c.Bool("all") {
 		if err := config.RemoveAllAuthentication(sc); err != nil {

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -921,8 +921,7 @@ _kpod_mount() {
 
 _kpod_push() {
     local boolean_options="
-    --disable-compression
-    -D
+    --compress
     --quiet
     -q
     --remove-signatures
@@ -931,6 +930,7 @@ _kpod_push() {
 
     local options_with_args="
     --authfile
+	--format
     --cert-dir
     --creds
     --sign-by

--- a/docs/kpod-push.1.md
+++ b/docs/kpod-push.1.md
@@ -9,8 +9,10 @@ kpod push - Push an image from local storage to elsewhere
 **kpod** **push** [*options* [...]] **imageID** [**destination**]
 
 ## DESCRIPTION
-Pushes an image from local storage to a specified destination, decompressing
-and recompressing layers as needed.
+Pushes an image from local storage to a specified destination.
+Push is mainly used to push images to registries, however **kpod push**
+can be used to save images to tarballs and directories using the following
+transports: **dir:**, **docker-archive:**, **docker-daemon:**, **oci-archive:**, and **ostree:**.
 
 ## imageID
 Image stored in local container/storage
@@ -19,6 +21,8 @@ Image stored in local container/storage
 
  The DESTINATION is a location to store container images
  The Image "DESTINATION" uses a "transport":"details" format.
+ If a transport is not given, kpod push will attempt to push
+ to a registry.
 
  Multiple transports are supported:
 
@@ -55,9 +59,15 @@ Credentials (USERNAME:PASSWORD) to use for authenticating to a registry
 
 Pathname of a directory containing TLS certificates and keys
 
-**--disable-compression, -D**
+**--compress**
 
-Don't compress copies of filesystem layers which will be pushed
+Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type, compressed or uncompressed, as source)
+Note: This flag can only be set when using the **dir** transport
+
+**--format, -f**
+
+Manifest Type (oci, v2s1, or v2s2) to use when pushing an image to a directory using the 'dir:' transport (default is manifest type of source)
+Note: This flag can only be set when using the **dir** transport
 
 **--quiet, -q**
 
@@ -109,6 +119,20 @@ Copying blob sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589a
  4.03 MB / 4.03 MB [========================================================] 1s
 Copying config sha256:ad4686094d8f0186ec8249fc4917b71faa2c1030d7b5a025c29f26e19d95c156
  1.41 KB / 1.41 KB [========================================================] 1s
+Writing manifest to image destination
+Storing signatures
+```
+
+This example pushes the rhel7 image to rhel7-dir with the "oci" manifest type
+```
+# kpod push --format oci registry.access.redhat.com/rhel7 dir:rhel7-dir
+Getting image source signatures
+Copying blob sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4
+ 71.41 MB / 71.41 MB [======================================================] 9s
+Copying blob sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a
+ 1.21 KB / 1.21 KB [========================================================] 0s
+Copying config sha256:f1b09a81455c351eaa484b61aacd048ab613c08e4c5d1da80c4c46301b03cf3b
+ 3.01 KB / 3.01 KB [========================================================] 0s
 Writing manifest to image destination
 Storing signatures
 ```

--- a/libpod/common/common.go
+++ b/libpod/common/common.go
@@ -16,31 +16,33 @@ var (
 )
 
 // GetCopyOptions constructs a new containers/image/copy.Options{} struct from the given parameters
-func GetCopyOptions(reportWriter io.Writer, signaturePolicyPath string, srcDockerRegistry, destDockerRegistry *DockerRegistryOptions, signing SigningOptions, authFile string) *cp.Options {
+func GetCopyOptions(reportWriter io.Writer, signaturePolicyPath string, srcDockerRegistry, destDockerRegistry *DockerRegistryOptions, signing SigningOptions, authFile, manifestType string, forceCompress bool) *cp.Options {
 	if srcDockerRegistry == nil {
 		srcDockerRegistry = &DockerRegistryOptions{}
 	}
 	if destDockerRegistry == nil {
 		destDockerRegistry = &DockerRegistryOptions{}
 	}
-	srcContext := srcDockerRegistry.GetSystemContext(signaturePolicyPath, authFile)
-	destContext := destDockerRegistry.GetSystemContext(signaturePolicyPath, authFile)
+	srcContext := srcDockerRegistry.GetSystemContext(signaturePolicyPath, authFile, forceCompress)
+	destContext := destDockerRegistry.GetSystemContext(signaturePolicyPath, authFile, forceCompress)
 	return &cp.Options{
-		RemoveSignatures: signing.RemoveSignatures,
-		SignBy:           signing.SignBy,
-		ReportWriter:     reportWriter,
-		SourceCtx:        srcContext,
-		DestinationCtx:   destContext,
+		RemoveSignatures:      signing.RemoveSignatures,
+		SignBy:                signing.SignBy,
+		ReportWriter:          reportWriter,
+		SourceCtx:             srcContext,
+		DestinationCtx:        destContext,
+		ForceManifestMIMEType: manifestType,
 	}
 }
 
 // GetSystemContext Constructs a new containers/image/types.SystemContext{} struct from the given signaturePolicy path
-func GetSystemContext(signaturePolicyPath, authFilePath string) *types.SystemContext {
+func GetSystemContext(signaturePolicyPath, authFilePath string, forceCompress bool) *types.SystemContext {
 	sc := &types.SystemContext{}
 	if signaturePolicyPath != "" {
 		sc.SignaturePolicyPath = signaturePolicyPath
 	}
 	sc.AuthFilePath = authFilePath
+	sc.DirForceCompress = forceCompress
 	return sc
 }
 

--- a/libpod/common/docker_registry_options.go
+++ b/libpod/common/docker_registry_options.go
@@ -22,13 +22,14 @@ type DockerRegistryOptions struct {
 
 // GetSystemContext constructs a new system context from the given signaturePolicy path and the
 // values in the DockerRegistryOptions
-func (o DockerRegistryOptions) GetSystemContext(signaturePolicyPath, authFile string) *types.SystemContext {
+func (o DockerRegistryOptions) GetSystemContext(signaturePolicyPath, authFile string, forceCompress bool) *types.SystemContext {
 	sc := &types.SystemContext{
 		SignaturePolicyPath:         signaturePolicyPath,
 		DockerAuthConfig:            o.DockerRegistryCreds,
 		DockerCertPath:              o.DockerCertPath,
 		DockerInsecureSkipTLSVerify: o.DockerInsecureSkipTLSVerify,
 		AuthFilePath:                authFile,
+		DirForceCompress:            forceCompress,
 	}
 	return sc
 }

--- a/test/kpod_push.bats
+++ b/test/kpod_push.bats
@@ -84,3 +84,19 @@ function setup() {
     run ${KPOD_BINARY} $KPOD_OPTIONS rmi "$ALPINE"
     echo "$output"
 }
+
+@test "push with manifest type conversion" {
+    run bash -c "${KPOD_BINARY} $KPOD_OPTIONS push --format oci "${BB}" dir:my-dir"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run bash -c "grep "application/vnd.oci.image.config.v1+json" my-dir/manifest.json"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run bash -c "${KPOD_BINARY} $KPOD_OPTIONS push --compress --format v2s2 "${BB}" dir:my-dir"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run bash -c "grep "application/vnd.docker.distribution.manifest.v2+json" my-dir/manifest.json"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    rm -rf my-dir
+}


### PR DESCRIPTION
User can select from 3 manifest types: oci, v2s1, or v2s2
e.g kpod push --format v2s2 alpine dir:my-directory
Added "compress" flag to enable compression when true

Signed-off-by: umohnani8 <umohnani@redhat.com>