### PR TITLE
Override hostname for container

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -508,3 +508,8 @@ func (c *Container) generateHosts() (string, error) {
 	}
 	return c.WriteStringToRundir("hosts", hosts)
 }
+
+// generateEtcHostname creates a containers /etc/hostname
+func (c *Container) generateEtcHostname(hostname string) (string, error) {
+	return c.WriteStringToRundir("hostname", hostname)
+}

--- a/test/podman_run_dns.bats
+++ b/test/podman_run_dns.bats
@@ -45,3 +45,12 @@ function setup() {
     echo "$output"
     [ "$status" -eq 0 ]
 }
+
+@test "test addition of hostname" {
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run --rm --hostname='foobar' ${ALPINE} cat /etc/hostname | grep foobar"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run bash -c "${PODMAN_BINARY} ${PODMAN_OPTIONS} run --rm --hostname='foobar' ${ALPINE} hostname | grep foobar"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Adds the ability to override the container's hostname.  Also, uses
the first twelve characters of the container ID as the default hostname
if none is provided.

Signed-off-by: baude <bbaude@redhat.com>