### PR TITLE
Host networking [wip, do not merge yet]

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -324,7 +324,8 @@ var createFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "network",
-		Usage: "Connect a container to a network (default 'default')",
+		Usage: "Connect a container to a network",
+		Value: "bridge",
 	},
 	cli.StringSliceFlag{
 		Name:  "network-alias",

--- a/test/podman_networking.bats
+++ b/test/podman_networking.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+    cleanup_test
+}
+
+function setup() {
+    copy_images
+}
+
+@test "test network connection with default bridge" {
+    run ${KPOD_BINARY} ${KPOD_OPTIONS} run -dt ${ALPINE} wget www.yahoo.com
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "test network connection with host" {
+    run ${KPOD_BINARY} ${KPOD_OPTIONS} run -dt --network host ${ALPINE} wget www.yahoo.com
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Allow for the user to specify network=host|bridge.  If network
is not specified, the default will be bridge.  While "none" is now
a valid option, it is not included in this.

Signed-off-by: baude <bbaude@redhat.com>