### PR TITLE
Remove unused fields from runtime config

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -200,33 +200,6 @@ func WithTmpDir(dir string) RuntimeOption {
 	}
 }
 
-// WithSELinux enables SELinux on the container server
-func WithSELinux() RuntimeOption {
-	return func(rt *Runtime) error {
-		if rt.valid {
-			return ErrRuntimeFinalized
-		}
-
-		rt.config.SelinuxEnabled = true
-
-		return nil
-	}
-}
-
-// WithPidsLimit specifies the maximum number of processes each container is
-// restricted to
-func WithPidsLimit(limit int64) RuntimeOption {
-	return func(rt *Runtime) error {
-		if rt.valid {
-			return ErrRuntimeFinalized
-		}
-
-		rt.config.PidsLimit = limit
-
-		return nil
-	}
-}
-
 // WithMaxLogSize sets the maximum size of container logs
 // Positive sizes are limits in bytes, -1 is unlimited
 func WithMaxLogSize(limit int64) RuntimeOption {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -46,8 +46,6 @@ type RuntimeConfig struct {
 	CgroupManager         string
 	StaticDir             string
 	TmpDir                string
-	SelinuxEnabled        bool
-	PidsLimit             int64
 	MaxLogSize            int64
 	NoPivotRoot           bool
 	CNIConfigDir          string
@@ -65,15 +63,13 @@ var (
 		ConmonEnvVars: []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		},
-		CgroupManager:  "cgroupfs",
-		StaticDir:      filepath.Join(storage.DefaultStoreOptions.GraphRoot, "libpod"),
-		TmpDir:         "/var/run/libpod",
-		SelinuxEnabled: false,
-		PidsLimit:      1024,
-		MaxLogSize:     -1,
-		NoPivotRoot:    false,
-		CNIConfigDir:   "/etc/cni/net.d/",
-		CNIPluginDir:   []string{"/usr/libexec/cni", "/opt/cni/bin"},
+		CgroupManager: "cgroupfs",
+		StaticDir:     filepath.Join(storage.DefaultStoreOptions.GraphRoot, "libpod"),
+		TmpDir:        "/var/run/libpod",
+		MaxLogSize:    -1,
+		NoPivotRoot:   false,
+		CNIConfigDir:  "/etc/cni/net.d/",
+		CNIPluginDir:  []string{"/usr/libexec/cni", "/opt/cni/bin"},
 	}
 )
 
@@ -323,6 +319,7 @@ func (r *Runtime) refresh(alivePath string) error {
 		}
 	}
 
+	// Create a file indicating the runtime is alive and ready
 	file, err := os.OpenFile(alivePath, os.O_RDONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "error creating runtime status file %s", alivePath)


### PR DESCRIPTION
SELinux is enabled on a per-container basis by giving it SELinux labels to use. PID limiting is handled in the spec, and we do not enforce a global one - whoever is handing us specs is responsible for that.

As such both of these are unnecessary in the runtime. Remove them.