### PR TITLE
Ensure batched containers have locks

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1366,6 +1366,7 @@ func (c *Container) Batch(batchFunc func(*Container) error) error {
 	newCtr.config = c.config
 	newCtr.state = c.state
 	newCtr.runtime = c.runtime
+	newCtr.lock = c.lock
 	newCtr.valid = true
 
 	newCtr.locked = true


### PR DESCRIPTION
This won't matter during batched operatins, but if the container leaks outside of the Batch() function it will segfault if asked to do any operation that locks unless this is applied
