### PR TITLE
Add support for dir transport to kpod save

### DIFF
--- a/cmd/kpod/load.go
+++ b/cmd/kpod/load.go
@@ -104,14 +104,18 @@ func loadCmd(c *cli.Context) error {
 	src := libpod.DockerArchive + ":" + input
 	imgName, err := runtime.PullImage(src, options)
 	if err != nil {
-		src = libpod.OCIArchive + ":" + input
 		// generate full src name with specified image:tag
+		fullSrc := libpod.OCIArchive + ":" + input
 		if image != "" {
-			src = src + ":" + image
+			fullSrc = fullSrc + ":" + image
 		}
-		imgName, err = runtime.PullImage(src, options)
+		imgName, err = runtime.PullImage(fullSrc, options)
 		if err != nil {
-			return errors.Wrapf(err, "error pulling %q", src)
+			src = libpod.DirTransport + ":" + input
+			imgName, err = runtime.PullImage(src, options)
+			if err != nil {
+				return errors.Wrapf(err, "error pulling %q", src)
+			}
 		}
 	}
 	fmt.Println("Loaded image: ", imgName)

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -1302,6 +1302,7 @@ _kpod_save() {
      --format
      "
      local boolean_options="
+	 --compress
      --quiet -q
      "
      _complete_ "$options_with_args" "$boolean_options"

--- a/docs/kpod-save.1.md
+++ b/docs/kpod-save.1.md
@@ -14,10 +14,10 @@ kpod-save - Save an image to docker-archive or oci-archive
 [**--help**|**-h**]
 
 ## DESCRIPTION
-**kpod save** saves an image to either **docker-archive** or **oci-archive**
-on the local machine, default is **docker-archive**.
-**kpod save** writes to STDOUT by default and can be redirected to a file using the **output** flag.
-The **quiet** flag suppresses the output when set.
+**kpod save** saves an image to either **docker-archive**, **oci-archive**, **oci-dir** (directory
+with oci manifest type), or **docker-dir** (directory with v2s2 manifest type) on the local machine,
+default is **docker-archive**. **kpod save** writes to STDOUT by default and can be redirected to a
+file using the **output** flag. The **quiet** flag suppresses the output when set.
 
 **kpod [GLOBAL OPTIONS]**
 
@@ -27,13 +27,20 @@ The **quiet** flag suppresses the output when set.
 
 ## OPTIONS
 
+**--compress**
+
+Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type, compressed or uncompressed, as source)
+Note: This flag can only be set when using the **dir** transport i.e --format=oci-dir or --format-docker-dir
+
 **--output, -o**
 Write to a file, default is STDOUT
 
 **--format**
-Save image to **oci-archive**
+Save image to **oci-archive**, **oci-dir** (directory with oci manifest type), or **docker-dir** (directory with v2s2 manifest type)
 ```
 --format oci-archive
+--format oci-dir
+--format docker-dir
 ```
 
 **--quiet, -q**
@@ -51,6 +58,36 @@ Suppress the output
 
 ```
 # kpod save -o oci-alpine.tar --format oci-archive alpine
+```
+
+```
+# kpod save --compress --format oci-dir -o alp-dir alpine
+Getting image source signatures
+Copying blob sha256:2fdfe1cd78c20d05774f0919be19bc1a3e4729bce219968e4188e7e0f1af679d
+ 1.97 MB / 1.97 MB [========================================================] 0s
+Copying config sha256:501d1a8f0487e93128df34ea349795bc324d5e0c0d5112e08386a9dfaff620be
+ 584 B / 584 B [============================================================] 0s
+Writing manifest to image destination
+Storing signatures
+```
+
+```
+# kpod save --format docker-dir -o ubuntu-dir ubuntu
+Getting image source signatures
+Copying blob sha256:660c48dd555dcbfdfe19c80a30f557ac57a15f595250e67bfad1e5663c1725bb
+ 45.55 MB / 45.55 MB [======================================================] 8s
+Copying blob sha256:4c7380416e7816a5ab1f840482c9c3ca8de58c6f3ee7f95e55ad299abbfe599f
+ 846 B / 846 B [============================================================] 0s
+Copying blob sha256:421e436b5f80d876128b74139531693be9b4e59e4f1081c9a3c379c95094e375
+ 620 B / 620 B [============================================================] 0s
+Copying blob sha256:e4ce6c3651b3a090bb43688f512f687ea6e3e533132bcbc4a83fb97e7046cea3
+ 849 B / 849 B [============================================================] 0s
+Copying blob sha256:be588e74bd348ce48bb7161350f4b9d783c331f37a853a80b0b4abc0a33c569e
+ 169 B / 169 B [============================================================] 0s
+Copying config sha256:20c44cd7596ff4807aef84273c99588d22749e2a7e15a7545ac96347baa65eda
+ 3.53 KB / 3.53 KB [========================================================] 0s
+Writing manifest to image destination
+Storing signatures
 ```
 
 ## SEE ALSO

--- a/test/kpod_load.bats
+++ b/test/kpod_load.bats
@@ -10,10 +10,10 @@ function teardown() {
     cleanup_test
 }
 @test "kpod load input flag" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $IMAGE
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} load -i alpine.tar
@@ -23,9 +23,9 @@ function teardown() {
 }
 
 @test "kpod load oci-archive image" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $ALPINE
 	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $ALPINE
 	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} load -i alpine.tar
 	echo "$output"
@@ -34,9 +34,9 @@ function teardown() {
 }
 
 @test "kpod load oci-archive image with signature-policy" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $ALPINE
 	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	run bash -c ${KPOD_BINARY} $KPOD_OPTIONS rmi $ALPINE
 	[ "$status" -eq 0 ]
 	cp /etc/containers/policy.json /tmp
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} load --signature-policy /tmp/policy.json -i alpine.tar
@@ -47,16 +47,31 @@ function teardown() {
 }
 
 @test "kpod load using quiet flag" {
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $IMAGE
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $IMAGE
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $ALPINE
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} load -q -i alpine.tar
 	echo "$output"
 	[ "$status" -eq 0 ]
 	rm -f alpine.tar
+}
+
+@test "kpod load directory" {
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} save --format oci-dir -o alp-dir $ALPINE
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi $ALPINE
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} load -i alp-dir
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run bash -c ${KPOD_BINARY} ${KPOD_OPTIONS} rmi alp-dir
+	echo "$output"
+	[ "$status" -eq 0 ]
 }
 
 @test "kpod load non-existent file" {

--- a/test/kpod_save.bats
+++ b/test/kpod_save.bats
@@ -42,3 +42,17 @@ function setup() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 }
+
+@test "kpod save to directory wit oci format" {
+	run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} save --format oci-dir -o alp-dir $ALPINE"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	rm -rf alp-dir
+}
+
+@test "kpod save to directory wit v2s2 (docker) format" {
+	run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} save --format docker-dir -o alp-dir $ALPINE"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	rm -rf alp-dir
+}


### PR DESCRIPTION
kpod save can now save images to directories using the
dir transport. Manifest conversion is also possible.
To save with the oci manifest type set --format to oci-dir
and to save with the v2s2(docker) manifest type, set --format
to docker-dir.
The layers can be compressed as well when saving to a directory
using the --compress flag.

Signed-off-by: umohnani8 <umohnani@redhat.com>
