### PR TITLE
switch to bats-core

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -96,3 +96,8 @@ fi
 make TAGS="${TAGS}"
 make TAGS="${TAGS}" install PREFIX=/host/usr ETCDIR=/host/etc
 make TAGS="${TAGS}" test-binaries
+
+# Add the new bats core instead of the deprecated bats
+git clone https://github.com/bats-core/bats-core /bats-core
+cd /bats-core
+install -D -m 755 libexec/* /host/usr/bin/

--- a/.papr.yml
+++ b/.papr.yml
@@ -15,7 +15,6 @@ tests:
   - CRIO_ROOT=/var/tmp/checkout PODMAN_BINARY=/usr/bin/podman CONMON_BINARY=/usr/libexec/crio/conmon PAPR=1 sh .papr.sh
 
 packages:
-    - bats
     - containernetworking-cni
 ---
 


### PR DESCRIPTION
it seems the original bats project is deprecated and bats-core
is an active fork of it.  we dont have packages in distributions
but will build from source.

Signed-off-by: baude <bbaude@redhat.com>