### PR TITLE
Shortcut for most recent container

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -14,6 +14,14 @@ import (
 	"github.com/urfave/cli"
 )
 
+var (
+	stores     = make(map[storage.Store]struct{})
+	LatestFlag = cli.BoolFlag{
+		Name:  "latest, l",
+		Usage: "act on the latest container podman is aware of",
+	}
+)
+
 const crioConfigPath = "/etc/crio/crio.conf"
 
 func getRuntime(c *cli.Context) (*libpod.Runtime, error) {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -653,7 +653,10 @@ _podman_attach() {
      local boolean_options="
      --help
      -h
-     --no-stdin"
+     --latest
+     -l
+     --no-stdin
+     "
      _complete_ "$options_with_args" "$boolean_options"
 }
 
@@ -752,6 +755,8 @@ _podman_exec() {
     -u
      "
     local boolean_options="
+    --latest
+    -l
     --privileged
     --tty
     -t
@@ -875,6 +880,8 @@ _podman_inspect() {
     local boolean_options="
      --help
      -h
+     --latest
+     -l
      "
     local options_with_args="
     --format
@@ -898,7 +905,10 @@ _podman_kill() {
      "
      local boolean_options="
      --help
-     -h"
+     -h
+     --latest
+     -l
+     "
      _complete_ "$options_with_args" "$boolean_options"
 }
 
@@ -910,6 +920,8 @@ _podman_logs() {
      local boolean_options="
      --follow
      -f
+     --latest
+     -l
      "
      _complete_ "$options_with_args" "$boolean_options"
 
@@ -1286,6 +1298,8 @@ _podman_rm() {
     -a
     --force
     -f
+    --latest
+    -l
     "
 
     local options_with_args="
@@ -1355,6 +1369,10 @@ podman_top() {
     local options_with_args="
     "
     local boolean_options="
+    --help
+    -h
+    --latest
+    -l
     "
     _complete_ "$options_with_args" "$boolean_options"
 }
@@ -1424,7 +1442,9 @@ _podman_start() {
      -a
      --attach
      -i
-     --interactive"
+     --interactive
+     --latest
+     -l"
      _complete_ "$options_with_args" "$boolean_options"
 }
 _podman_stop() {
@@ -1433,7 +1453,9 @@ _podman_stop() {
      "
      local boolean_options="
      --all
-     -a"
+     -a
+     --latest
+     -l"
      _complete_ "$options_with_args" "$boolean_options"
 }
 

--- a/docs/podman-attach.1.md
+++ b/docs/podman-attach.1.md
@@ -20,6 +20,10 @@ sequence is CTRL-p CTRL-q. You configure the key sequence using the --detach-key
 Override the key sequence for detaching a container. Format is a single character [a-Z] or
 ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _.
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
+
 **--no-stdin**
 Do not attach STDIN. The default is false.
 
@@ -27,6 +31,10 @@ Do not attach STDIN. The default is false.
 
 ```
 podman attach foobar
+[root@localhost /]#
+```
+```
+podman attach --latest
 [root@localhost /]#
 ```
 ```

--- a/docs/podman-exec.1.md
+++ b/docs/podman-exec.1.md
@@ -22,6 +22,10 @@ command to be executed.
 **--interactive, -i**
 Not supported.  All exec commands are interactive by default.
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started  container could be from either of those methods.
+
 **--privileged**
 Give the process extended Linux capabilities when running the command in container.
 

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -21,6 +21,10 @@ Return data on items of the specified type.  Type can be 'container', 'image' or
 
 Format the output using the given Go template
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
+
 **--size**
 
 Display the total file size if the type is a container

--- a/docs/podman-kill.1.md
+++ b/docs/podman-kill.1.md
@@ -12,6 +12,9 @@ podman kill - Kills one or more containers with a signal
 The main process inside each container specified will be sent SIGKILL, or any signal specified with option --signal.
 
 ## OPTIONS
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
 
 **--signal, s**
 
@@ -25,6 +28,8 @@ podman kill mywebserver
 podman kill 860a4b23
 
 podman kill --signal TERM 860a4b23
+
+podman kill --latest
 
 ## SEE ALSO
 podman(1), podman-stop(1)

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -21,6 +21,9 @@ Force the removal of a running container
 
 Remove all containers.  Can be used in conjunction with -f as well.
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
 ## EXAMPLE
 
 podman rm mywebserver
@@ -30,6 +33,8 @@ podman rm mywebserver myflaskserver 860a4b23
 podman rm -f 860a4b23
 
 podman rm -f -a
+
+podman rm -f --latest
 
 ## SEE ALSO
 podman(1), podman-rmi(1)

--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -29,6 +29,9 @@ ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _.
 
 Attach container's STDIN. The default is false.
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
 
 ## EXAMPLE
 
@@ -37,6 +40,8 @@ podman start mywebserver
 podman start 860a4b23 5421ab4
 
 podman start -i -a 860a4b23
+
+podman start -i -l
 
 ## SEE ALSO
 podman(1), podman-create(1)

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -17,6 +17,10 @@ Display a live stream of one or more containers' resource usage statistics
 
 Show all containers.  Only running containers are shown by default
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
+
 **--no-reset**
 
 Do not clear the terminal/screen in between reporting intervals

--- a/docs/podman-stop.1.md
+++ b/docs/podman-stop.1.md
@@ -23,6 +23,9 @@ Timeout to wait before forcibly stopping the container
 
 Stop all running containers.  This does not include paused containers.
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
 
 ## EXAMPLE
 
@@ -35,6 +38,8 @@ podman stop mywebserver 860a4b23
 podman stop --timeout 2 860a4b23
 
 podman stop -a
+
+podman stop --latest
 
 ## SEE ALSO
 podman(1), podman-rm(1)

--- a/docs/podman-top.1.md
+++ b/docs/podman-top.1.md
@@ -21,6 +21,10 @@ Display the running process of the container. ps-OPTION can be any of the option
 **--format**
   Display the output in an alternate format.  The only supported format is **JSON**.
 
+**--latest, -l**
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
+
 ## EXAMPLES
 
 ```

--- a/test/podman_exec.bats
+++ b/test/podman_exec.bats
@@ -28,3 +28,10 @@ function setup() {
     echo "$output"
     [ "$status" -eq 0 ]
 }
+
+@test "exec simple command using latest" {
+    ${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d -t ${ALPINE} sleep 60
+    run ${PODMAN_BINARY} ${PODMAN_OPTIONS} exec -l ls
+    echo "$output"
+    [ "$status" -eq 0 ]
+}

--- a/test/podman_inspect.bats
+++ b/test/podman_inspect.bats
@@ -45,8 +45,7 @@ function setup() {
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} create ${BB} ls"
     echo "$output"
     [ "$status" -eq 0 ]
-    ctr_id="$output"
-    run bash -c "${PODMAN_BINARY} $PODMAN_OPTIONS inspect --size $ctr_id | python -m json.tool | grep SizeRootFs"
+    run bash -c "${PODMAN_BINARY} $PODMAN_OPTIONS inspect --size -l | python -m json.tool | grep SizeRootFs"
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/podman_kill.bats
+++ b/test/podman_kill.bats
@@ -62,3 +62,10 @@ function setup() {
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} ps --no-trunc"
     [ "$status" -eq 0 ]
 }
+
+@test "kill the latest container run" {
+    ${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d ${ALPINE} sleep 9999
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} kill -l"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}

--- a/test/podman_logs.bats
+++ b/test/podman_logs.bats
@@ -42,11 +42,10 @@ function setup() {
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d $BB ls"
     echo "$output"
     [ "$status" -eq 0 ]
-    ctr_id="$output"
-    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} logs --since 2017-08-07T10:10:09.056611202-04:00 $ctr_id"
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} logs --since 2017-08-07T10:10:09.056611202-04:00 -l"
     echo "$output"
     [ "$status" -eq 0 ]
-    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} rm $ctr_id"
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} rm -l"
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/test/podman_stop.bats
+++ b/test/podman_stop.bats
@@ -47,3 +47,10 @@ function setup() {
     echo "$output"
     [ "$status" -eq 0 ]
 }
+
+@test "stop a container with latest" {
+    ${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d ${ALPINE} sleep 9999
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} stop -t 1 -l"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
It is desirable to have a shortcut for the most
recently created container.  We can now use "**latest"
to represent the most recent container instead of its
container ID or name.  For example:

Signed-off-by: baude <bbaude@redhat.com>