### PR TITLE
Shortname deletion continued

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -347,6 +347,7 @@ func getTags(nameInput string) (reference.NamedTagged, bool, error) {
 func (k *Image) GetLocalImageName() (string, error) {
 	_, err := k.runtime.GetImage(k.Name)
 	if err == nil {
+		k.LocalName = k.Name
 		return k.Name, nil
 	}
 	localImages, err := k.runtime.GetImages(&ImageFilterParams{})
@@ -359,6 +360,7 @@ func (k *Image) GetLocalImageName() (string, error) {
 	}
 	for _, image := range localImages {
 		if strings.HasPrefix(image.ID, k.Name) {
+			k.ID = image.ID
 			return image.ID, nil
 		}
 		for _, name := range image.Names {
@@ -379,11 +381,13 @@ func (k *Image) GetLocalImageName() (string, error) {
 			}
 
 			if imageName == k.Name {
+				k.LocalName = name
 				return name, nil
 			}
 			imageSplit := strings.Split(imageName, "/")
 			baseName := imageSplit[len(imageSplit)-1]
 			if baseName == k.Name {
+				k.LocalName = name
 				return name, nil
 			}
 		}

--- a/test/podman_commit.bats
+++ b/test/podman_commit.bats
@@ -13,7 +13,6 @@ function setup() {
 }
 
 @test "podman commit default" {
-    skip "Skipping until docker name removed from image store assumptions"
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d --name my_ctr ${FEDORA_MINIMAL} sleep 6000"
     echo "$output"
     [ "$status" -eq 0 ]
@@ -32,7 +31,6 @@ function setup() {
 }
 
 @test "podman commit with message flag" {
-    skip "Skipping until docker name removed from image store assumptions"
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d --name my_ctr ${FEDORA_MINIMAL} sleep 6000"
     echo "$output"
     [ "$status" -eq 0 ]
@@ -51,7 +49,6 @@ function setup() {
 }
 
 @test "podman commit with author flag" {
-    skip "Skipping until docker name removed from image store assumptions"
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d --name my_ctr ${FEDORA_MINIMAL} sleep 6000"
     echo "$output"
     [ "$status" -eq 0 ]
@@ -70,7 +67,6 @@ function setup() {
 }
 
 @test "podman commit with change flag" {
-    skip "Skipping until docker name removed from image store assumptions"
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d --name my_ctr ${FEDORA_MINIMAL} sleep 6000"
     echo "$output"
     [ "$status" -eq 0 ]
@@ -89,7 +85,6 @@ function setup() {
 }
 
 @test "podman commit with pause flag" {
-    skip "Skipping until docker name removed from image store assumptions"
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d --name my_ctr ${FEDORA_MINIMAL} sleep 6000"
     echo "$output"
     [ "$status" -eq 0 ]
@@ -108,7 +103,6 @@ function setup() {
 }
 
 @test "podman commit non-running container" {
-    skip "Skipping until docker name removed from image store assumptions"
     run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} create --name my_ctr ${FEDORA_MINIMAL} ls"
     echo "$output"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
With certain short name usages, rmi still was unable to delete
certain images. This was also reflected in several commit tests
that were temporarily disabled.

Signed-off-by: baude <bbaude@redhat.com>