### PR TITLE
Don't pull cached images

### DIFF
--- a/test/podman_images.bats
+++ b/test/podman_images.bats
@@ -2,43 +2,32 @@
 
 load helpers
 
-IMAGE="busybox"
-
 function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
 @test "podman images" {
-    run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${IMAGE}
-    echo "$output"
-    [ "$status" -eq 0 ]
     run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} images
-    echo "$output"
-    [ "$status" -eq 0 ]
-    run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} rmi ${IMAGE}
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "podman images test valid json" {
-    ${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${IMAGE}
     run ${PODMAN_BINARY} ${PODMAN_OPTIONS} images --format json
     echo "$output" | python -m json.tool
-    [ "$status" -eq 0 ]
-    run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} rmi ${IMAGE}
-    echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "podman images check name json output" {
-    ${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${IMAGE}
+    ${PODMAN_BINARY} ${PODMAN_OPTIONS} rmi -fa
+    ${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${ALPINE}
     run  ${PODMAN_BINARY} ${PODMAN_OPTIONS} images --format json
     [ "$status" -eq 0 ]
     name=$(echo $output | python -c 'import sys; import json; print(json.loads(sys.stdin.read())[0])["names"][0]')
-    [ "$name" == "docker.io/library/${IMAGE}:latest" ]
-    run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} rmi ${IMAGE}
-    echo "$output"
-    [ "$status" -eq 0 ]
+    [ "$name" == "docker.io/library/alpine:latest" ]
 }
 
 @test "podman images short options" {

--- a/test/podman_run.bats
+++ b/test/podman_run.bats
@@ -101,9 +101,6 @@ function setup() {
 IMAGE="docker.io/library/fedora:latest"
 
 @test "run limits test" {
-
-    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${IMAGE}"
-
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run --ulimit rtprio=99 --cap-add=sys_nice ${IMAGE}  cat /proc/self/sched"
     echo $output
     [ "$status" -eq 0 ]

--- a/test/podman_run_ns.bats
+++ b/test/podman_run_ns.bats
@@ -11,9 +11,6 @@ function setup() {
 }
 
 @test "run pidns test" {
-
-    ${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${ALPINE}
-
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run ${ALPINE}  sh -c 'echo \$\$'"
     echo $output
     [ "$status" -eq 0 ]
@@ -32,9 +29,6 @@ function setup() {
 }
 
 @test "run ipcns test" {
-
-    ${PODMAN_BINARY} ${PODMAN_OPTIONS} pull ${ALPINE}
-
     tmp=$(mktemp /dev/shm/foo.XXXXX)
     run ${PODMAN_BINARY} ${PODMAN_OPTIONS} run --ipc=host ${ALPINE} ls $tmp
     echo $output

--- a/test/podman_tag.bats
+++ b/test/podman_tag.bats
@@ -2,17 +2,16 @@
 
 load helpers
 
-IMAGE="alpine:latest"
-
 function teardown() {
     cleanup_test
 }
 
+function setup() {
+    copy_images
+}
+
 @test "podman tag with shortname:latest" {
-	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} pull $IMAGE"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} tag $IMAGE foobar:latest"
+	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} tag ${ALPINE} foobar:latest"
 	[ "$status" -eq 0 ]
 	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} inspect foobar:latest"
 	echo "$output"
@@ -22,10 +21,7 @@ function teardown() {
 }
 
 @test "podman tag with shortname" {
-	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} pull $IMAGE"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} tag $IMAGE foobar"
+	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} tag ${ALPINE} foobar"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} inspect foobar:latest"
@@ -36,10 +32,7 @@ function teardown() {
 }
 
 @test "podman tag with shortname:tag" {
-	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} pull $IMAGE"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} tag $IMAGE foobar:v"
+	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} tag ${ALPINE} foobar:v"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} inspect foobar:v"


### PR DESCRIPTION
In our tests, each test instance is already seeded with images.  In that case,
we do not need to pull down an image that is already seeded.

Signed-off-by: baude <bbaude@redhat.com>