### PR TITLE
Add DNS and security fields to DB

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -156,23 +156,28 @@ type ContainerConfig struct {
 	Mounts []string `json:"mounts,omitempty"`
 
 	// Security Config
+	// Whether the container is privileged
+	Privileged bool `json:"privileged"`
+	// Whether to set the No New Privileges flag
+	NoNewPrivs bool `json:"noNewPrivs"`
 	// SELinux process label for container
 	ProcessLabel string `json:"ProcessLabel,omitempty"`
 	// SELinux mount label for root filesystem
 	MountLabel string `json:"MountLabel,omitempty"`
 	// User and group to use in the container
 	// Can be specified by name or UID/GID
-	User string `json:"user"`
+	User string `json:"user,omitempty"`
 
 	// Namespace Config
 	// IDs of container to share namespaces with
 	// NetNsCtr conflicts with the CreateNetNS bool
-	IPCNsCtr   string `json:"ipcNsCtr"`
-	MountNsCtr string `json:"mountNsCtr"`
-	NetNsCtr   string `json:"netNsCtr"`
-	PIDNsCtr   string `json:"pidNsCtr"`
-	UserNsCtr  string `json:"userNsCtr"`
-	UTSNsCtr   string `json:"utsNsCtr"`
+	IPCNsCtr    string `json:"ipcNsCtr,omitempty"`
+	MountNsCtr  string `json:"mountNsCtr,omitempty"`
+	NetNsCtr    string `json:"netNsCtr,omitempty"`
+	PIDNsCtr    string `json:"pidNsCtr,omitempty"`
+	UserNsCtr   string `json:"userNsCtr,omitempty"`
+	UTSNsCtr    string `json:"utsNsCtr,omitempty"`
+	CgroupNsCtr string `json:"cgroupNsCtr,omitempty"`
 
 	// Network Config
 	// CreateNetNS indicates that libpod should create and configure a new
@@ -183,6 +188,18 @@ type ContainerConfig struct {
 	// namespace
 	// These are not used unless CreateNetNS is true
 	PortMappings []ocicni.PortMapping `json:"portMappings,omitempty"`
+	// DNS servers to use in container resolv.conf
+	// Will override servers in host resolv if set
+	DNSServer []net.IP `json:"dnsServer,omitempty"`
+	// DNS Search domains to use in container resolv.conf
+	// Will override search domains in host resolv if set
+	DNSSearch []string `json:"dnsSearch,omitempty"`
+	// DNS options to be set in container resolv.conf
+	// With override options in host resolv if set
+	DNSOption []string `json:"dnsOption,omitempty"`
+	// Hosts to add in container
+	// Will be appended to host's host file
+	HostAdd []string `json:"hostsAdd,omitempty"`
 
 	// Misc Options
 	// Whether to keep container STDIN open

--- a/libpod/sql_state_test.go
+++ b/libpod/sql_state_test.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containers/storage"
+	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,6 +31,24 @@ func getTestContainer(id, name, locksDir string) (*Container, error) {
 			StopSignal:      0,
 			StopTimeout:     0,
 			CreatedTime:     time.Now(),
+			Privileged:      true,
+			Mounts:          []string{"/does/not/exist"},
+			DNSServer:       []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("192.168.2.2")},
+			DNSSearch:       []string{"example.com", "example.example.com"},
+			PortMappings: []ocicni.PortMapping{
+				{
+					HostPort:      80,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					HostIP:        "192.168.3.3",
+				},
+				{
+					HostPort:      100,
+					ContainerPort: 110,
+					Protocol:      "udp",
+					HostIP:        "192.168.4.4",
+				},
+			},
 		},
 		state: &containerRuntimeInfo{
 			State:      ContainerStateRunning,


### PR DESCRIPTION
Also moves port mappings out of the SQL DB and into a file on disk. These could get very sizable (hundred to thousands of ports) so moving them out to a file will keep the DB small and fast.

Finally, add a foreign key reference from container ID to container state ID. This ensures we never get into an inconsistent state where we have data in one table but not the other.