### PR TITLE
Remove --storage-opt from podman run/create

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -114,7 +114,6 @@ type createConfig struct {
 	SigProxy           bool              //sig-proxy
 	StopSignal         syscall.Signal    // stop-signal
 	StopTimeout        uint              // stop-timeout
-	StorageOpts        []string          //storage-opt
 	Sysctl             map[string]string //sysctl
 	Tmpfs              []string          // tmpfs
 	Tty                bool              //tty
@@ -626,7 +625,6 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 		SigProxy:    c.Bool("sig-proxy"),
 		StopSignal:  stopSignal,
 		StopTimeout: c.Uint("stop-timeout"),
-		StorageOpts: c.StringSlice("storage-opt"),
 		Sysctl:      sysctl,
 		Tmpfs:       c.StringSlice("tmpfs"),
 		Tty:         tty,

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -170,6 +170,9 @@ func createCmd(c *cli.Context) error {
 	defer runtime.Shutdown(false)
 
 	imageName, _, data, err := imageData(c, runtime, c.Args()[0])
+	if err != nil {
+		return err
+	}
 	createConfig, err := parseCreateOpts(c, runtime, imageName, data)
 	if err != nil {
 		return err
@@ -370,7 +373,6 @@ func imageData(c *cli.Context, runtime *libpod.Runtime, image string) (string, s
 // Parses CLI options related to container creation into a config which can be
 // parsed into an OCI runtime spec
 func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, data *libpod.ImageData) (*createConfig, error) {
-	//imageName, imageID, data, err := imageData(c, runtime, image)
 	var command []string
 	var memoryLimit, memoryReservation, memorySwap, memoryKernel int64
 	var blkioWeight uint16

--- a/cmd/podman/parse.go
+++ b/cmd/podman/parse.go
@@ -696,21 +696,6 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) { //nolint
 	return securityOpts, nil
 }
 
-// parses storage options per container into a map
-// for storage-opt flag
-func parseStorageOpts(storageOpts []string) (map[string]string, error) { //nolint
-	m := make(map[string]string)
-	for _, option := range storageOpts {
-		if strings.Contains(option, "=") {
-			opt := strings.SplitN(option, "=", 2)
-			m[opt[0]] = opt[1]
-		} else {
-			return nil, errors.Errorf("invalid storage option %q", option)
-		}
-	}
-	return m, nil
-}
-
 // convertKVStringsToMap converts ["key=value"] to {"key":"value"}
 func convertKVStringsToMap(values []string) map[string]string {
 	result := make(map[string]string, len(values))

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -46,6 +46,10 @@ func runCmd(c *cli.Context) error {
 	}
 
 	imageName, _, data, err := imageData(c, runtime, c.Args()[0])
+	if err != nil {
+		return err
+	}
+
 	createConfig, err := parseCreateOpts(c, runtime, imageName, data)
 	if err != nil {
 		return err

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1079,7 +1079,6 @@ _podman_container_run() {
 		--shm-size
 		--stop-signal
 		--stop-timeout
-		--storage-opt
 		--tmpfs
 		--sysctl
 		--ulimit

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -422,17 +422,6 @@ incompatible with any restart policy other than `none`.
 **--stop-timeout**=*10*
   Timeout (in seconds) to stop a container. Default is 10.
 
-**--storage-opt**=[]
-   Storage driver options per container
-
-   $ podman create -it --storage-opt size=120G fedora /bin/bash
-
-   This (size) will allow to set the container rootfs size to 120G at creation time.
-   This option is only available for the `devicemapper`, `btrfs`, `overlay2` and `zfs` graph drivers.
-   For the `devicemapper`, `btrfs` and `zfs` storage drivers, user cannot pass a size less than the Default BaseFS Size.
-   For the `overlay2` storage driver, the size option is only available if the backing fs is `xfs` and mounted with the `pquota` mount option.
-   Under these conditions, user can pass any size less then the backing fs size.
-
 **--sysctl**=SYSCTL
   Configure namespaced kernel parameters at runtime
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -420,17 +420,6 @@ incompatible with any restart policy other than `none`.
 **--stop-timeout**=*10*
   Timeout (in seconds) to stop a container. Default is 10.
 
-**--storage-opt**=[]
-   Storage driver options per container
-
-   $ podman run -it --storage-opt size=120G fedora /bin/bash
-
-   This (size) will allow to set the container rootfs size to 120G at creation time.
-   This option is only available for the `devicemapper`, `btrfs`, `overlay2`  and `zfs` graph drivers.
-   For the `devicemapper`, `btrfs` and `zfs` storage drivers, user cannot pass a size less than the Default BaseFS Size.
-   For the `overlay2` storage driver, the size option is only available if the backing fs is `xfs` and mounted with the `pquota` mount option.
-   Under these conditions, user can pass any size less then the backing fs size.
-
 **--sysctl**=SYSCTL
   Configure namespaced kernel parameters at runtime
 


### PR DESCRIPTION
podman command has storage options as a global option,
these should be set there, rather then in the create and
run commands.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>