### PR TITLE
Use incremental go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/test/checkseccomp
 
 kpod: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/kpod $(PROJECT))
-	$(GO) build $(LDFLAGS_KPOD) -tags "$(BUILDTAGS)" -o bin/$@ $(PROJECT)/cmd/kpod
+	$(GO) build -i $(LDFLAGS_KPOD) -tags "$(BUILDTAGS)" -o bin/$@ $(PROJECT)/cmd/kpod
 
 clean:
 ifneq ($(GOPATH),)


### PR DESCRIPTION
Speed up kpod builds by not recompiling eveything but only
what has changed.

Signed-off-by: baude <bbaude@redhat.com>