### PR TITLE
Add shared namespace support

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -29,7 +29,6 @@ ${LINTER} \
 	--enable=gofmt\
 	--enable=golint\
 	--enable=ineffassign\
-	--enable=interfacer\
 	--enable=megacheck\
 	--enable=misspell\
 	--enable=structcheck\

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -545,15 +545,15 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 		options = append(options, libpod.WithName(c.Name))
 	}
 	// TODO parse ports into libpod format and include
-	if !c.NetMode.IsHost() && !c.NetMode.IsContainer() {
-		options = append(options, libpod.WithNetNS([]ocicni.PortMapping{}))
-	} else if c.NetMode.IsContainer() {
+	if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())
 		if err != nil {
 			return nil, errors.Wrapf(err, "container %q not found", c.NetMode.ConnectedContainer())
 		}
 
 		options = append(options, libpod.WithNetNSFrom(connectedCtr))
+	} else if !c.NetMode.IsHost() {
+		options = append(options, libpod.WithNetNS([]ocicni.PortMapping{}))
 	}
 	if c.PidMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.PidMode.Container())

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -53,21 +52,10 @@ func blockAccessToKernelFilesystems(config *createConfig, g *generate.Generator)
 func addPidNS(config *createConfig, g *generate.Generator) error {
 	pidMode := config.PidMode
 	if pidMode.IsHost() {
-		return g.RemoveLinuxNamespace(libpod.PIDNamespace)
+		return g.RemoveLinuxNamespace(string(spec.PIDNamespace))
 	}
 	if pidMode.IsContainer() {
-		ctr, err := config.Runtime.LookupContainer(pidMode.Container())
-		if err != nil {
-			return errors.Wrapf(err, "container %q not found", pidMode.Container())
-		}
-		pid, err := ctr.PID()
-		if err != nil {
-			return errors.Wrapf(err, "Failed to get pid of container %q", pidMode.Container())
-		}
-		pidNsPath := fmt.Sprintf("/proc/%d/ns/pid", pid)
-		if err := g.AddOrReplaceLinuxNamespace(libpod.PIDNamespace, pidNsPath); err != nil {
-			return err
-		}
+		logrus.Debug("using container pidmode")
 	}
 	return nil
 }
@@ -76,7 +64,7 @@ func addNetNS(config *createConfig, g *generate.Generator) error {
 	netMode := config.NetMode
 	if netMode.IsHost() {
 		logrus.Debug("Using host netmode")
-		return g.RemoveLinuxNamespace(libpod.NetNamespace)
+		return g.RemoveLinuxNamespace(spec.NetworkNamespace)
 	} else if netMode.IsNone() {
 		logrus.Debug("Using none netmode")
 		return nil
@@ -85,18 +73,6 @@ func addNetNS(config *createConfig, g *generate.Generator) error {
 		return nil
 	} else if netMode.IsContainer() {
 		logrus.Debug("Using container netmode")
-		ctr, err := config.Runtime.LookupContainer(netMode.ConnectedContainer())
-		if err != nil {
-			return errors.Wrapf(err, "container %q not found", netMode.ConnectedContainer())
-		}
-		pid, err := ctr.PID()
-		if err != nil {
-			return errors.Wrapf(err, "Failed to get pid of container %q", netMode.ConnectedContainer())
-		}
-		nsPath := fmt.Sprintf("/proc/%d/ns/net", pid)
-		if err := g.AddOrReplaceLinuxNamespace(libpod.NetNamespace, nsPath); err != nil {
-			return err
-		}
 	} else {
 		return errors.Errorf("unknown network mode")
 	}
@@ -106,7 +82,7 @@ func addNetNS(config *createConfig, g *generate.Generator) error {
 func addUTSNS(config *createConfig, g *generate.Generator) error {
 	utsMode := config.UtsMode
 	if utsMode.IsHost() {
-		return g.RemoveLinuxNamespace(libpod.UTSNamespace)
+		return g.RemoveLinuxNamespace(spec.UTSNamespace)
 	}
 	return nil
 }
@@ -114,21 +90,10 @@ func addUTSNS(config *createConfig, g *generate.Generator) error {
 func addIpcNS(config *createConfig, g *generate.Generator) error {
 	ipcMode := config.IpcMode
 	if ipcMode.IsHost() {
-		return g.RemoveLinuxNamespace(libpod.IPCNamespace)
+		return g.RemoveLinuxNamespace(spec.IPCNamespace)
 	}
 	if ipcMode.IsContainer() {
-		ctr, err := config.Runtime.LookupContainer(ipcMode.Container())
-		if err != nil {
-			return errors.Wrapf(err, "container %q not found", ipcMode.Container())
-		}
-		pid, err := ctr.PID()
-		if err != nil {
-			return errors.Wrapf(err, "Failed to get pid of container %q", ipcMode.Container())
-		}
-		nsPath := fmt.Sprintf("/proc/%d/ns/ipc", pid)
-		if err := g.AddOrReplaceLinuxNamespace(libpod.IPCNamespace, nsPath); err != nil {
-			return err
-		}
+		logrus.Debug("Using container ipcmode")
 	}
 
 	return nil
@@ -580,9 +545,33 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 		options = append(options, libpod.WithName(c.Name))
 	}
 	// TODO parse ports into libpod format and include
-	if !c.NetMode.IsHost() {
+	if !c.NetMode.IsHost() && !c.NetMode.IsContainer() {
 		options = append(options, libpod.WithNetNS([]ocicni.PortMapping{}))
+	} else if c.NetMode.IsContainer() {
+		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())
+		if err != nil {
+			return nil, errors.Wrapf(err, "container %q not found", c.NetMode.ConnectedContainer())
+		}
+
+		options = append(options, libpod.WithNetNSFrom(connectedCtr))
 	}
+	if c.PidMode.IsContainer() {
+		connectedCtr, err := c.Runtime.LookupContainer(c.PidMode.Container())
+		if err != nil {
+			return nil, errors.Wrapf(err, "container %q not found", c.PidMode.Container())
+		}
+
+		options = append(options, libpod.WithPIDNSFrom(connectedCtr))
+	}
+	if c.IpcMode.IsContainer() {
+		connectedCtr, err := c.Runtime.LookupContainer(c.IpcMode.Container())
+		if err != nil {
+			return nil, errors.Wrapf(err, "container %q not found", c.IpcMode.Container())
+		}
+
+		options = append(options, libpod.WithIPCNSFrom(connectedCtr))
+	}
+
 	options = append(options, libpod.WithStopSignal(c.StopSignal))
 	options = append(options, libpod.WithStopTimeout(c.StopTimeout))
 	return options, nil

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -71,7 +71,7 @@ const (
 	InvalidNS LinuxNS = iota
 	// IPCNS is the IPC namespace
 	IPCNS LinuxNS = iota
-	// MntNS is the mount namespace
+	// MountNS is the mount namespace
 	MountNS LinuxNS = iota
 	// NetNS is the network namespace
 	NetNS LinuxNS = iota

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -133,7 +133,6 @@ type Container struct {
 // TODO enable pod support
 // TODO Add readonly support
 // TODO add SHM size support
-// TODO add shared namespace support
 
 // containerRuntimeInfo contains the current state of the container
 // It is stored on disk in a tmpfs and recreated on reboot

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -81,6 +81,8 @@ const (
 	UserNS LinuxNS = iota
 	// UTSNS is the UTS namespace
 	UTSNS LinuxNS = iota
+	// CgroupNS is the CGroup namespace
+	CgroupNS LinuxNS = iota
 )
 
 // String returns a string representation of a Linux namespace
@@ -101,6 +103,8 @@ func (ns LinuxNS) String() string {
 		return "user"
 	case UTSNS:
 		return "uts"
+	case CgroupNS:
+		return "cgroup"
 	default:
 		return "unknown"
 	}
@@ -917,6 +921,21 @@ func (c *Container) Init() (err error) {
 		}
 
 		if err := g.AddOrReplaceLinuxNamespace(spec.UTSNamespace, nsPath); err != nil {
+			return err
+		}
+	}
+	if c.config.CgroupNsCtr != "" {
+		cgroupCtr, err := c.runtime.state.Container(c.config.CgroupNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := cgroupCtr.NamespacePath(CgroupNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(spec.CgroupNamespace, nsPath); err != nil {
 			return err
 		}
 	}

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -63,6 +63,49 @@ const (
 // CgroupParent is the default prefix to a cgroup path in libpod
 var CgroupParent = "/libpod_parent"
 
+// LinuxNS represents a Linux namespace
+type LinuxNS int
+
+const (
+	// InvalidNS is an invalid namespace
+	InvalidNS LinuxNS = iota
+	// IPCNS is the IPC namespace
+	IPCNS LinuxNS = iota
+	// MntNS is the mount namespace
+	MountNS LinuxNS = iota
+	// NetNS is the network namespace
+	NetNS LinuxNS = iota
+	// PIDNS is the PID namespace
+	PIDNS LinuxNS = iota
+	// UserNS is the user namespace
+	UserNS LinuxNS = iota
+	// UTSNS is the UTS namespace
+	UTSNS LinuxNS = iota
+)
+
+// String returns a string representation of a Linux namespace
+// It is guaranteed to be the name of the namespace in /proc for valid ns types
+func (ns LinuxNS) String() string {
+	switch ns {
+	case InvalidNS:
+		return "invalid"
+	case IPCNS:
+		return "ipc"
+	case MountNS:
+		return "mnt"
+	case NetNS:
+		return "net"
+	case PIDNS:
+		return "pid"
+	case UserNS:
+		return "user"
+	case UTSNS:
+		return "uts"
+	default:
+		return "unknown"
+	}
+}
+
 // Container is a single OCI container
 type Container struct {
 	config *ContainerConfig
@@ -484,6 +527,26 @@ func (c *Container) MountPoint() (string, error) {
 	return c.state.Mountpoint, nil
 }
 
+// NamespacePath returns the path of one of the container's namespaces
+// If the container is not running, an error will be returned
+func (c *Container) NamespacePath(ns LinuxNS) (string, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if err := c.syncContainer(); err != nil {
+		return "", errors.Wrapf(err, "error updating container %s state", c.ID())
+	}
+
+	if c.state.State != ContainerStateRunning {
+		return "", errors.Wrapf(ErrCtrStopped, "cannot get namespace path unless container %s is running", c.ID())
+	}
+
+	if ns == InvalidNS {
+		return "", errors.Wrapf(ErrInvalidArg, "invalid namespace requested from container %s", c.ID())
+	}
+
+	return fmt.Sprintf("/proc/%d/ns/%s", c.state.PID, ns.String()), nil
+}
+
 // The path to the container's root filesystem - where the OCI spec will be
 // placed, amongst other things
 func (c *Container) bundlePath() string {
@@ -764,6 +827,98 @@ func (c *Container) Init() (err error) {
 		// User and Group must go together
 		g.SetProcessUID(uid)
 		g.SetProcessGID(gid)
+	}
+
+	// Add shared namespaces from other containers
+	if c.config.IPCNsCtr != "" {
+		ipcCtr, err := c.runtime.state.Container(c.config.IPCNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := ipcCtr.NamespacePath(IPCNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(spec.IPCNamespace, nsPath); err != nil {
+			return err
+		}
+	}
+	if c.config.MountNsCtr != "" {
+		mountCtr, err := c.runtime.state.Container(c.config.MountNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := mountCtr.NamespacePath(MountNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(spec.MountNamespace, nsPath); err != nil {
+			return err
+		}
+	}
+	if c.config.NetNsCtr != "" {
+		netCtr, err := c.runtime.state.Container(c.config.NetNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := netCtr.NamespacePath(NetNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(spec.NetworkNamespace, nsPath); err != nil {
+			return err
+		}
+	}
+	if c.config.PIDNsCtr != "" {
+		pidCtr, err := c.runtime.state.Container(c.config.PIDNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := pidCtr.NamespacePath(PIDNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(string(spec.PIDNamespace), nsPath); err != nil {
+			return err
+		}
+	}
+	if c.config.UserNsCtr != "" {
+		userCtr, err := c.runtime.state.Container(c.config.UserNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := userCtr.NamespacePath(UserNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(spec.UserNamespace, nsPath); err != nil {
+			return err
+		}
+	}
+	if c.config.UTSNsCtr != "" {
+		utsCtr, err := c.runtime.state.Container(c.config.UTSNsCtr)
+		if err != nil {
+			return err
+		}
+
+		nsPath, err := utsCtr.NamespacePath(UTSNS)
+		if err != nil {
+			return err
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(spec.UTSNamespace, nsPath); err != nil {
+			return err
+		}
 	}
 
 	c.runningSpec = g.Spec()

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -28,6 +28,13 @@ type State interface {
 	UpdateContainer(ctr *Container) error
 	// SaveContainer saves a container's current state to the backing store
 	SaveContainer(ctr *Container) error
+	// ContainerInUse checks if other containers depend upon a given
+	// container
+	// It returns a slice of the IDs of containers which depend on the given
+	// container. If the slice is empty, no container depend on the given
+	// container.
+	// A container cannot be removed if other containers depend on it
+	ContainerInUse(ctr *Container) ([]string, error)
 	// Retrieves all containers presently in state
 	AllContainers() ([]*Container, error)
 


### PR DESCRIPTION
Add support for shared namespaces in Libpod. A container may depend upon the namespaces of another container, sharing them. This is the foundation for pods.

Remove existing podman support for shared namespaces in favor of libpod support.

Still needs BATS tests for podman changes.