### PR TITLE
Add support for copyup by default on tmpfs mounts

### DIFF
--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -282,7 +282,7 @@ func createConfigToOCISpec(config *createConfig) (*spec.Spec, error) {
 			options = strings.Split(spliti[1], ",")
 		}
 		// Default options if nothing passed
-		g.AddTmpfsMount(spliti[0], options)
+		g.AddTmpfsMount(spliti[0], append(options, "tmpcopyup"))
 	}
 
 	for name, val := range config.Env {


### PR DESCRIPTION
Also begin adding support for shm-size. Needs to be made to work
on /dev/shm as well.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>