### PR TITLE
podman run container id to file

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -154,6 +154,12 @@ func createCmd(c *cli.Context) error {
 		return err
 	}
 
+	if c.String("cidfile") != "" {
+		if err := libpod.WriteFile("", c.String("cidfile")); err != nil {
+			return errors.Wrapf(err, "unable to write cidfile %s", c.String("cidfile"))
+		}
+	}
+
 	runtime, err := getRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
@@ -196,11 +202,12 @@ func createCmd(c *cli.Context) error {
 	logrus.Debug("new container created ", ctr.ID())
 
 	if c.String("cidfile") != "" {
-		libpod.WriteFile(ctr.ID(), c.String("cidfile"))
-	} else {
-		fmt.Printf("%s\n", ctr.ID())
+		err := libpod.WriteFile(ctr.ID(), c.String("cidfile"))
+		if err != nil {
+			logrus.Error(err)
+		}
 	}
-
+	fmt.Printf("%s\n", ctr.ID())
 	return nil
 }
 

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -29,6 +29,13 @@ func runCmd(c *cli.Context) error {
 	if err := validateFlags(c, createFlags); err != nil {
 		return err
 	}
+
+	if c.String("cidfile") != "" {
+		if err := libpod.WriteFile("", c.String("cidfile")); err != nil {
+			return errors.Wrapf(err, "unable to write cidfile %s", c.String("cidfile"))
+		}
+	}
+
 	runtime, err := getRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
@@ -84,8 +91,9 @@ func runCmd(c *cli.Context) error {
 	logrus.Debug("new container created ", ctr.ID())
 
 	if c.String("cidfile") != "" {
-		libpod.WriteFile(ctr.ID(), c.String("cidfile"))
-		return nil
+		if err := libpod.WriteFile(ctr.ID(), c.String("cidfile")); err != nil {
+			logrus.Error(err)
+		}
 	}
 
 	// Create a bool channel to track that the console socket attach

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -24,7 +24,7 @@ const (
 func WriteFile(content string, path string) error {
 	baseDir := filepath.Dir(path)
 	if baseDir != "" {
-		if _, err := os.Stat(path); err != nil {
+		if _, err := os.Stat(baseDir); err != nil {
 			return err
 		}
 	}

--- a/test/podman_run.bats
+++ b/test/podman_run.bats
@@ -132,3 +132,12 @@ IMAGE="docker.io/library/fedora:latest"
     echo $output
     [ "$status" -eq 0 ]
 }
+
+@test "podman run with cidfile" {
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run --cidfile /tmp/cidfile $BB ls"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run rm /tmp/cidfile
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
podman run --cidfile /tmp/foo writes the container's id
to a file.

Signed-off-by: baude <bbaude@redhat.com>