### PR TITLE
Fix output for created containers

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -412,7 +412,7 @@ func getTemplateOutput(containers []*libpod.Container, opts psOptions) ([]psTemp
 			status = "Up " + runningFor + " ago"
 		case libpod.ContainerStatePaused:
 			status = "Paused"
-		case libpod.ContainerStateCreated:
+		case libpod.ContainerStateCreated, libpod.ContainerStateConfigured:
 			status = "Created"
 		default:
 			status = "Dead"

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -80,13 +80,6 @@ func rmCmd(c *cli.Context) error {
 		}
 	}
 	for _, container := range delContainers {
-		if err != nil {
-			if lastError != nil {
-				fmt.Fprintln(os.Stderr, lastError)
-			}
-			lastError = errors.Wrapf(err, "failed to find container %s", container.ID())
-			continue
-		}
 		err = runtime.RemoveContainer(container, c.Bool("force"))
 		if err != nil {
 			if lastError != nil {


### PR DESCRIPTION
Created containers that haven't hit runc yet should still
be considered created (not dead).

Also, fixed loop for deleting containers as leftover code
still exited there that prevented proper deletion of containers
that could be deleted.

Signed-off-by: baude <bbaude@redhat.com>