### PR TITLE
Fix podman stats based on QE feedback

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -22,7 +22,10 @@ var (
 	}
 )
 
-const crioConfigPath = "/etc/crio/crio.conf"
+const (
+	crioConfigPath = "/etc/crio/crio.conf"
+	idTruncLength  = 12
+)
 
 func getRuntime(c *cli.Context) (*libpod.Runtime, error) {
 
@@ -86,6 +89,13 @@ func getConfig(c *cli.Context) (*libkpod.Config, error) {
 func splitCamelCase(src string) string {
 	entries := camelcase.Split(src)
 	return strings.Join(entries, " ")
+}
+
+func shortID(id string) string {
+	if len(id) > idTruncLength {
+		return id[:idTruncLength]
+	}
+	return id
 }
 
 // validateFlags searches for StringFlags or StringSlice flags that never had

--- a/cmd/podman/history.go
+++ b/cmd/podman/history.go
@@ -14,10 +14,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const (
-	createdByTruncLength = 45
-	idTruncLength        = 12
-)
+const createdByTruncLength = 45
 
 // historyTemplateParams stores info about each layer
 type historyTemplateParams struct {
@@ -169,7 +166,7 @@ func getHistoryTemplateOutput(history []v1.History, layers []types.BlobInfo, ima
 			imageID = "<missing>"
 		}
 		if !opts.noTrunc && i == len(history)-1 {
-			imageID = imageID[:idTruncLength]
+			imageID = shortID(imageID)
 		}
 
 		var size int64

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -194,7 +194,7 @@ func getImagesTemplateOutput(runtime *libpod.Runtime, images []*storage.Image, o
 
 		imageID := "sha256:" + img.ID
 		if !opts.noTrunc {
-			imageID = img.ID[:idTruncLength]
+			imageID = shortID(img.ID)
 		}
 
 		repository := "<none>"

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -474,7 +474,7 @@ func getTemplateOutput(containers []*libpod.Container, opts psOptions) ([]psTemp
 		}
 
 		if !opts.noTrunc {
-			ctrID = ctr.ID()[:idTruncLength]
+			ctrID = shortID(ctr.ID())
 			imageName = conConfig.RootfsImageName
 		}
 

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -31,48 +31,58 @@ Disable streaming stats and only pull the first result, default setting is false
 
 **--format="TEMPLATE"**
 
-Pretty-print images using a Go template
+Pretty-print container statistics to JSON or using a Go template
+
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder** | **Description**   |
+| --------------- | ---------------   |
+| .ID             | Container ID      |
+| .Name           | Container Name    |
+| .CPUPerc        | CPU percentage    |
+| .MemUsage       | Memory usage      |
+| .MemPerc        | Memory percentage |
+| .NetIO          | Network IO        |
+| .BlockIO        | Block IO          |
+| .PIDS           | Number of PIDs    |
 
 
 ## EXAMPLE
 
 ```
 # podman stats -a --no-stream
-
-CONTAINER      CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO       PIDS
-132ade621b5d   0.00%   1.618MB / 33.08GB   0.00%   0B / 0B   0B / 0B        0
-940e00a40a77   0.00%   1.544MB / 33.08GB   0.00%   0B / 0B   0B / 0B        0
-72a1dfb44ca7   0.00%   1.528MB / 33.08GB   0.00%   0B / 0B   0B / 0B        0
-f5a62a71b07b   0.00%   5.669MB / 33.08GB   0.02%   0B / 0B   0B / 0B        3
-31eab2cf93f4   0.00%   16.42MB / 33.08GB   0.05%   0B / 0B   22.43MB / 0B   0
-
-#
+ID             NAME              CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO   PIDS
+a9f807ffaacd   frosty_hodgkin    --      3.092MB / 16.7GB    0.02%   -- / --   -- / --    2
+3b33001239ee   sleepy_stallman   --      -- / --             --      -- / --   -- / --    --
 ```
 
 ```
-# podman stats --no-stream 31eab2cf93f4
-CONTAINER      CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO       PIDS
-31eab2cf93f4   0.00%   16.42MB / 33.08GB   0.05%   0B / 0B   22.43MB / 0B   0
+# podman stats --no-stream a9f80
+ID             NAME             CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO   PIDS
+a9f807ffaacd   frosty_hodgkin   --      3.092MB / 16.7GB    0.02%   -- / --   -- / --    2
+```
 
-#
 ```
-```
-# podman stats --no-stream --format=json 31eab2cf93f4
+# podman stats --no-stream --format=json a9f80
 [
     {
-        "name": "31eab2cf93f4",
-        "id": "31eab2cf93f413af64a3f13d8d78393238658465d75e527333a8577f251162ec",
-        "cpu_percent": "0.00%",
-        "mem_usage": "16.42MB / 33.08GB",
-        "mem_percent": "0.05%",
-        "netio": "0B / 0B",
-        "blocki": "22.43MB / 0B",
-        "pids": 0
+        "id": "a9f807ffaacd",
+        "name": "frosty_hodgkin",
+        "cpu_percent": "--",
+        "mem_usage": "3.092MB / 16.7GB",
+        "mem_percent": "0.02%",
+        "netio": "-- / --",
+        "blocki": "-- / --",
+        "pids": "2"
     }
 ]
-#
 ```
 
+```
+# podman stats --no-stream --format "table {{.ID}} {{.Name}} {{.MemUsage}}" 6eae
+ID             NAME           MEM USAGE / LIMIT
+6eae9e25a564   clever_bassi   3.031MB / 16.7GB
+```
 
 ## SEE ALSO
 podman(1)

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -13,6 +13,7 @@ import (
 // ContainerStats contains the statistics information for a running container
 type ContainerStats struct {
 	ContainerID string
+	Name        string
 	CPU         float64
 	CPUNano     uint64
 	SystemNano  uint64
@@ -30,6 +31,7 @@ type ContainerStats struct {
 func (c *Container) GetContainerStats(previousStats *ContainerStats) (*ContainerStats, error) {
 	stats := new(ContainerStats)
 	stats.ContainerID = c.ID()
+	stats.Name = c.Name()
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if err := c.syncContainer(); err != nil {


### PR DESCRIPTION
QE found issues with formatting the go template and
the man page was lacking information.
Changed the format of the output to match latest docker.

Signed-off-by: umohnani8 <umohnani@redhat.com>