### PR TITLE
Add latest to wait

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1469,7 +1469,11 @@ _podman_unpause() {
 
 _podman_wait() {
      local options_with_args=""
-     local boolean_options="--help -h"
+     local boolean_options="
+        --help
+        -h
+        -l
+        --latest"
      _complete_ "$options_with_args" "$boolean_options"
 }
 

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -21,9 +21,15 @@ After the container stops, the container's return code is printed.
 **--help, -h**
   Print usage statement
 
+**--latest, -l**
+  Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods.
+
 ## EXAMPLES
 
   podman wait mywebserver
+
+  podman wait --latest
 
   podman wait 860a4b23
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -271,11 +271,14 @@ func (r *Runtime) GetContainersByList(containers []string) ([]*Container, error)
 
 // GetLatestContainer returns a container object of the latest created container.
 func (r *Runtime) GetLatestContainer() (*Container, error) {
-	var lastCreatedIndex int
+	lastCreatedIndex := -1
 	var lastCreatedTime time.Time
 	ctrs, err := r.GetAllContainers()
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to find latest container")
+	}
+	if len(ctrs) == 0 {
+		return nil, ErrNoSuchCtr
 	}
 	for containerIndex, ctr := range ctrs {
 		createdTime := ctr.config.CreatedTime

--- a/test/podman_wait.bats
+++ b/test/podman_wait.bats
@@ -34,3 +34,10 @@ function teardown() {
     run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} wait $ctr_id
     [ "$status" -eq 0 ]
 }
+
+@test "wait on the latest container" {
+    ${PODMAN_BINARY} ${PODMAN_OPTIONS} run -d ${ALPINE} sleep 5
+    run bash -c ${PODMAN_BINARY} ${PODMAN_OPTIONS} wait -l
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
It is desirable to have a --latest switch on the podman wait
command so we can wait on the latest container created to end.

Also, fixes a panic with latest where no containers are available.

Signed-off-by: baude <bbaude@redhat.com>