### PR TITLE
cni: 98-podman-loopback.conf is not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,7 @@ install.completions:
 	install ${SELINUXOPT} -m 644 -D completions/bash/podman ${BASHINSTALLDIR}
 
 install.cni:
-	install ${SELINUXOPT} -D -m 644 cni/98-podman-loopback.conf ${ETCDIR}/cni/net.d/98-podman-loopback.conf
-	install ${SELINUXOPT} -m 644 cni/97-podman-bridge.conf ${ETCDIR}/cni/net.d/97-podman-bridge.conf
+	install ${SELINUXOPT} -D -m 644 cni/97-podman-bridge.conf ${ETCDIR}/cni/net.d/97-podman-bridge.conf
 
 uninstall:
 	rm -f $(LIBEXECDIR)/crio/conmon

--- a/cni/98-podman-loopback.conf
+++ b/cni/98-podman-loopback.conf
@@ -1,4 +1,0 @@
-{
-    "cniVersion": "0.2.0",
-    "type": "loopback"
-}


### PR DESCRIPTION
ocicni internally handles the loopback so this file is not required.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@mheon @baude 