### PR TITLE
Save ContainerConfig.User to database

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -156,6 +156,7 @@ type ContainerConfig struct {
 	CreatedTime time.Time `json:"createdTime"`
 	// User/GID to use within the container
 	User string `json:"user"`
+
 	// TODO save log location here and pass into OCI code
 	// TODO allow overriding of log path
 }

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -15,7 +15,7 @@ import (
 
 // DBSchema is the current DB schema version
 // Increments every time a change is made to the database's tables
-const DBSchema = 5
+const DBSchema = 6
 
 // SQLState is a state implementation backed by a persistent SQLite3 database
 type SQLState struct {
@@ -271,7 +271,7 @@ func (s *SQLState) HasContainer(id string) (bool, error) {
 func (s *SQLState) AddContainer(ctr *Container) (err error) {
 	const (
 		addCtr = `INSERT INTO containers VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
                 );`
 		addCtrState = `INSERT INTO containerState VALUES (
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
@@ -336,7 +336,8 @@ func (s *SQLState) AddContainer(ctr *Container) (err error) {
 		timeToSQL(ctr.config.CreatedTime),
 		ctr.config.RootfsImageID,
 		ctr.config.RootfsImageName,
-		boolToSQL(ctr.config.UseImageConfig))
+		boolToSQL(ctr.config.UseImageConfig),
+		ctr.config.User)
 	if err != nil {
 		return errors.Wrapf(err, "error adding static information for container %s to database", ctr.ID())
 	}

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -181,6 +181,7 @@ func prepareDB(db *sql.DB) (err error) {
             RootfsImageID TEXT NOT NULL,
             RootfsImageName TEXT NOT NULL,
             UseImageConfig INTEGER NOT NULL,
+            User TEXT NOT NULL,
             CHECK (Stdin IN (0, 1)),
             CHECK (CreateNetNS IN (0, 1)),
             CHECK (UseImageConfig IN (0, 1)),
@@ -290,6 +291,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 		rootfsImageID      string
 		rootfsImageName    string
 		useImageConfig     int
+		user               string
 		state              int
 		configPath         string
 		runDir             string
@@ -320,6 +322,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 		&rootfsImageID,
 		&rootfsImageName,
 		&useImageConfig,
+		&user,
 		&state,
 		&configPath,
 		&runDir,
@@ -355,6 +358,7 @@ func ctrFromScannable(row scannable, runtime *Runtime, specsDir string, lockDir 
 	ctr.config.Stdin = boolFromSQL(stdin)
 	ctr.config.StopSignal = stopSignal
 	ctr.config.StopTimeout = stopTimeout
+	ctr.config.User = user
 
 	ctr.state.State = ContainerState(state)
 	ctr.state.ConfigPath = configPath


### PR DESCRIPTION
Ensures that, after a restart, containers will remember if we told them to start as a non-root user