### PR TITLE
Fix locks to better handle removed containers

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -430,11 +430,6 @@ func newContainer(rspec *spec.Spec, lockDir string) (*Container, error) {
 
 	// Path our lock file will reside at
 	lockPath := filepath.Join(lockDir, ctr.config.ID)
-	// Ensure there is no conflict - file does not exist
-	_, err := os.Stat(lockPath)
-	if err == nil || !os.IsNotExist(err) {
-		return nil, errors.Wrapf(ErrCtrExists, "lockfile for container ID %s already exists", ctr.config.ID)
-	}
 	// Grab a lockfile at the given path
 	lock, err := storage.GetLockfile(lockPath)
 	if err != nil {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -401,3 +401,19 @@ func WithPodName(name string) PodCreateOption {
 		return nil
 	}
 }
+
+// WithPodLabels sets the labels of a pod
+func WithPodLabels(labels map[string]string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+
+		pod.labels = make(map[string]string)
+		for key, value := range labels {
+			pod.labels[key] = value
+		}
+
+		return nil
+	}
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/containers/storage"
@@ -57,11 +56,6 @@ func newPod(lockDir string) (*Pod, error) {
 
 	// Path our lock file will reside at
 	lockPath := filepath.Join(lockDir, pod.id)
-	// Ensure there is no conflict - file does not exist
-	_, err := os.Stat(lockPath)
-	if err == nil || !os.IsNotExist(err) {
-		return nil, errors.Wrapf(ErrCtrExists, "lockfile for pod ID %s already exists", pod.id)
-	}
 	// Grab a lockfile at the given path
 	lock, err := storage.GetLockfile(lockPath)
 	if err != nil {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -138,7 +138,7 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 	}
 
 	// Make a directory to hold container lockfiles
-	lockDir := filepath.Join(runtime.config.StaticDir, "lock")
+	lockDir := filepath.Join(runtime.config.TmpDir, "lock")
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -24,7 +24,7 @@ func (r *Runtime) NewPod(options ...PodCreateOption) (*Pod, error) {
 		return nil, ErrRuntimeStopped
 	}
 
-	pod, err := newPod()
+	pod, err := newPod(r.lockDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating pod")
 	}

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -154,8 +154,6 @@ func prepareDB(db *sql.DB) (err error) {
 	// TODO add Pod ID to CreateStaticContainer as a FOREIGN KEY referencing podStatic(Id)
 	// TODO add ctr shared namespaces information - A separate table, probably? So we can FOREIGN KEY the ID
 	// TODO schema migration might be necessary and should be handled here
-	// TODO add a table for the runtime, and refuse to load the database if the runtime configuration
-	// does not match the one in the database
 
 	// Enable foreign keys in SQLite
 	if _, err := db.Exec("PRAGMA foreign_keys = ON;"); err != nil {


### PR DESCRIPTION
Depends on #136 

Removes checks that locks already exist when creating containers - these checks were racy and aren't really necessary, as we may theoretically reuse container IDs.

Also moves locks into a tmpfs, so they will be reaped on reboot. We can't clean them up otherwise right now.