### PR TITLE
Continue Pod work and expand unit tests

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -114,7 +114,6 @@ func (ns LinuxNS) String() string {
 type Container struct {
 	config *ContainerConfig
 
-	pod         *Pod
 	runningSpec *spec.Spec
 
 	state *containerRuntimeInfo

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -341,7 +341,7 @@ func (c *Container) Dependencies() []string {
 	}
 
 	depends := make([]string, 0, len(dependsCtrs))
-	for ctr, _ := range dependsCtrs {
+	for ctr := range dependsCtrs {
 		depends = append(depends, ctr)
 	}
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -310,6 +310,40 @@ func (c *Container) ProcessLabel() string {
 	return c.config.ProcessLabel
 }
 
+// Dependencies gets the containers this container depends upon
+func (c *Container) Dependencies() []string {
+	// Collect in a map first to remove dupes
+	dependsCtrs := map[string]bool{}
+	if c.config.IPCNsCtr != "" {
+		dependsCtrs[c.config.IPCNsCtr] = true
+	}
+	if c.config.MountNsCtr != "" {
+		dependsCtrs[c.config.MountNsCtr] = true
+	}
+	if c.config.NetNsCtr != "" {
+		dependsCtrs[c.config.NetNsCtr] = true
+	}
+	if c.config.PIDNsCtr != "" {
+		dependsCtrs[c.config.NetNsCtr] = true
+	}
+	if c.config.UserNsCtr != "" {
+		dependsCtrs[c.config.UserNsCtr] = true
+	}
+	if c.config.UTSNsCtr != "" {
+		dependsCtrs[c.config.UTSNsCtr] = true
+	}
+	if c.config.CgroupNsCtr != "" {
+		dependsCtrs[c.config.CgroupNsCtr] = true
+	}
+
+	depends := make([]string, len(dependsCtrs), 0)
+	for ctr, _ := range dependsCtrs {
+		depends = append(depends, ctr)
+	}
+
+	return depends
+}
+
 // Spec returns the container's OCI runtime spec
 // The spec returned is the one used to create the container. The running
 // spec may differ slightly as mounts are added based on the image

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -336,7 +336,11 @@ func (c *Container) Dependencies() []string {
 		dependsCtrs[c.config.CgroupNsCtr] = true
 	}
 
-	depends := make([]string, len(dependsCtrs), 0)
+	if len(dependsCtrs) == 0 {
+		return []string{}
+	}
+
+	depends := make([]string, 0, len(dependsCtrs))
 	for ctr, _ := range dependsCtrs {
 		depends = append(depends, ctr)
 	}

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -188,8 +188,7 @@ func (s *InMemoryState) UpdateContainer(ctr *Container) error {
 	}
 
 	// If the container does not exist, return error
-	_, ok := s.containers[ctr.ID()]
-	if !ok {
+	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
 		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
@@ -208,8 +207,7 @@ func (s *InMemoryState) SaveContainer(ctr *Container) error {
 	}
 
 	// If the container does not exist, return error
-	_, ok := s.containers[ctr.ID()]
-	if !ok {
+	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
 		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
@@ -371,7 +369,8 @@ func (s *InMemoryState) UpdatePod(pod *Pod) error {
 func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	if !pod.valid {
 		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and cannot be added to", pod.ID())
-	} else if !ctr.valid {
+	}
+	if !ctr.valid {
 		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid and cannot be added to the pod", ctr.ID())
 	}
 
@@ -391,12 +390,12 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	}
 
 	if err := s.ctrNameIndex.Reserve(ctr.Name(), ctr.ID()); err != nil {
-		return errors.Wrapf(err, "error registering container name %s", ctr.Name())
+		return errors.Wrapf(err, "error reserving container name %s", ctr.Name())
 	}
 
 	if err := s.ctrIDIndex.Add(ctr.ID()); err != nil {
 		s.ctrNameIndex.Release(ctr.Name())
-		return errors.Wrapf(err, "error registering container ID %s", ctr.ID())
+		return errors.Wrapf(err, "error releasing container ID %s", ctr.ID())
 	}
 
 	s.containers[ctr.ID()] = ctr
@@ -409,7 +408,8 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	if !pod.valid {
 		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and containers cannot be removed", pod.ID())
-	} else if !ctr.valid {
+	}
+	if !ctr.valid {
 		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid and cannot be removed from the pod", ctr.ID())
 	}
 
@@ -417,7 +417,8 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	exists, err := pod.HasContainer(ctr.ID())
 	if err != nil {
 		return errors.Wrapf(err, "error checking for container %s in pod %s", ctr.ID(), pod.ID())
-	} else if !exists {
+	}
+	if !exists {
 		return errors.Wrapf(ErrNoSuchCtr, "no container %s in pod %s", ctr.ID(), pod.ID())
 	}
 

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -104,8 +104,7 @@ func (s *InMemoryState) HasContainer(id string) (bool, error) {
 }
 
 // AddContainer adds a container to the state
-// If the container belongs to a pod, the pod must already be present when the
-// container is added, and the container must be present in the pod
+// Containers in a pod cannot be added to the state
 func (s *InMemoryState) AddContainer(ctr *Container) error {
 	if !ctr.valid {
 		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
@@ -116,17 +115,8 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
 	}
 
-	if ctr.pod != nil {
-		if _, ok := s.pods[ctr.pod.ID()]; !ok {
-			return errors.Wrapf(ErrNoSuchPod, "pod %s does not exist, cannot add container %s", ctr.pod.ID(), ctr.ID())
-		}
-
-		hasCtr, err := ctr.pod.HasContainer(ctr.ID())
-		if err != nil {
-			return errors.Wrapf(err, "error checking if container %s is present in pod %s", ctr.ID(), ctr.pod.ID())
-		} else if !hasCtr {
-			return errors.Wrapf(ErrNoSuchCtr, "container %s is not present in pod %s", ctr.ID(), ctr.pod.ID())
-		}
+	if ctr.config.Pod != "" {
+		return errors.Wrapf(ErrInvalidArg, "cannot add a container that is in a pod with AddContainer, use AddContainerToPod")
 	}
 
 	if err := s.ctrNameIndex.Reserve(ctr.Name(), ctr.ID()); err != nil {
@@ -342,6 +332,86 @@ func (s *InMemoryState) RemovePod(pod *Pod) error {
 	}
 	delete(s.pods, pod.ID())
 	s.podNameIndex.Release(pod.Name())
+
+	return nil
+}
+
+// UpdatePod updates a pod's state from the backing database
+// As in-memory states have no database this is a no-op
+func (s *InMemoryState) UpdatePod(pod *Pod) error {
+	return nil
+}
+
+// AddContainerToPod adds a container to the given pod, also adding it to the
+// state
+func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
+	if !pod.valid {
+		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and cannot be added to", pod.ID())
+	} else if !ctr.valid {
+		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid and cannot be added to the pod", ctr.ID())
+	}
+
+	if ctr.config.Pod != pod.ID() {
+		return errors.Wrapf(ErrInvalidArg, "container %s is not in pod %s", ctr.ID(), pod.ID())
+	}
+
+	// Add container to pod
+	if err := pod.addContainer(ctr); err != nil {
+		return err
+	}
+
+	// Add container to state
+	_, ok := s.containers[ctr.ID()]
+	if ok {
+		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
+	}
+
+	if err := s.ctrNameIndex.Reserve(ctr.Name(), ctr.ID()); err != nil {
+		return errors.Wrapf(err, "error registering container name %s", ctr.Name())
+	}
+
+	if err := s.ctrIDIndex.Add(ctr.ID()); err != nil {
+		s.ctrNameIndex.Release(ctr.Name())
+		return errors.Wrapf(err, "error registering container ID %s", ctr.ID())
+	}
+
+	s.containers[ctr.ID()] = ctr
+
+	return nil
+}
+
+// RemoveContainerFromPod removes the given container from the given pod
+// The container is also removed from the state
+func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
+	if !pod.valid {
+		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and containers cannot be removed", pod.ID())
+	} else if !ctr.valid {
+		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid and cannot be removed from the pod", ctr.ID())
+	}
+
+	// Is the container in the pod?
+	exists, err := pod.HasContainer(ctr.ID())
+	if err != nil {
+		return errors.Wrapf(err, "error checking for container %s in pod %s", ctr.ID(), pod.ID())
+	} else if !exists {
+		return errors.Wrapf(ErrNoSuchCtr, "no container %s in pod %s", ctr.ID(), pod.ID())
+	}
+
+	// Remove container from pod
+	if err := pod.removeContainer(ctr); err != nil {
+		return err
+	}
+
+	// Remove container from state
+	if _, ok := s.containers[ctr.ID()]; !ok {
+		return errors.Wrapf(ErrNoSuchCtr, "no container exists in state with ID %s", ctr.ID())
+	}
+
+	if err := s.ctrIDIndex.Delete(ctr.ID()); err != nil {
+		return errors.Wrapf(err, "error removing container ID from index")
+	}
+	delete(s.containers, ctr.ID())
+	s.ctrNameIndex.Release(ctr.Name())
 
 	return nil
 }

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -284,6 +284,20 @@ func (s *InMemoryState) HasPod(id string) (bool, error) {
 	return ok, nil
 }
 
+// PodContainers retrieves the containers from a pod given the pod's full ID
+func (s *InMemoryState) PodContainers(id string) ([]*Container, error) {
+	if id == "" {
+		return nil, ErrEmptyID
+	}
+
+	pod, ok := s.pods[id]
+	if !ok {
+		return nil, errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found", id)
+	}
+
+	return pod.GetContainers()
+}
+
 // AddPod adds a given pod to the state
 // Only empty pods can be added to the state
 func (s *InMemoryState) AddPod(pod *Pod) error {

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -182,6 +182,18 @@ func (s *InMemoryState) RemoveContainer(ctr *Container) error {
 // As all state is in-memory, no update will be required
 // As such this is a no-op
 func (s *InMemoryState) UpdateContainer(ctr *Container) error {
+	// If the container is invalid, return error
+	if !ctr.valid {
+		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
+	}
+
+	// If the container does not exist, return error
+	_, ok := s.containers[ctr.ID()]
+	if !ok {
+		ctr.valid = false
+		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
+	}
+
 	return nil
 }
 
@@ -190,6 +202,18 @@ func (s *InMemoryState) UpdateContainer(ctr *Container) error {
 // are made
 // As such this is a no-op
 func (s *InMemoryState) SaveContainer(ctr *Container) error {
+	// If the container is invalid, return error
+	if !ctr.valid {
+		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
+	}
+
+	// If the container does not exist, return error
+	_, ok := s.containers[ctr.ID()]
+	if !ok {
+		ctr.valid = false
+		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
+	}
+
 	return nil
 }
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -81,15 +81,21 @@ func WithSignaturePolicy(path string) RuntimeOption {
 	}
 }
 
-// WithInMemoryState specifies that the runtime will be backed by an in-memory
-// state only, and state will not persist after the runtime is shut down
-func WithInMemoryState() RuntimeOption {
+// WithStateType sets the backing state implementation for libpod
+// Please note that information is not portable between backing states
+// As such, if this differs between two libpods running on the same system,
+// they will not share containers, and unspecified behavior may occur
+func WithStateType(storeType RuntimeStateStore) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
 			return ErrRuntimeFinalized
 		}
 
-		rt.config.InMemoryState = true
+		if storeType == InvalidStateStore {
+			return errors.Wrapf(ErrInvalidArg, "must provide a valid state store type")
+		}
+
+		rt.config.StateType = storeType
 
 		return nil
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -334,7 +334,6 @@ func (r *Runtime) WithPod(pod *Pod) CtrCreateOption {
 		}
 
 		ctr.config.Pod = pod.ID()
-		ctr.pod = pod
 
 		return nil
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -191,13 +191,14 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 	runtime.netPlugin = netPlugin
 
 	// Set up the state
-	if runtime.config.StateType == InMemoryStateStore {
+	switch runtime.config.StateType {
+	case InMemoryStateStore:
 		state, err := NewInMemoryState()
 		if err != nil {
 			return nil, err
 		}
 		runtime.state = state
-	} else if runtime.config.StateType == SQLiteStateStore {
+	case SQLiteStateStore:
 		dbPath := filepath.Join(runtime.config.StaticDir, "sql_state.db")
 		specsDir := filepath.Join(runtime.config.StaticDir, "ocispec")
 
@@ -215,7 +216,7 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 			return nil, err
 		}
 		runtime.state = state
-	} else {
+	default:
 		return nil, errors.Wrapf(ErrInvalidArg, "unrecognized state type passed")
 	}
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -14,6 +14,21 @@ import (
 	"github.com/ulule/deepcopier"
 )
 
+// RuntimeStateStore is a constant indicating which state store implementation
+// should be used by libpod
+type RuntimeStateStore int
+
+const (
+	// InvalidStateStore is an invalid state store
+	InvalidStateStore RuntimeStateStore = iota
+	// InMemoryStateStore is an in-memory state that will not persist data
+	// on containers and pods between libpod instances or after system
+	// reboot
+	InMemoryStateStore RuntimeStateStore = iota
+	// SQLiteStateStore is a state backed by a SQLite database
+	SQLiteStateStore RuntimeStateStore = iota
+)
+
 // A RuntimeOption is a functional option which alters the Runtime created by
 // NewRuntime
 type RuntimeOption func(*Runtime) error
@@ -39,7 +54,7 @@ type RuntimeConfig struct {
 	InsecureRegistries    []string
 	Registries            []string
 	SignaturePolicyPath   string
-	InMemoryState         bool
+	StateType             RuntimeStateStore
 	RuntimePath           string
 	ConmonPath            string
 	ConmonEnvVars         []string
@@ -57,7 +72,7 @@ var (
 		// Leave this empty so containers/storage will use its defaults
 		StorageConfig:         storage.StoreOptions{},
 		ImageDefaultTransport: DefaultTransport,
-		InMemoryState:         false,
+		StateType:             SQLiteStateStore,
 		RuntimePath:           "/usr/bin/runc",
 		ConmonPath:            findConmonPath(),
 		ConmonEnvVars: []string{
@@ -176,14 +191,14 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 	runtime.netPlugin = netPlugin
 
 	// Set up the state
-	if runtime.config.InMemoryState {
+	if runtime.config.StateType == InMemoryStateStore {
 		state, err := NewInMemoryState()
 		if err != nil {
 			return nil, err
 		}
 		runtime.state = state
-	} else {
-		dbPath := filepath.Join(runtime.config.StaticDir, "state.sql")
+	} else if runtime.config.StateType == SQLiteStateStore {
+		dbPath := filepath.Join(runtime.config.StaticDir, "sql_state.db")
 		specsDir := filepath.Join(runtime.config.StaticDir, "ocispec")
 
 		// Make a directory to hold JSON versions of container OCI specs
@@ -200,6 +215,8 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 			return nil, err
 		}
 		runtime.state = state
+	} else {
+		return nil, errors.Wrapf(ErrInvalidArg, "unrecognized state type passed")
 	}
 
 	// We now need to see if the system has restarted

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -82,11 +82,11 @@ func (r *Runtime) NewContainer(rSpec *spec.Spec, options ...CtrCreateOption) (c 
 		}
 
 		if err := r.state.AddContainerToPod(pod, ctr); err != nil {
-			return nil, errors.Wrapf(err, "error adding new container to state")
+			return nil, err
 		}
 	} else {
 		if err := r.state.AddContainer(ctr); err != nil {
-			return nil, errors.Wrapf(err, "error adding new container to state")
+			return nil, err
 		}
 	}
 
@@ -166,17 +166,17 @@ func (r *Runtime) removeContainer(c *Container, force bool) error {
 		}
 
 		if err := r.state.RemoveContainerFromPod(pod, c); err != nil {
-			return errors.Wrapf(err, "error removing container %s from state", c.ID())
+			return err
 		}
 	} else {
 		if err := r.state.RemoveContainer(c); err != nil {
-			return errors.Wrapf(err, "error removing container from state")
+			return err
 		}
 	}
 
 	// Delete the container
 	// Only do this if we're not ContainerStateConfigured - if we are,
-	// we haven't been created in runc yet
+	// we haven't been created in the runtime yet
 	if c.state.State == ContainerStateConfigured {
 		if err := r.ociRuntime.deleteContainer(c); err != nil {
 			return errors.Wrapf(err, "error removing container %s from runc", c.ID())

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -651,6 +651,8 @@ func (s *SQLState) SaveContainer(ctr *Container) error {
 		return errors.Wrapf(err, "error retrieving number of rows modified by update of container %s", ctr.ID())
 	}
 	if rows == 0 {
+		// Container was probably removed elsewhere
+		ctr.valid = false
 		return ErrNoSuchCtr
 	}
 

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -836,6 +836,11 @@ func (s *SQLState) HasPod(id string) (bool, error) {
 	return false, ErrNotImplemented
 }
 
+// PodContainers returns all the containers in a pod given the pod's full ID
+func (s *SQLState) PodContainers(id string) ([]*Container, error) {
+	return nil, ErrNotImplemented
+}
+
 // AddPod adds a pod to the state
 // Only empty pods can be added to the state
 func (s *SQLState) AddPod(pod *Pod) error {

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -853,6 +853,21 @@ func (s *SQLState) RemovePod(pod *Pod) error {
 	return ErrNotImplemented
 }
 
+// UpdatePod updates a pod from the database
+func (s *SQLState) UpdatePod(pod *Pod) error {
+	return ErrNotImplemented
+}
+
+// AddContainerToPod adds a container to the given pod
+func (s *SQLState) AddContainerToPod(pod *Pod, ctr *Container) error {
+	return ErrNotImplemented
+}
+
+// RemoveContainerFromPods removes a container from the given pod
+func (s *SQLState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
+	return ErrNotImplemented
+}
+
 // AllPods retrieves all pods presently in the state
 func (s *SQLState) AllPods() ([]*Pod, error) {
 	return nil, ErrNotImplemented

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -865,7 +865,7 @@ func (s *SQLState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	return ErrNotImplemented
 }
 
-// RemoveContainerFromPods removes a container from the given pod
+// RemoveContainerFromPod removes a container from the given pod
 func (s *SQLState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	return ErrNotImplemented
 }

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -16,9 +16,7 @@ type State interface {
 	// Checks if a container with the given ID is present in the state
 	HasContainer(id string) (bool, error)
 	// Adds container to state
-	// If the container belongs to a pod, that pod must already be present
-	// in the state when the container is added, and the container must be
-	// present in the pod
+	// The container cannot be part of a pod
 	AddContainer(ctr *Container) error
 	// Removes container from state
 	// The container will only be removed from the state, not from the pod
@@ -53,6 +51,14 @@ type State interface {
 	// Containers within a pod will not be removed from the state, and will
 	// not be changed to remove them from the now-removed pod
 	RemovePod(pod *Pod) error
+	// UpdatePod updates a pod's state from the backing store
+	UpdatePod(pod *Pod) error
+	// AddContainerToPod adds a container to an existing pod
+	// The container given will be added to the state and the pod
+	AddContainerToPod(pod *Pod, ctr *Container) error
+	// RemoveContainerFromPod removes a container from an existing pod
+	// The container will also be removed from the state
+	RemoveContainerFromPod(pod *Pod, ctr *Container) error
 	// Retrieves all pods presently in state
 	AllPods() ([]*Pod, error)
 }

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -44,6 +44,8 @@ type State interface {
 	LookupPod(idOrName string) (*Pod, error)
 	// Checks if a pod with the given ID is present in the state
 	HasPod(id string) (bool, error)
+	// Get all the containers in a pod. Accepts full ID of pod.
+	PodContainers(id string) ([]*Container, error)
 	// Adds pod to state
 	// Only empty pods can be added to the state
 	AddPod(pod *Pod) error

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -513,21 +513,19 @@ func getAllContainersTwoContainers(t *testing.T, state State, lockPath string) {
 }
 
 func TestContainerInUseInvalidContainer(t *testing.T) {
-	state, path, _, err := getEmptyState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+	runForAllStates(t, "TestContainerInUseInvalidContainer", containerInUseInvalidContainer)
+}
 
-	_, err = state.ContainerInUse(&Container{})
+func containerInUseInvalidContainer(t *testing.T, state State, lockPath string) {
+	_, err := state.ContainerInUse(&Container{})
 	assert.Error(t, err)
 }
 
 func TestContainerInUseOneContainer(t *testing.T) {
-	state, path, lockPath, err := getEmptyState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+	runForAllStates(t, "TestContainerInUseOneContainer", containerInUseOneContainer)
+}
 
+func containerInUseOneContainer(t *testing.T, state State, lockPath string) {
 	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
 	assert.NoError(t, err)
 	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
@@ -548,11 +546,10 @@ func TestContainerInUseOneContainer(t *testing.T) {
 }
 
 func TestContainerInUseTwoContainers(t *testing.T) {
-	state, path, lockPath, err := getEmptyState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+	runForAllStates(t, "TestContainerInUseTwoContainers", containerInUseTwoContainers)
+}
 
+func containerInUseTwoContainers(t *testing.T, state State, lockPath string) {
 	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
 	assert.NoError(t, err)
 	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
@@ -578,11 +575,10 @@ func TestContainerInUseTwoContainers(t *testing.T) {
 }
 
 func TestCannotRemoveContainerWithDependency(t *testing.T) {
-	state, path, lockPath, err := getEmptyState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+	runForAllStates(t, "TestCannotRemoveContainerWithDependency", cannotRemoveContainerWithDependency)
+}
 
+func cannotRemoveContainerWithDependency(t *testing.T, state State, lockPath string) {
 	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
 	assert.NoError(t, err)
 	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
@@ -601,11 +597,10 @@ func TestCannotRemoveContainerWithDependency(t *testing.T) {
 }
 
 func TestCanRemoveContainerAfterDependencyRemoved(t *testing.T) {
-	state, path, lockPath, err := getEmptyState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+	runForAllStates(t, "TestCanRemoveContainerAfterDependencyRemoved", canRemoveContainerAfterDependencyRemoved)
+}
 
+func canRemoveContainerAfterDependencyRemoved(t *testing.T, state State, lockPath string) {
 	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
 	assert.NoError(t, err)
 	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -152,7 +152,7 @@ func TestAddInvalidContainerFails(t *testing.T) {
 }
 
 func addInvalidContainerFails(t *testing.T, state State, lockPath string) {
-	err := state.AddContainer(&Container{config:&ContainerConfig{ID: "1234"}})
+	err := state.AddContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 	assert.Error(t, err)
 }
 
@@ -398,7 +398,7 @@ func TestUpdateInvalidContainerReturnsError(t *testing.T) {
 }
 
 func updateInvalidContainerReturnsError(t *testing.T, state State, lockPath string) {
-	err := state.UpdateContainer(&Container{config:&ContainerConfig{ID: "1234"}})
+	err := state.UpdateContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 	assert.Error(t, err)
 }
 
@@ -407,7 +407,7 @@ func TestSaveInvalidContainerReturnsError(t *testing.T) {
 }
 
 func saveInvalidContainerReturnsError(t *testing.T, state State, lockPath string) {
-	err := state.SaveContainer(&Container{config:&ContainerConfig{ID: "1234"}})
+	err := state.SaveContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 	assert.Error(t, err)
 }
 

--- a/libpod/test_common.go
+++ b/libpod/test_common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 )
 
+// nolint
 func getTestContainer(id, name, locksDir string) (*Container, error) {
 	ctr := &Container{
 		config: &ContainerConfig{
@@ -75,6 +76,7 @@ func getTestContainer(id, name, locksDir string) (*Container, error) {
 
 // This horrible hack tests if containers are equal in a way that should handle
 // empty arrays being dropped to nil pointers in the spec JSON
+// nolint
 func testContainersEqual(a, b *Container) bool {
 	if a == nil && b == nil {
 		return true

--- a/libpod/test_common.go
+++ b/libpod/test_common.go
@@ -1,0 +1,114 @@
+package libpod
+
+import (
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/containers/storage"
+	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/opencontainers/runtime-tools/generate"
+)
+
+func getTestContainer(id, name, locksDir string) (*Container, error) {
+	ctr := &Container{
+		config: &ContainerConfig{
+			ID:              id,
+			Name:            name,
+			RootfsImageID:   id,
+			RootfsImageName: "testimg",
+			ImageVolumes:    true,
+			ReadOnly:        true,
+			StaticDir:       "/does/not/exist/",
+			Stdin:           true,
+			Labels:          make(map[string]string),
+			StopSignal:      0,
+			StopTimeout:     0,
+			CreatedTime:     time.Now(),
+			Privileged:      true,
+			Mounts:          []string{"/does/not/exist"},
+			DNSServer:       []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("192.168.2.2")},
+			DNSSearch:       []string{"example.com", "example.example.com"},
+			PortMappings: []ocicni.PortMapping{
+				{
+					HostPort:      80,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					HostIP:        "192.168.3.3",
+				},
+				{
+					HostPort:      100,
+					ContainerPort: 110,
+					Protocol:      "udp",
+					HostIP:        "192.168.4.4",
+				},
+			},
+		},
+		state: &containerRuntimeInfo{
+			State:      ContainerStateRunning,
+			ConfigPath: "/does/not/exist/specs/" + id,
+			RunDir:     "/does/not/exist/tmp/",
+			Mounted:    true,
+			Mountpoint: "/does/not/exist/tmp/" + id,
+			PID:        1234,
+		},
+		valid: true,
+	}
+
+	g := generate.New()
+	ctr.config.Spec = g.Spec()
+
+	ctr.config.Labels["test"] = "testing"
+
+	// Must make lockfile or container will error on being retrieved from DB
+	lockPath := filepath.Join(locksDir, id)
+	lock, err := storage.GetLockfile(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	ctr.lock = lock
+
+	return ctr, nil
+}
+
+// This horrible hack tests if containers are equal in a way that should handle
+// empty arrays being dropped to nil pointers in the spec JSON
+func testContainersEqual(a, b *Container) bool {
+	if a == nil && b == nil {
+		return true
+	} else if a == nil || b == nil {
+		return false
+	}
+
+	if a.valid != b.valid {
+		return false
+	}
+
+	aConfigJSON, err := json.Marshal(a.config)
+	if err != nil {
+		return false
+	}
+
+	bConfigJSON, err := json.Marshal(b.config)
+	if err != nil {
+		return false
+	}
+
+	if !reflect.DeepEqual(aConfigJSON, bConfigJSON) {
+		return false
+	}
+
+	aStateJSON, err := json.Marshal(a.state)
+	if err != nil {
+		return false
+	}
+
+	bStateJSON, err := json.Marshal(b.state)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(aStateJSON, bStateJSON)
+}


### PR DESCRIPTION
This cherry-picks three commits off the BoltDB state PR #184 that can be merged independently.

It continues work on preparing to add pods by adding new methods to state, and expands unit testing of states to include the in-memory state implementation.