### PR TITLE
Fixed Created At and Running For value

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -427,9 +427,17 @@ func getTemplateOutput(containers []*libpod.Container, opts psOptions) ([]psTemp
 		if batchErr != nil {
 			return nil, err
 		}
-
-		runningFor := units.HumanDuration(time.Since(conConfig.CreatedTime))
-		createdAt := runningFor + " ago"
+		runningFor := ""
+		startedTime, err := ctr.StartedTime()
+		if err != nil {
+			logrus.Errorf("error getting started time for %q: %v", ctr.ID(), err)
+		}
+		// If the container has not be started, the "zero" value of time is 0001-01-01 00:00:00 +0000 UTC
+		// which would make the time elapsed about a few hundred of years. So checking for the "zero" value of time.Time
+		if startedTime != (time.Time{}) {
+			runningFor = units.HumanDuration(time.Since(startedTime))
+		}
+		createdAt := conConfig.CreatedTime.Format("2006-01-02 15:04:05 -0700 MST")
 		imageName := conConfig.RootfsImageName
 		rootFsSize, err := ctr.RootFsSize()
 		if err != nil {


### PR DESCRIPTION
Changed the Created At value to match the format of docker ps
and fixed the value for Running For to reflect the time elapsed
since the container has been started. Initially it was showing
the time elapsed since the container was created.

Example output:
```
sudo podman ps -a --format "table {{.ID}} {{.CreatedAt}} {{.Status}} {{.RunningFor}}"
CONTAINER ID   CREATED AT                      STATUS                  RUNNING FOR
a9f807ffaacd   2018-01-23 13:31:32 -0500 EST   Up About a minute ago   About a minute
3b33001239ee   2018-01-23 12:20:05 -0500 EST   Created                 
```

Signed-off-by: umohnani8 <umohnani@redhat.com>