### PR TITLE
Exec: No arg reorder

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -35,12 +35,13 @@ var (
 `
 
 	execCommand = cli.Command{
-		Name:        "exec",
-		Usage:       "Run a process in a running container",
-		Description: execDescription,
-		Flags:       execFlags,
-		Action:      execCmd,
-		ArgsUsage:   "CONTAINER-NAME",
+		Name:           "exec",
+		Usage:          "Run a process in a running container",
+		Description:    execDescription,
+		Flags:          execFlags,
+		Action:         execCmd,
+		ArgsUsage:      "CONTAINER-NAME",
+		SkipArgReorder: true,
 	}
 )
 


### PR DESCRIPTION
Do not re-order the args for exec.  Like run, it is very possible
that a user will pass a -something in their command and this currently
does not work.

Signed-off-by: baude <bbaude@redhat.com>