### PR TITLE
Make --net alias to --network

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -316,7 +316,8 @@ var createFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "net",
-		Usage: "Setup the network namespace",
+		Usage: "Connect a container to a network (alias for --network)",
+		Value: "bridge",
 	},
 	cli.StringFlag{
 		Name:  "network",

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -536,6 +536,17 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to translate --shm-size")
 	}
+	// Network
+	// Both --network and --net have default values of 'bridge'
+	// --net only overrides --network when --network is not explicitly
+	// set and --net is.
+	if c.IsSet("network") && c.IsSet("net") {
+		return nil, errors.Errorf("cannot use --network and --net together.  use only --network instead")
+	}
+	networkMode := c.String("network")
+	if !c.IsSet("network") && c.IsSet("net") {
+		networkMode = c.String("net")
+	}
 
 	config := &createConfig{
 		Runtime:        runtime,
@@ -564,10 +575,10 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 		LogDriverOpt:   c.StringSlice("log-opt"),
 		MacAddress:     c.String("mac-address"),
 		Name:           c.String("name"),
-		Network:        c.String("network"),
+		Network:        networkMode,
 		NetworkAlias:   c.StringSlice("network-alias"),
 		IpcMode:        ipcMode,
-		NetMode:        container.NetworkMode(c.String("network")),
+		NetMode:        container.NetworkMode(networkMode),
 		UtsMode:        utsMode,
 		PidMode:        pidMode,
 		Pod:            c.String("pod"),


### PR DESCRIPTION
A compatibility option of --net should alias the --network
option.  The --net option will only override --network if
--network is not explicitly set and --net is.  Both default
to 'bridge'.

Signed-off-by: baude <bbaude@redhat.com>