### PR TITLE
Run by shortname

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -344,7 +344,7 @@ func imageData(c *cli.Context, runtime *libpod.Runtime, image string) (string, s
 	if err != nil {
 		return "", "", nil, err
 	}
-	storageImage, err := runtime.GetImage(image)
+	storageImage, err := runtime.GetImage(imageName)
 	if err != nil {
 		return "", "", nil, errors.Wrapf(err, "error getting storage image %q", image)
 	}
@@ -452,7 +452,6 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime) (*createConfig, er
 		}
 		shmDir = ctr.ShmDir()
 	}
-
 	imageName, imageID, data, err := imageData(c, runtime, image)
 	if err != nil {
 		return nil, err

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -328,12 +328,12 @@ func getTags(nameInput string) (reference.NamedTagged, bool, error) {
 // It will return an empty string and error if not found.
 func (k *Image) GetLocalImageName() (string, error) {
 	_, err := k.runtime.GetImage(k.Name)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to obtain local image")
+	if err == nil {
+		return k.Name, nil
 	}
 	localImages, err := k.runtime.GetImages(&ImageFilterParams{})
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to obtain local image")
+		return "", errors.Wrapf(err, "unable to find local images")
 	}
 	_, isTagged, err := getTags(k.Name)
 	if err != nil {
@@ -370,8 +370,7 @@ func (k *Image) GetLocalImageName() (string, error) {
 			}
 		}
 	}
-	fqname, _ := k.GetFQName()
-	return fqname, nil
+	return "", errors.Wrapf(storage.ErrImageUnknown, "unable to find image locally")
 }
 
 // HasLatest determines if we have the latest image local


### PR DESCRIPTION
While pulling by shortname (fedora-minimal) worked, running a container
by the short name did not due to a logic error.

Signed-off-by: baude <bbaude@redhat.com>