### PR TITLE
Touchup build man page to add missing -q flag

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -52,7 +52,7 @@ Recognized formats include *oci* (OCI image-spec v1.0, the default) and
 
 Pull the image even if a version of the image is already present.
 
-**--quiet**
+**-q, --quiet**
 
 Suppress output messages which indicate which instruction is being processed,
 and of progress when pulling images from a registry, and when writing the


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

A real small one.  I discovered that we'd left off the '-q' option from the build man page.  The code is already there to support it.