### PR TITLE
test/podman_networking.bats: kpod to podman

### DIFF
--- a/test/podman_networking.bats
+++ b/test/podman_networking.bats
@@ -11,13 +11,19 @@ function setup() {
 }
 
 @test "test network connection with default bridge" {
-    run ${KPOD_BINARY} ${KPOD_OPTIONS} run -dt ${ALPINE} wget www.yahoo.com
+    run ${PODMAN_BINARY} ${PODMAN_OPTIONS} run -dt ${ALPINE} wget www.yahoo.com
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run ${PODMAN_BINARY} ${PODMAN_OPTIONS} wait --latest
     echo "$output"
     [ "$status" -eq 0 ]
 }
 
 @test "test network connection with host" {
-    run ${KPOD_BINARY} ${KPOD_OPTIONS} run -dt --network host ${ALPINE} wget www.yahoo.com
+    run ${PODMAN_BINARY} ${PODMAN_OPTIONS} run -dt --network host ${ALPINE} wget www.yahoo.com
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run ${PODMAN_BINARY} ${PODMAN_OPTIONS} wait --latest
     echo "$output"
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
this test was still referring to KPOD_BINARY and not podman

Signed-off-by: baude <bbaude@redhat.com>