### PR TITLE
Add removal failure test after unpause

### DIFF
--- a/test/podman_pause.bats
+++ b/test/podman_pause.bats
@@ -101,6 +101,11 @@ function teardown() {
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} ps -a --filter id=$ctr_id"
     echo "$output"
     [ "$status" -eq 0 ]
+    # Container should be running after unpause and shouldn't
+    # be removable without the force flag.
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} rm $ctr_id"
+    echo "$output"
+    [ "$status" -eq 125 ]
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} rm -f $ctr_id"
     echo "$output"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds a test to make sure you can't remove a container after it's been unpaused.  After being unpaused the container should be running and remove shouldn't work without the --force param.  

This is an addition to a fix that @ypu did in #180