### PR TITLE
Remove kpod handling of conmon

### DIFF
--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -12,7 +12,6 @@ import (
 const (
 	crioRoot            = "/var/lib/containers/storage"
 	crioRunRoot         = "/var/run/containers/storage"
-	conmonPath          = "/usr/local/libexec/crio/conmon"
 	pauseImage          = "kubernetes/pause"
 	pauseCommand        = "/pause"
 	defaultTransport    = "docker://"
@@ -278,7 +277,6 @@ func DefaultConfig() *Config {
 			RuntimeUntrustedWorkload: "",
 			DefaultWorkloadTrust:     "trusted",
 
-			Conmon: conmonPath,
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -134,9 +134,10 @@ func WithConmonPath(path string) RuntimeOption {
 		if rt.valid {
 			return ErrRuntimeFinalized
 		}
-
-		rt.config.ConmonPath = path
-
+		// TODO Once libkpod is eliminated, "" should throw an error
+		if path != "" {
+			rt.config.ConmonPath = path
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
We don't want libkpod overrides for conmon's path to misdirect
the already set path for conmon from libpod.

Signed-off-by: baude <bbaude@redhat.com>