### PR TITLE
Touch up certs-dir verbiage a bit

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -32,7 +32,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "cert-dir",
-			Usage: "Pathname of a directory containing TLS certificates and keys",
+			Usage: "Pathname of a directory containing TLS certificates and keys used to connect to the registry",
 		},
 		cli.BoolTFlag{
 			Name:  "tls-verify",

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -38,7 +38,7 @@ Username for registry
 Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
 
 **--cert-dir**
-Pathname of a directory containing TLS certificates and keys
+Pathname of a directory containing TLS certificates and keys used to connect to the registry
 
 **--tls-verify**
 Require HTTPS and verify certificates when contacting registries (default: true)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

A quick tweak to the cert-dir verbiage to specify the certs/keys are to be used with a registry.