### PR TITLE
DNS and Host options

### DIFF
--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -584,6 +584,19 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 
 	options = append(options, libpod.WithStopSignal(c.StopSignal))
 	options = append(options, libpod.WithStopTimeout(c.StopTimeout))
+	if len(c.DNSSearch) > 0 {
+		options = append(options, libpod.WithDNSSearch(c.DNSSearch))
+	}
+	if len(c.DNSServers) > 0 {
+		options = append(options, libpod.WithDNS(c.DNSServers))
+	}
+	if len(c.DNSOpt) > 0 {
+		options = append(options, libpod.WithDNSOption(c.DNSOpt))
+	}
+	if len(c.HostAdd) > 0 {
+		options = append(options, libpod.WithHosts(c.HostAdd))
+	}
+
 	return options, nil
 }
 

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -79,22 +79,15 @@ func (c *Container) Init() (err error) {
 	}
 
 	// Copy /etc/resolv.conf to the container's rundir
-	resolvPath := "/etc/resolv.conf"
+	runDirResolv, err := c.generateResolvConf()
+	if err != nil {
+		return err
+	}
 
-	// Check if the host system is using system resolve and if so
-	// copy its resolv.conf
-	_, err = os.Stat("/run/systemd/resolve/resolv.conf")
-	if err == nil {
-		resolvPath = "/run/systemd/resolve/resolv.conf"
-	}
-	runDirResolv, err := c.copyHostFileToRundir(resolvPath)
-	if err != nil {
-		return errors.Wrapf(err, "unable to copy resolv.conf to ", runDirResolv)
-	}
 	// Copy /etc/hosts to the container's rundir
-	runDirHosts, err := c.copyHostFileToRundir("/etc/hosts")
+	runDirHosts, err := c.generateHosts()
 	if err != nil {
-		return errors.Wrapf(err, "unable to copy /etc/hosts to ", runDirHosts)
+		return errors.Wrapf(err, "unable to copy /etc/hosts to container space")
 	}
 
 	// Save OCI spec to disk

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"net"
 	"path/filepath"
 	"regexp"
 	"syscall"
@@ -638,6 +639,58 @@ func WithPodLabels(labels map[string]string) PodCreateOption {
 			pod.labels[key] = value
 		}
 
+		return nil
+	}
+}
+
+// WithDNSSearch sets the additional search domains of a container
+func WithDNSSearch(searchDomains []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		ctr.config.DNSSearch = searchDomains
+		return nil
+	}
+}
+
+// WithDNS sets additional name servers for the container
+func WithDNS(dnsServers []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		var dns []net.IP
+		for _, i := range dnsServers {
+			result := net.ParseIP(i)
+			if result == nil {
+				return errors.Wrapf(ErrInvalidArg, "invalid IP address %s", i)
+			}
+			dns = append(dns, result)
+		}
+		ctr.config.DNSServer = dns
+		return nil
+	}
+}
+
+// WithDNSOption sets addition dns options for the container
+func WithDNSOption(dnsOptions []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		ctr.config.DNSOption = dnsOptions
+		return nil
+	}
+}
+
+// WithHosts sets additional host:IP for the hosts file
+func WithHosts(hosts []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		ctr.config.HostAdd = hosts
 		return nil
 	}
 }


### PR DESCRIPTION
Add --dns-search, --dns-opt, --dns-server and --add-host.

Each of these options are destructive in nature, meaning if the user
adds one of them, all current ones are removed from the produced
resolv.conf.

* dns-server allows the user to specify dns servers.
* dns-opt allows the user to specify special resolv.conf options
* dns-search allows the user to specify search domains

The add-host option is not destructive and truly just adds the host
to /etc/hosts.

Signed-off-by: baude <bbaude@redhat.com>