### PR TITLE
Make database write in syncContainer conditional

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -412,11 +412,16 @@ func (c *Container) syncContainer() error {
 	// And then save back to disk
 	if (c.state.State != ContainerStateUnknown) &&
 		(c.state.State != ContainerStateConfigured) {
+		oldState := c.state.State
+		// TODO: optionally replace this with a stat for the exit file
 		if err := c.runtime.ociRuntime.updateContainerStatus(c); err != nil {
 			return err
 		}
-		if err := c.save(); err != nil {
-			return err
+		// Only save back to DB if state changed
+		if c.state.State != oldState {
+			if err := c.save(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Only update the database when the state has changed. This should save a database write during syncContainer most of the time.