### PR TITLE
Finish implementing stop signal parsing

### DIFF
--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -533,6 +533,7 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 	// TODO parse ports into libpod format and include
 	// TODO should not happen if --net=host
 	options = append(options, libpod.WithNetNS([]ocicni.PortMapping{}))
+	options = append(options, libpod.WithStopSignal(c.StopSignal))
 
 	return options, nil
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"fmt"
 	"path/filepath"
+	"syscall"
 
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
@@ -396,7 +397,7 @@ func WithName(name string) CtrCreateOption {
 }
 
 // WithStopSignal sets the signal that will be sent to stop the container
-func WithStopSignal(signal uint) CtrCreateOption {
+func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return ErrCtrFinalized
@@ -408,7 +409,7 @@ func WithStopSignal(signal uint) CtrCreateOption {
 			return errors.Wrapf(ErrInvalidArg, "stop signal cannot be greater than 64 (SIGRTMAX)")
 		}
 
-		ctr.config.StopSignal = signal
+		ctr.config.StopSignal = uint(signal)
 
 		return nil
 	}


### PR DESCRIPTION
Stop Signal from kpod create/run was not fully plumbed in,
This will pass the stopsignal into the container database on
create and run of containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>