### PR TITLE
Plumb through the --stop-timeout signal handling

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -393,6 +393,7 @@ var createFlags = []cli.Flag{
 	cli.IntFlag{
 		Name:  "stop-timeout",
 		Usage: "Timeout (in seconds) to stop a container. Default is 10",
+		Value: libpod.CtrRemoveTimeout,
 	},
 	cli.StringSliceFlag{
 		Name:  "storage-opt",

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -110,7 +110,7 @@ type createConfig struct {
 	ShmDir             string
 	SigProxy           bool              //sig-proxy
 	StopSignal         syscall.Signal    // stop-signal
-	StopTimeout        int64             // stop-timeout
+	StopTimeout        uint              // stop-timeout
 	StorageOpts        []string          //storage-opt
 	Sysctl             map[string]string //sysctl
 	Tmpfs              []string          // tmpfs
@@ -494,7 +494,7 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime) (*createConfig, er
 		ShmDir:      shmDir,
 		SigProxy:    c.Bool("sig-proxy"),
 		StopSignal:  stopSignal,
-		StopTimeout: c.Int64("stop-timeout"),
+		StopTimeout: c.Uint("stop-timeout"),
 		StorageOpts: c.StringSlice("storage-opt"),
 		Sysctl:      sysctl,
 		Tmpfs:       c.StringSlice("tmpfs"),

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -559,7 +559,7 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 	// TODO should not happen if --net=host
 	options = append(options, libpod.WithNetNS([]ocicni.PortMapping{}))
 	options = append(options, libpod.WithStopSignal(c.StopSignal))
-
+	options = append(options, libpod.WithStopTimeout(c.StopTimeout))
 	return options, nil
 }
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -146,6 +146,8 @@ type ContainerConfig struct {
 	Mounts []string `json:"mounts,omitempty"`
 	// StopSignal is the signal that will be used to stop the container
 	StopSignal uint `json:"stopSignal,omitempty"`
+	// StopTimeout is the signal that will be used to stop the container
+	StopTimeout uint `json:"stopTimeout,omitempty"`
 	// Shared namespaces with container
 	SharedNamespaceCtr *string           `json:"shareNamespacesWith,omitempty"`
 	SharedNamespaceMap map[string]string `json:"sharedNamespaces"`
@@ -671,9 +673,10 @@ func (c *Container) Start() error {
 // to stop the container, and if it has not stopped after the given timeout (in
 // seconds), uses SIGKILL to attempt to forcibly stop the container.
 // If timeout is 0, SIGKILL will be used immediately
-func (c *Container) Stop(timeout int64) error {
+func (c *Container) Stop(timeout uint) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	logrus.Debugf("Stopping ctr %s with timeout %d", c.ID(), timeout)
 
 	if err := c.syncContainer(); err != nil {
 		return err
@@ -1107,4 +1110,9 @@ func (c *Container) copyHostFileToRundir(sourcePath string) (string, error) {
 		return "", err
 	}
 	return destFileName, nil
+}
+
+// StopTimeout returns a stop timeout field for this container
+func (c *Container) StopTimeout() uint {
+	return c.config.StopTimeout
 }

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -401,7 +401,7 @@ func (r *OCIRuntime) killContainer(ctr *Container, signal uint) error {
 // immediately kill with SIGKILL
 // Does not set finished time for container, assumes you will run updateStatus
 // after to pull the exit code
-func (r *OCIRuntime) stopContainer(ctr *Container, timeout int64) error {
+func (r *OCIRuntime) stopContainer(ctr *Container, timeout uint) error {
 	// Ping the container to see if it's alive
 	// If it's not, it's already stopped, return
 	err := unix.Kill(ctr.state.PID, 0)

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -415,6 +415,19 @@ func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 	}
 }
 
+// WithStopTimeout sets the time to after initial stop signal is sent to container, before sending the kill signal
+func WithStopTimeout(timeout uint) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+
+		ctr.config.StopTimeout = timeout
+
+		return nil
+	}
+}
+
 // WithNetNS indicates that the container should be given a new network
 // namespace with a minimal configuration
 // An optional array of port mappings can be provided

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -277,7 +277,7 @@ func (r *Runtime) Shutdown(force bool) error {
 			logrus.Errorf("Error retrieving containers from database: %v", err)
 		} else {
 			for _, ctr := range ctrs {
-				if err := ctr.Stop(ctrRemoveTimeout); err != nil {
+				if err := ctr.Stop(CtrRemoveTimeout); err != nil {
 					logrus.Errorf("Error stopping container %s: %v", ctr.ID(), err)
 				}
 			}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -9,7 +9,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const ctrRemoveTimeout = 10
+// CtrRemoveTimeout is the default number of seconds to wait after stopping a container
+// before sending the kill signal
+const CtrRemoveTimeout = 10
 
 // Contains the public Runtime API for containers
 
@@ -34,6 +36,7 @@ func (r *Runtime) NewContainer(spec *spec.Spec, options ...CtrCreateOption) (c *
 	if err != nil {
 		return nil, err
 	}
+	ctr.config.StopTimeout = CtrRemoveTimeout
 
 	for _, option := range options {
 		if err := option(ctr); err != nil {
@@ -122,7 +125,7 @@ func (r *Runtime) removeContainer(c *Container, force bool) error {
 
 	// Check that the container's in a good state to be removed
 	if c.state.State == ContainerStateRunning && force {
-		if err := r.ociRuntime.stopContainer(c, ctrRemoveTimeout); err != nil {
+		if err := r.ociRuntime.stopContainer(c, c.StopTimeout()); err != nil {
 			return errors.Wrapf(err, "cannot remove container %s as it could not be stopped", c.ID())
 		}
 

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -15,7 +15,7 @@ import (
 
 // DBSchema is the current DB schema version
 // Increments every time a change is made to the database's tables
-const DBSchema = 4
+const DBSchema = 5
 
 // SQLState is a state implementation backed by a persistent SQLite3 database
 type SQLState struct {
@@ -271,7 +271,7 @@ func (s *SQLState) HasContainer(id string) (bool, error) {
 func (s *SQLState) AddContainer(ctr *Container) (err error) {
 	const (
 		addCtr = `INSERT INTO containers VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
                 );`
 		addCtrState = `INSERT INTO containerState VALUES (
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
@@ -332,6 +332,7 @@ func (s *SQLState) AddContainer(ctr *Container) (err error) {
 		boolToSQL(ctr.config.Stdin),
 		string(labelsJSON),
 		ctr.config.StopSignal,
+		ctr.config.StopTimeout,
 		timeToSQL(ctr.config.CreatedTime),
 		ctr.config.RootfsImageID,
 		ctr.config.RootfsImageName,

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -176,6 +176,7 @@ func prepareDB(db *sql.DB) (err error) {
             Stdin INTEGER NOT NULL,
             LabelsJSON TEXT NOT NULL,
             StopSignal INTEGER NOT NULL,
+            StopTimeout INTEGER NOT NULL,
             CreatedTime TEXT NOT NULL,
             RootfsImageID TEXT NOT NULL,
             RootfsImageName TEXT NOT NULL,
@@ -284,6 +285,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 		stdin              int
 		labelsJSON         string
 		stopSignal         uint
+		stopTimeout        uint
 		createdTimeString  string
 		rootfsImageID      string
 		rootfsImageName    string
@@ -313,6 +315,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 		&stdin,
 		&labelsJSON,
 		&stopSignal,
+		&stopTimeout,
 		&createdTimeString,
 		&rootfsImageID,
 		&rootfsImageName,
@@ -351,6 +354,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 	ctr.config.StaticDir = staticDir
 	ctr.config.Stdin = boolFromSQL(stdin)
 	ctr.config.StopSignal = stopSignal
+	ctr.config.StopTimeout = stopTimeout
 
 	ctr.state.State = ContainerState(state)
 	ctr.state.ConfigPath = configPath

--- a/libpod/sql_state_test.go
+++ b/libpod/sql_state_test.go
@@ -26,6 +26,7 @@ func getTestContainer(id, name, locksDir string) (*Container, error) {
 			Stdin:           true,
 			Labels:          make(map[string]string),
 			StopSignal:      0,
+			StopTimeout:     0,
 			CreatedTime:     time.Now(),
 		},
 		state: &containerRuntimeInfo{


### PR DESCRIPTION
podman run/create have the ability to set the stop timeout flag.
We need to stop it in the database.

Also Allowing negative time for stop timeout makes no sense, so switching
to timeout of uint, allows user to specify huge timeout values.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>