### PR TITLE
Finish pod backend

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -106,8 +106,6 @@ type Container struct {
 }
 
 // TODO fetch IP and Subnet Mask from networks once we have updated OCICNI
-// TODO enable pod support
-// TODO Add readonly support
 
 // containerState contains the current state of the container
 // It is stored on disk in a tmpfs and recreated on reboot
@@ -162,8 +160,6 @@ type ContainerConfig struct {
 	RootfsImageName string `json:"rootfsImageName,omitempty"`
 	// Whether to mount volumes specified in the image
 	ImageVolumes bool `json:"imageVolumes"`
-	// Whether to make the container read only
-	ReadOnly bool `json:"readOnly"`
 	// Src path to be mounted on /dev/shm in container
 	ShmDir string `json:"ShmDir,omitempty"`
 	// Size of the container's SHM

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -411,7 +411,7 @@ func (c *Container) WriteStringToRundir(destFile, output string) (string, error)
 	return destFileName, nil
 }
 
-type resolv struct {
+type resolvConf struct {
 	nameServers   []string
 	searchDomains []string
 	options       []string
@@ -464,8 +464,8 @@ func (c *Container) generateResolvConf() (string, error) {
 }
 
 // createResolv creates a resolv struct from an input string
-func createResolv(input string) resolv {
-	var resolv resolv
+func createResolv(input string) resolvConf {
+	var resolv resolvConf
 	for _, line := range strings.Split(input, "\n") {
 		if strings.HasPrefix(line, "search") {
 			fields := strings.Fields(line)
@@ -494,7 +494,7 @@ func createResolv(input string) resolv {
 }
 
 //ToString returns a resolv struct in the form of a resolv.conf
-func (r resolv) ToString() string {
+func (r resolvConf) ToString() string {
 	var result string
 	// Populate the output string with search domains
 	result += fmt.Sprintf("search %s\n", strings.Join(r.searchDomains, " "))

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -8,9 +8,9 @@ import (
 	"github.com/projectatomic/libpod/pkg/registrar"
 )
 
-// TODO: unified name/ID registry to ensure no name and ID conflicts between
-// containers and pods
-// This can probably be used to replace the existing trunc index and registrars
+// TODO: Maybe separate idIndex for pod/containers
+// As of right now, partial IDs used in Lookup... need to be unique as well
+// This may be undesirable?
 
 // An InMemoryState is a purely in-memory state store
 type InMemoryState struct {
@@ -486,7 +486,7 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	}
 
 	// Is the container already in the pod?
-	if _, ok := podCtrs[ctr.ID()]; ok {
+	if _, ok = podCtrs[ctr.ID()]; ok {
 		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in pod %s", ctr.ID(), pod.ID())
 	}
 

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -114,8 +114,7 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
 	}
 
-	_, ok := s.containers[ctr.ID()]
-	if ok {
+	if _, ok := s.containers[ctr.ID()]; ok {
 		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
 	}
 
@@ -128,8 +127,7 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 	// use, so this should be fine.
 	depCtrs := ctr.Dependencies()
 	for _, depCtr := range depCtrs {
-		_, ok = s.containers[depCtr]
-		if !ok {
+		if _, ok := s.containers[depCtr]; !ok {
 			return errors.Wrapf(ErrNoSuchCtr, "cannot depend on nonexistent container %s", depCtr)
 		}
 	}
@@ -309,7 +307,7 @@ func (s *InMemoryState) HasPod(id string) (bool, error) {
 // PodHasContainer checks if the given pod has a container with the given ID
 func (s *InMemoryState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
 	if !pod.valid {
-		return false, errors.Wrapf(ErrPodRemoved, "pod %s is not valid")
+		return false, errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	if ctrID == "" {
@@ -329,7 +327,7 @@ func (s *InMemoryState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
 // PodContainersByID returns the IDs of all containers in the given pod
 func (s *InMemoryState) PodContainersByID(pod *Pod) ([]string, error) {
 	if !pod.valid {
-		return nil, errors.Wrapf(ErrPodRemoved, "pod %s is not valid")
+		return nil, errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	podCtrs, ok := s.podContainers[pod.ID()]
@@ -354,7 +352,7 @@ func (s *InMemoryState) PodContainersByID(pod *Pod) ([]string, error) {
 // PodContainers retrieves the containers from a pod
 func (s *InMemoryState) PodContainers(pod *Pod) ([]*Container, error) {
 	if !pod.valid {
-		return nil, errors.Wrapf(ErrPodRemoved, "pod %s is not valid")
+		return nil, errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	podCtrs, ok := s.podContainers[pod.ID()]
@@ -456,8 +454,7 @@ func (s *InMemoryState) RemovePodContainers(pod *Pod) error {
 		ctrDeps, ok := s.ctrDepends[ctr]
 		if ok {
 			for _, dep := range ctrDeps {
-				_, ok := podCtrs[dep]
-				if !ok {
+				if _, ok := podCtrs[dep]; !ok {
 					return errors.Wrapf(ErrCtrExists, "container %s has dependency %s outside of pod %s", ctr, dep, pod.ID())
 				}
 			}
@@ -511,15 +508,13 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	// use, so this should be fine.
 	depCtrs := ctr.Dependencies()
 	for _, depCtr := range depCtrs {
-		_, ok = s.containers[depCtr]
-		if !ok {
+		if _, ok = s.containers[depCtr]; !ok {
 			return errors.Wrapf(ErrNoSuchCtr, "cannot depend on nonexistent container %s", depCtr)
 		}
 	}
 
 	// Add container to state
-	_, ok = s.containers[ctr.ID()]
-	if ok {
+	if _, ok = s.containers[ctr.ID()]; ok {
 		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
 	}
 

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -15,10 +15,9 @@ type Pod struct {
 	name   string
 	labels map[string]string
 
-	containers map[string]*Container
-
-	valid bool
-	lock  storage.Locker
+	valid   bool
+	runtime *Runtime
+	lock storage.Locker
 }
 
 // ID retrieves the pod's ID
@@ -42,17 +41,11 @@ func (p *Pod) Labels() map[string]string {
 }
 
 // Creates a new, empty pod
-func newPod(lockDir string) (*Pod, error) {
+func newPod(lockDir string, runtime *Runtime) (*Pod, error) {
 	pod := new(Pod)
 	pod.id = stringid.GenerateNonCryptoID()
 	pod.name = namesgenerator.GetRandomName(0)
-
-	pod.containers = make(map[string]*Container)
-
-	// TODO: containers and pods share a locks folder, but not tables in the
-	// database
-	// As the locks are 256-bit pseudorandom integers, collision is unlikely
-	// But it's something worth looking into
+	pod.runtime = runtime
 
 	// Path our lock file will reside at
 	lockPath := filepath.Join(lockDir, pod.id)
@@ -66,47 +59,9 @@ func newPod(lockDir string) (*Pod, error) {
 	return pod, nil
 }
 
-// Adds a container to the pod
-// Does not check that container's pod ID is set correctly, or attempt to set
-// pod ID after adding
-func (p *Pod) addContainer(ctr *Container) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	if !p.valid {
-		return ErrPodRemoved
-	}
-
-	if !ctr.valid {
-		return ErrCtrRemoved
-	}
-
-	if _, ok := p.containers[ctr.ID()]; ok {
-		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in pod %s", ctr.ID(), p.id)
-	}
-
-	p.containers[ctr.ID()] = ctr
-
-	return nil
-}
-
-// Removes a container from the pod
-// Does not perform any checks on the container
-func (p *Pod) removeContainer(ctr *Container) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	if !p.valid {
-		return ErrPodRemoved
-	}
-
-	if _, ok := p.containers[ctr.ID()]; !ok {
-		return errors.Wrapf(ErrNoSuchCtr, "no container with id %s in pod %s", ctr.ID(), p.id)
-	}
-
-	delete(p.containers, ctr.ID())
-
-	return nil
+// Init() initializes all containers within a pod that have not been initialized
+func (p *Pod) Init() error {
+	return ErrNotImplemented
 }
 
 // Start starts all containers within a pod that are not already running
@@ -126,20 +81,15 @@ func (p *Pod) Kill(signal uint) error {
 
 // HasContainer checks if a container is present in the pod
 func (p *Pod) HasContainer(id string) (bool, error) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	if !p.valid {
 		return false, ErrPodRemoved
 	}
 
-	_, ok := p.containers[id]
-
-	return ok, nil
+	return p.runtime.state.PodHasContainer(p, id)
 }
 
-// GetContainers retrieves the containers in the pod
-func (p *Pod) GetContainers() ([]*Container, error) {
+// AllContainersID returns the container IDs of all the containers in the pod
+func (p *Pod) AllContainersByID() ([]string, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -147,12 +97,19 @@ func (p *Pod) GetContainers() ([]*Container, error) {
 		return nil, ErrPodRemoved
 	}
 
-	ctrs := make([]*Container, 0, len(p.containers))
-	for _, ctr := range p.containers {
-		ctrs = append(ctrs, ctr)
+	return p.runtime.state.PodContainersByID(p)
+}
+
+// AllContainers retrieves the containers in the pod
+func (p *Pod) AllContainers() ([]*Container, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if !p.valid {
+		return nil, ErrPodRemoved
 	}
 
-	return ctrs, nil
+	return p.runtime.state.PodContainers(p)
 }
 
 // Status gets the status of all containers in the pod

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -45,6 +45,7 @@ func newPod(lockDir string, runtime *Runtime) (*Pod, error) {
 	pod := new(Pod)
 	pod.id = stringid.GenerateNonCryptoID()
 	pod.name = namesgenerator.GetRandomName(0)
+	pod.labels = make(map[string]string)
 	pod.runtime = runtime
 
 	// Path our lock file will reside at

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -17,7 +17,7 @@ type Pod struct {
 
 	valid   bool
 	runtime *Runtime
-	lock storage.Locker
+	lock    storage.Locker
 }
 
 // ID retrieves the pod's ID
@@ -59,7 +59,7 @@ func newPod(lockDir string, runtime *Runtime) (*Pod, error) {
 	return pod, nil
 }
 
-// Init() initializes all containers within a pod that have not been initialized
+// Init initializes all containers within a pod that have not been initialized
 func (p *Pod) Init() error {
 	return ErrNotImplemented
 }
@@ -88,7 +88,7 @@ func (p *Pod) HasContainer(id string) (bool, error) {
 	return p.runtime.state.PodHasContainer(p, id)
 }
 
-// AllContainersID returns the container IDs of all the containers in the pod
+// AllContainersByID returns the container IDs of all the containers in the pod
 func (p *Pod) AllContainersByID() ([]string, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -121,8 +121,9 @@ func (r *Runtime) removeContainer(c *Container, force bool) error {
 	// We need to lock the pod before we lock the container
 	// To avoid races around removing a container and the pod it is in
 	var pod *Pod
+	var err error
 	if c.config.Pod != "" {
-		pod, err := r.state.Pod(c.config.Pod)
+		pod, err = r.state.Pod(c.config.Pod)
 		if err != nil {
 			return errors.Wrapf(err, "container %s is in pod %s, but pod cannot be retrieved", c.ID(), pod.ID())
 		}

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -44,12 +44,142 @@ func (r *Runtime) NewPod(options ...PodCreateOption) (*Pod, error) {
 	return nil, ErrNotImplemented
 }
 
-// RemovePod removes a pod and all containers in it
-// If force is specified, all containers in the pod will be stopped first
-// Otherwise, RemovePod will return an error if any container in the pod is running
-// Remove acts atomically, removing all containers or no containers
-func (r *Runtime) RemovePod(p *Pod, force bool) error {
-	return ErrNotImplemented
+// RemovePod removes a pod
+// If removeCtrs is specified, containers will be removed
+// Otherwise, a pod that is not empty will return an error and not be removed
+// If force is specified with removeCtrs, all containers will be stopped before
+// being removed
+// Otherwise, the pod will not be removed if any containers are running
+func (r *Runtime) RemovePod(p *Pod, removeCtrs, force bool) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if !r.valid {
+		return ErrRuntimeStopped
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if !p.valid {
+		return ErrPodRemoved
+	}
+
+	ctrs, err := r.state.PodContainers(p)
+	if err != nil {
+		return err
+	}
+
+	numCtrs := len(ctrs)
+
+	if !removeCtrs && numCtrs > 0 {
+		return errors.Wrapf(ErrCtrExists, "pod %s contains containers and cannot be removed", p.ID())
+	}
+
+	// Go through and lock all containers so we can operate on them all at once
+	dependencies := make(map[string][]string)
+	for _, ctr := range ctrs {
+		ctr.lock.Lock()
+		defer ctr.lock.Unlock()
+
+		// Sync all containers
+		if err := ctr.syncContainer(); err != nil {
+			return err
+		}
+
+		// Check if the container is in a good state to be removed
+		if ctr.state.State == ContainerStatePaused {
+			return errors.Wrapf(ErrCtrStateInvalid, "pod %s contains paused container %s, cannot remove", p.ID(), ctr.ID())
+		}
+
+		if ctr.state.State == ContainerStateUnknown {
+			return errors.Wrapf(ErrCtrStateInvalid, "pod %s contains container %s with invalid state", p.ID(), ctr.ID())
+		}
+
+		// If the container is running and force is not set we can't do anything
+		if ctr.state.State == ContainerStateRunning {
+			return errors.Wrapf(ErrCtrStateInvalid, "pod %s contains container %s which is running", p.ID(), ctr.ID())
+		}
+
+		deps, err := r.state.ContainerInUse(ctr)
+		if err != nil {
+			return err
+		}
+		dependencies[ctr.ID()] = deps
+	}
+
+	// Check if containers have dependencies
+	// If they do, and the dependencies are not in the pod, error
+	for ctr, deps := range dependencies {
+		for _, dep := range deps {
+			if _, ok := dependencies[dep]; !ok {
+				return errors.Wrapf(ErrCtrExists, "container %s depends on container %s not in pod %s", ctr, dep, p.ID())
+			}
+		}
+	}
+
+	// First loop through all containers and stop them
+	// Do not remove in this loop to ensure that we don't remove unless all
+	// containers are in a good state
+	if force {
+		for _, ctr := range ctrs {
+			// If force is set and the container is running, stop it now
+			if ctr.state.State == ContainerStateRunning {
+				if err := r.ociRuntime.stopContainer(ctr, ctr.StopTimeout()); err != nil {
+					return errors.Wrapf(err, "error stopping container %s to remove pod %s", ctr.ID(), p.ID())
+				}
+
+				// Sync again to pick up stopped state
+				if err := ctr.syncContainer(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Start removing containers
+	// We can remove containers even if they have dependencies now
+	// As we have guaranteed their dependencies are in the pod
+	for _, ctr := range ctrs {
+		// Stop network NS
+		if err := r.teardownNetNS(ctr); err != nil {
+			return err
+		}
+
+		// Stop container's storage
+		if err := ctr.teardownStorage(); err != nil {
+			return err
+		}
+
+		// Delete the container from runc (only if we are not
+		// ContainerStateConfigured)
+		if ctr.state.State != ContainerStateConfigured {
+			if err := r.ociRuntime.deleteContainer(ctr); err != nil {
+				return errors.Wrapf(err, "error removing container %s from runc", ctr.ID())
+			}
+		}
+
+	}
+
+	// Remove containers from the state
+	if err := r.state.RemovePodContainers(p); err != nil {
+		return err
+	}
+
+	// Mark containers invalid
+	for _, ctr := range ctrs {
+		ctr.valid = false
+	}
+
+	// Remove pod from state
+	if err := r.state.RemovePod(p); err != nil {
+		return err
+	}
+
+	// Mark pod invalid
+	p.valid = false
+
+	return nil
 }
 
 // GetPod retrieves a pod by its ID

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -24,7 +24,7 @@ func (r *Runtime) NewPod(options ...PodCreateOption) (*Pod, error) {
 		return nil, ErrRuntimeStopped
 	}
 
-	pod, err := newPod(r.lockDir)
+	pod, err := newPod(r.lockDir, r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating pod")
 	}

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -97,7 +97,7 @@ func (r *Runtime) RemovePod(p *Pod, removeCtrs, force bool) error {
 		}
 
 		// If the container is running and force is not set we can't do anything
-		if ctr.state.State == ContainerStateRunning {
+		if ctr.state.State == ContainerStateRunning && !force {
 			return errors.Wrapf(ErrCtrStateInvalid, "pod %s contains container %s which is running", p.ID(), ctr.ID())
 		}
 

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -839,8 +839,20 @@ func (s *SQLState) HasPod(id string) (bool, error) {
 	return false, ErrNotImplemented
 }
 
+// PodHasContainer checks if the given pod containers a container with the given
+// ID
+func (s *SQLState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
+	return false, ErrNotImplemented
+}
+
+// PodContainersByID returns the container IDs of all containers in the given
+// pod
+func (s *SQLState) PodContainersByID(pod *Pod) ([]string, error) {
+	return nil, ErrNotImplemented
+}
+
 // PodContainers returns all the containers in a pod given the pod's full ID
-func (s *SQLState) PodContainers(id string) ([]*Container, error) {
+func (s *SQLState) PodContainers(pod *Pod) ([]*Container, error) {
 	return nil, ErrNotImplemented
 }
 
@@ -853,11 +865,6 @@ func (s *SQLState) AddPod(pod *Pod) error {
 // RemovePod removes a pod from the state
 // Only empty pods can be removed
 func (s *SQLState) RemovePod(pod *Pod) error {
-	return ErrNotImplemented
-}
-
-// UpdatePod updates a pod from the database
-func (s *SQLState) UpdatePod(pod *Pod) error {
 	return ErrNotImplemented
 }
 

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -3,7 +3,6 @@ package libpod
 import (
 	"database/sql"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -148,23 +147,7 @@ func (s *SQLState) Refresh() (err error) {
 
 // Container retrieves a container from its full ID
 func (s *SQLState) Container(id string) (*Container, error) {
-	const query = `SELECT containers.*,
-                              containerState.State,
-                              containerState.ConfigPath,
-                              containerState.RunDir,
-                              containerState.MountPoint,
-                              containerState.StartedTime,
-                              containerState.FinishedTime,
-                              containerState.ExitCode,
-                              containerState.OomKilled,
-                              containerState.Pid,
-                              containerState.NetNSPath,
-                              containerState.IPAddress,
-                              containerState.SubnetMask
-                       FROM containers
-                       INNER JOIN
-                           containerState ON containers.Id = containerState.Id
-                       WHERE containers.Id=?;`
+	const query = containerQuery + "WHERE containers.Id=?;"
 
 	if id == "" {
 		return nil, ErrEmptyID
@@ -186,23 +169,7 @@ func (s *SQLState) Container(id string) (*Container, error) {
 
 // LookupContainer retrieves a container by full or unique partial ID or name
 func (s *SQLState) LookupContainer(idOrName string) (*Container, error) {
-	const query = `SELECT containers.*,
-                              containerState.State,
-                              containerState.ConfigPath,
-                              containerState.RunDir,
-                              containerState.MountPoint,
-                              containerState.StartedTime,
-                              containerState.FinishedTime,
-                              containerState.ExitCode,
-                              containerState.OomKilled,
-                              containerState.Pid,
-                              containerState.NetNSPath,
-                              containerState.IPAddress,
-                              containerState.SubnetMask
-                       FROM containers
-                       INNER JOIN
-                           containerState ON containers.Id = containerState.Id
-                       WHERE (containers.Id LIKE ?) OR containers.Name=?;`
+	const query = containerQuery + "WHERE (containers.Id LIKE ?) OR containers.Name=?;"
 
 	if idOrName == "" {
 		return nil, ErrEmptyID
@@ -277,189 +244,15 @@ func (s *SQLState) HasContainer(id string) (bool, error) {
 // If the container belongs to a pod, that pod must already be present in the
 // state, and the container will be added to the pod
 func (s *SQLState) AddContainer(ctr *Container) (err error) {
-	const (
-		addCtr = `INSERT INTO containers VALUES (
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?
-                );`
-		addCtrState = `INSERT INTO containerState VALUES (
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?,
-                    ?, ?, ?
-                );`
-	)
-
-	if !s.valid {
-		return ErrDBClosed
-	}
-
 	if !ctr.valid {
 		return ErrCtrRemoved
 	}
 
-	mounts, err := json.Marshal(ctr.config.Mounts)
-	if err != nil {
-		return errors.Wrapf(err, "error marshaling container %s mounts to JSON", ctr.ID())
+	if ctr.config.Pod != "" {
+		return errors.Wrapf(ErrPodExists, "cannot add container that belongs to a pod, use AddContainerToPod instead")
 	}
 
-	dnsServerJSON, err := json.Marshal(ctr.config.DNSServer)
-	if err != nil {
-		return errors.Wrapf(err, "error marshaling container %s DNS servers to JSON", ctr.ID())
-	}
-
-	dnsSearchJSON, err := json.Marshal(ctr.config.DNSSearch)
-	if err != nil {
-		return errors.Wrapf(err, "error marshaling container %s DNS search domains to JSON", ctr.ID())
-	}
-
-	dnsOptionJSON, err := json.Marshal(ctr.config.DNSOption)
-	if err != nil {
-		return errors.Wrapf(err, "error marshaling container %s DNS options to JSON", ctr.ID())
-	}
-
-	hostAddJSON, err := json.Marshal(ctr.config.HostAdd)
-	if err != nil {
-		return errors.Wrapf(err, "error marshaling container %s hosts to JSON", ctr.ID())
-	}
-
-	labelsJSON, err := json.Marshal(ctr.config.Labels)
-	if err != nil {
-		return errors.Wrapf(err, "error marshaling container %s labels to JSON", ctr.ID())
-	}
-
-	netNSPath := ""
-	if ctr.state.NetNS != nil {
-		netNSPath = ctr.state.NetNS.Path()
-	}
-
-	specJSON, err := json.Marshal(ctr.config.Spec)
-	if err != nil {
-		return errors.Wrapf(err, "error marshalling container %s spec to JSON", ctr.ID())
-	}
-
-	portsJSON := []byte{}
-	if len(ctr.config.PortMappings) > 0 {
-		portsJSON, err = json.Marshal(&ctr.config.PortMappings)
-		if err != nil {
-			return errors.Wrapf(err, "error marshalling container %s port mappings to JSON", ctr.ID())
-		}
-	}
-
-	tx, err := s.db.Begin()
-	if err != nil {
-		return errors.Wrapf(err, "error beginning database transaction")
-	}
-	defer func() {
-		if err != nil {
-			if err2 := tx.Rollback(); err2 != nil {
-				logrus.Errorf("Error rolling back transaction to add container %s: %v", ctr.ID(), err2)
-			}
-		}
-	}()
-
-	// Add static container information
-	_, err = tx.Exec(addCtr,
-		ctr.ID(),
-		ctr.Name(),
-		stringToNullString(ctr.PodID()),
-
-		ctr.config.RootfsImageID,
-		ctr.config.RootfsImageName,
-		boolToSQL(ctr.config.ImageVolumes),
-		boolToSQL(ctr.config.ReadOnly),
-		ctr.config.ShmDir,
-		ctr.config.ShmSize,
-		ctr.config.StaticDir,
-		string(mounts),
-		ctr.LogPath(),
-
-		boolToSQL(ctr.config.Privileged),
-		boolToSQL(ctr.config.NoNewPrivs),
-		ctr.config.ProcessLabel,
-		ctr.config.MountLabel,
-		ctr.config.User,
-
-		stringToNullString(ctr.config.IPCNsCtr),
-		stringToNullString(ctr.config.MountNsCtr),
-		stringToNullString(ctr.config.NetNsCtr),
-		stringToNullString(ctr.config.PIDNsCtr),
-		stringToNullString(ctr.config.UserNsCtr),
-		stringToNullString(ctr.config.UTSNsCtr),
-		stringToNullString(ctr.config.CgroupNsCtr),
-
-		boolToSQL(ctr.config.CreateNetNS),
-		string(dnsServerJSON),
-		string(dnsSearchJSON),
-		string(dnsOptionJSON),
-		string(hostAddJSON),
-
-		boolToSQL(ctr.config.Stdin),
-		string(labelsJSON),
-		ctr.config.StopSignal,
-		ctr.config.StopTimeout,
-		timeToSQL(ctr.config.CreatedTime),
-		ctr.config.CgroupParent)
-	if err != nil {
-		return errors.Wrapf(err, "error adding static information for container %s to database", ctr.ID())
-	}
-
-	// Add container state to the database
-	_, err = tx.Exec(addCtrState,
-		ctr.ID(),
-		ctr.state.State,
-		ctr.state.ConfigPath,
-		ctr.state.RunDir,
-		ctr.state.Mountpoint,
-		timeToSQL(ctr.state.StartedTime),
-		timeToSQL(ctr.state.FinishedTime),
-		ctr.state.ExitCode,
-		boolToSQL(ctr.state.OOMKilled),
-		ctr.state.PID,
-		netNSPath,
-		ctr.state.IPAddress,
-		ctr.state.SubnetMask)
-	if err != nil {
-		return errors.Wrapf(err, "error adding container %s state to database", ctr.ID())
-	}
-
-	// Save the container's runtime spec to disk
-	specPath := getSpecPath(s.specsDir, ctr.ID())
-	if err := ioutil.WriteFile(specPath, specJSON, 0750); err != nil {
-		return errors.Wrapf(err, "error saving container %s spec JSON to disk", ctr.ID())
-	}
-	defer func() {
-		if err != nil {
-			if err2 := os.Remove(specPath); err2 != nil {
-				logrus.Errorf("Error removing container %s JSON spec from state: %v", ctr.ID(), err2)
-			}
-		}
-	}()
-
-	// If the container has port mappings, save them to disk
-	if len(ctr.config.PortMappings) > 0 {
-		portPath := getPortsPath(s.specsDir, ctr.ID())
-		if err := ioutil.WriteFile(portPath, portsJSON, 0750); err != nil {
-			return errors.Wrapf(err, "error saving container %s port JSON to disk", ctr.ID())
-		}
-		defer func() {
-			if err != nil {
-				if err2 := os.Remove(portPath); err2 != nil {
-					logrus.Errorf("Error removing container %s JSON ports from state: %v", ctr.ID(), err2)
-				}
-			}
-		}()
-	}
-
-	if err := tx.Commit(); err != nil {
-		return errors.Wrapf(err, "error committing transaction to add container %s", ctr.ID())
-	}
-
-	return nil
+	return s.addContainer(ctr)
 }
 
 // UpdateContainer updates a container's state from the database
@@ -709,93 +502,18 @@ func (s *SQLState) ContainerInUse(ctr *Container) ([]string, error) {
 	return ids, nil
 }
 
-// RemoveContainer removes the container from the state
+// RemoveContainer removes the given container from the state
 func (s *SQLState) RemoveContainer(ctr *Container) error {
-	const (
-		removeCtr   = "DELETE FROM containers WHERE Id=?;"
-		removeState = "DELETE FROM containerState WHERE ID=?;"
-	)
-
-	if !s.valid {
-		return ErrDBClosed
+	if ctr.config.Pod != "" {
+		return errors.Wrapf(ErrPodExists, "container %s belongs to a pod, use RemoveContainerFromPod", ctr.ID())
 	}
 
-	committed := false
-
-	tx, err := s.db.Begin()
-	if err != nil {
-		return errors.Wrapf(err, "error beginning database transaction")
-	}
-	defer func() {
-		if err != nil && !committed {
-			if err2 := tx.Rollback(); err2 != nil {
-				logrus.Errorf("Error rolling back transaction to add container %s: %v", ctr.ID(), err2)
-			}
-		}
-	}()
-
-	// Check rows acted on for the first transaction, verify we actually removed something
-	result, err := tx.Exec(removeCtr, ctr.ID())
-	if err != nil {
-		return errors.Wrapf(err, "error removing container %s from containers table", ctr.ID())
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return errors.Wrapf(err, "error retrieving number of rows in transaction removing container %s", ctr.ID())
-	} else if rows == 0 {
-		return ErrNoSuchCtr
-	}
-
-	if _, err := tx.Exec(removeState, ctr.ID()); err != nil {
-		return errors.Wrapf(err, "error removing container %s from state table", ctr.ID())
-	}
-
-	if err := tx.Commit(); err != nil {
-		return errors.Wrapf(err, "error committing transaction to remove container %s", ctr.ID())
-	}
-
-	committed = true
-
-	// Remove the container's JSON from disk
-	jsonPath := getSpecPath(s.specsDir, ctr.ID())
-	if err := os.Remove(jsonPath); err != nil {
-		return errors.Wrapf(err, "error removing JSON spec from state for container %s", ctr.ID())
-	}
-
-	// Remove containers ports JSON from disk
-	// May not exist, so ignore os.IsNotExist
-	portsPath := getPortsPath(s.specsDir, ctr.ID())
-	if err := os.Remove(portsPath); err != nil {
-		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "error removing JSON ports from state for container %s", ctr.ID())
-		}
-	}
-
-	ctr.valid = false
-
-	return nil
+	return s.removeContainer(ctr)
 }
 
 // AllContainers retrieves all the containers presently in the state
 func (s *SQLState) AllContainers() ([]*Container, error) {
-	// TODO maybe do an ORDER BY here?
-	const query = `SELECT containers.*,
-                              containerState.State,
-                              containerState.ConfigPath,
-                              containerState.RunDir,
-                              containerState.MountPoint,
-                              containerState.StartedTime,
-                              containerState.FinishedTime,
-                              containerState.ExitCode,
-                              containerState.OomKilled,
-                              containerState.Pid,
-                              containerState.NetNSPath,
-                              containerState.IPAddress,
-                              containerState.SubnetMask
-                      FROM containers
-                      INNER JOIN
-                          containerState ON containers.Id = containerState.Id
-                      ORDER BY containers.CreatedTime DESC;`
+	const query = containerQuery + ";"
 
 	if !s.valid {
 		return nil, ErrDBClosed
@@ -826,59 +544,352 @@ func (s *SQLState) AllContainers() ([]*Container, error) {
 
 // Pod retrieves a pod by its full ID
 func (s *SQLState) Pod(id string) (*Pod, error) {
-	return nil, ErrNotImplemented
+	const query = "SELECT * FROM pods WHERE Id=?;"
+
+	if !s.valid {
+		return nil, ErrDBClosed
+	}
+
+	if id == "" {
+		return nil, ErrEmptyID
+	}
+
+	row := s.db.QueryRow(query, id)
+
+	pod, err := s.podFromScannable(row)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving pod %s from database", id)
+	}
+
+	return pod, nil
 }
 
 // LookupPod retrieves a pot by full or unique partial ID or name
 func (s *SQLState) LookupPod(idOrName string) (*Pod, error) {
-	return nil, ErrNotImplemented
+	const query = "SELECT * FROM pods WHERE (Id LIKE ?) OR Name=?;"
+
+	if idOrName == "" {
+		return nil, ErrEmptyID
+	}
+
+	if !s.valid {
+		return nil, ErrDBClosed
+	}
+
+	rows, err := s.db.Query(query, idOrName+"%", idOrName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving pod %s row from database", idOrName)
+	}
+	defer rows.Close()
+
+	foundResult := false
+	var pod *Pod
+	for rows.Next() {
+		if foundResult {
+			return nil, errors.Wrapf(ErrCtrExists, "more than one result for ID or name %s", idOrName)
+		}
+
+		var err error
+		pod, err = s.podFromScannable(rows)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error retrieving pod %s from database", idOrName)
+		}
+		foundResult = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error retrieving rows for pod ID or name %s", idOrName)
+	}
+
+	if !foundResult {
+		return nil, errors.Wrapf(ErrNoSuchCtr, "no pod with ID or name %s found", idOrName)
+	}
+
+
+	return pod, nil
 }
 
 // HasPod checks if a pod exists given its full ID
 func (s *SQLState) HasPod(id string) (bool, error) {
-	return false, ErrNotImplemented
+	if id == "" {
+		return false, ErrEmptyID
+	}
+
+	if !s.valid {
+		return false, ErrDBClosed
+	}
+
+	return s.podExists(id)
 }
 
 // PodHasContainer checks if the given pod containers a container with the given
 // ID
 func (s *SQLState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
-	return false, ErrNotImplemented
+	const query = "SELECT 1 FROM containers WHERE Id=? AND Pod=?;"
+
+	if ctrID == "" {
+		return false, ErrEmptyID
+	}
+
+	if !s.valid {
+		return false, ErrDBClosed
+	}
+
+	if !pod.valid {
+		return false, ErrPodRemoved
+	}
+
+	row := s.db.QueryRow(query, ctrID, pod.ID())
+
+	var check int
+	err := row.Scan(&check)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+
+		return false, errors.Wrapf(err, "error questing database for existence of container %s", ctrID)
+	} else if check != 1 {
+		return false, errors.Wrapf(ErrInternal, "check digit for PodHasContainer query incorrect")
+	}
+
+
+	return true, nil
 }
 
 // PodContainersByID returns the container IDs of all containers in the given
 // pod
 func (s *SQLState) PodContainersByID(pod *Pod) ([]string, error) {
-	return nil, ErrNotImplemented
+	const query = "SELECT Id FROM containers WHERE Pod=?;"
+
+	if !s.valid {
+		return nil, ErrDBClosed
+	}
+
+	if !pod.valid {
+		return nil, ErrPodRemoved
+	}
+
+	// Check to make sure pod still exists in DB
+	exists, err := s.podExists(pod.ID())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		pod.valid = false
+		return nil, ErrPodRemoved
+	}
+
+	// Get actual containers
+	rows, err := s.db.Query(query, pod.ID())
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving containers from database")
+	}
+	defer rows.Close()
+
+	containers := []string{}
+
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			if err == sql.ErrNoRows {
+				return nil, ErrNoSuchCtr
+			}
+
+			return nil, errors.Wrapf(err, "error parsing database row into container ID")
+		}
+
+		containers = append(containers, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error retrieving container rows")
+	}
+
+
+	return containers, nil
 }
 
 // PodContainers returns all the containers in a pod given the pod's full ID
 func (s *SQLState) PodContainers(pod *Pod) ([]*Container, error) {
-	return nil, ErrNotImplemented
+	const query = containerQuery + "WHERE containers.Pod=?;"
+
+	if !s.valid {
+		return nil, ErrDBClosed
+	}
+
+	if !pod.valid {
+		return nil, ErrPodRemoved
+	}
+
+	// Check to make sure pod still exists in DB
+	exists, err := s.podExists(pod.ID())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		pod.valid = false
+		return nil, ErrPodRemoved
+	}
+
+	// Get actual containers
+	rows, err := s.db.Query(query, pod.ID())
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving containers from database")
+	}
+	defer rows.Close()
+
+	containers := []*Container{}
+
+	for rows.Next() {
+		ctr, err := s.ctrFromScannable(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		containers = append(containers, ctr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error retrieving container rows")
+	}
+
+	return containers, nil
 }
 
 // AddPod adds a pod to the state
 // Only empty pods can be added to the state
-func (s *SQLState) AddPod(pod *Pod) error {
-	return ErrNotImplemented
+func (s *SQLState) AddPod(pod *Pod) (err error) {
+	const query = "INSERT INTO pods VALUES (?, ?, ?);"
+
+	if !s.valid {
+		return ErrDBClosed
+	}
+
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	labelsJSON, err := json.Marshal(pod.labels)
+	if err != nil {
+		return errors.Wrapf(err, "error marshaling pod %s labels to JSON", pod.ID())
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return errors.Wrapf(err, "error beginning database transaction")
+	}
+	defer func() {
+		if err != nil {
+			if err2 := tx.Rollback(); err2 != nil {
+				logrus.Errorf("Error rolling back transaction to add pod %s: %v", pod.ID(), err2)
+			}
+		}
+	}()
+
+	_, err = tx.Exec(query, pod.ID(), pod.Name(), string(labelsJSON))
+	if err != nil {
+		return errors.Wrapf(err, "error adding pod %s to database", pod.ID())
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrapf(err, "error committing transaction to add pod %s", pod.ID())
+	}
+
+	return nil
 }
 
 // RemovePod removes a pod from the state
 // Only empty pods can be removed
 func (s *SQLState) RemovePod(pod *Pod) error {
-	return ErrNotImplemented
+	const query = "DELETE FROM pods WHERE ID=?;"
+
+	if !s.valid {
+		return ErrDBClosed
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return errors.Wrapf(err, "error beginning database transaction")
+	}
+	defer func() {
+		if err != nil {
+			if err2 := tx.Rollback(); err2 != nil {
+				logrus.Errorf("Error rolling back transaction to remove pod %s: %v", pod.ID(), err2)
+			}
+		}
+	}()
+
+	// Check rows acted on for the first transaction, verify we actually removed something
+	result, err := tx.Exec(query, pod.ID())
+	if err != nil {
+		return errors.Wrapf(err, "error removing pod %s from containers table", pod.ID())
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving number of rows in transaction removing pod %s", pod.ID())
+	} else if rows == 0 {
+		return ErrNoSuchPod
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrapf(err, "error committing transaction to remove pod %s", pod.ID())
+	}
+
+	return nil
 }
 
 // AddContainerToPod adds a container to the given pod
 func (s *SQLState) AddContainerToPod(pod *Pod, ctr *Container) error {
-	return ErrNotImplemented
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	if !ctr.valid {
+		return ErrCtrRemoved
+	}
+
+	if ctr.config.Pod != pod.ID() {
+		return errors.Wrapf(ErrInvalidArg, "container's pod ID does not match given pod's ID")
+	}
+
+	return s.addContainer(ctr)
 }
 
 // RemoveContainerFromPod removes a container from the given pod
 func (s *SQLState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
-	return ErrNotImplemented
+	if ctr.config.Pod != pod.ID() {
+		return errors.Wrapf(ErrInvalidArg, "container %s is not in pod %s", ctr.ID(), pod.ID())
+	}
+
+	return s.removeContainer(ctr)
 }
 
 // AllPods retrieves all pods presently in the state
 func (s *SQLState) AllPods() ([]*Pod, error) {
-	return nil, ErrNotImplemented
+	const query = "SELECT * FROM pods;"
+
+	if !s.valid {
+		return nil, ErrDBClosed
+	}
+
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error querying database for all pods")
+	}
+	defer rows.Close()
+
+	pods := []*Pod{}
+
+	for rows.Next() {
+		pod, err := s.podFromScannable(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		pods = append(pods, pod)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error retrieving pod rows")
+	}
+
+	return pods, nil
 }

--- a/libpod/sql_state.go
+++ b/libpod/sql_state.go
@@ -920,13 +920,11 @@ func (s *SQLState) RemovePodContainers(pod *Pod) (err error) {
 	// Remove state first, as it needs the subquery on containers
 	// Don't bother checking if we actually removed anything, we just want to
 	// empty the pod
-	_, err = tx.Exec(removeCtrState, pod.ID())
-	if err != nil {
+	if _, err := tx.Exec(removeCtrState, pod.ID()); err != nil {
 		return errors.Wrapf(err, "error removing pod %s containers from state table", pod.ID())
 	}
 
-	_, err = tx.Exec(removeCtr, pod.ID())
-	if err != nil {
+	if _, err := tx.Exec(removeCtr, pod.ID()); err != nil {
 		return errors.Wrapf(err, "error removing pod %s containers from containers table", pod.ID())
 	}
 

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -37,6 +37,7 @@ const (
                           FROM containers
                           INNER JOIN
                               containerState ON containers.Id = containerState.Id `
+	// ExistsQuery is a query to check if a pod exists
 	ExistsQuery = "SELECT 1 FROM pods WHERE Id=?;"
 )
 

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -672,8 +672,7 @@ func (s *SQLState) ctrFromScannable(row scannable) (*Container, error) {
 	// Retrieve the ports from disk
 	// They may not exist - if they don't, this container just doesn't have ports
 	portPath := getPortsPath(s.specsDir, id)
-	_, err = os.Stat(portPath)
-	if err != nil {
+	if _, err = os.Stat(portPath); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, errors.Wrapf(err, "error stating container %s JSON ports", id)
 		}

--- a/libpod/sql_state_internal.go
+++ b/libpod/sql_state_internal.go
@@ -195,7 +195,6 @@ func prepareDB(db *sql.DB) (err error) {
             RootfsImageID   TEXT    NOT NULL,
             RootfsImageName TEXT    NOT NULL,
             ImageVolumes    INTEGER NOT NULL,
-            ReadOnly        INTEGER NOT NULL,
             ShmDir          TEXT    NOT NULL,
             ShmSize         INTEGER NOT NULL,
             StaticDir       TEXT    NOT NULL,
@@ -230,7 +229,6 @@ func prepareDB(db *sql.DB) (err error) {
             CgroupParent    TEXT    NOT NULL,
 
             CHECK (ImageVolumes IN (0, 1)),
-            CHECK (ReadOnly IN (0, 1)),
             CHECK (SHMSize>=0),
             CHECK (Privileged IN (0, 1)),
             CHECK (NoNewPrivs IN (0, 1)),
@@ -403,7 +401,6 @@ func (s *SQLState) ctrFromScannable(row scannable) (*Container, error) {
 		rootfsImageID   string
 		rootfsImageName string
 		imageVolumes    int
-		readOnly        int
 		shmDir          string
 		shmSize         int64
 		staticDir       string
@@ -459,7 +456,6 @@ func (s *SQLState) ctrFromScannable(row scannable) (*Container, error) {
 		&rootfsImageID,
 		&rootfsImageName,
 		&imageVolumes,
-		&readOnly,
 		&shmDir,
 		&shmSize,
 		&staticDir,
@@ -524,7 +520,6 @@ func (s *SQLState) ctrFromScannable(row scannable) (*Container, error) {
 	ctr.config.RootfsImageID = rootfsImageID
 	ctr.config.RootfsImageName = rootfsImageName
 	ctr.config.ImageVolumes = boolFromSQL(imageVolumes)
-	ctr.config.ReadOnly = boolFromSQL(readOnly)
 	ctr.config.ShmDir = shmDir
 	ctr.config.ShmSize = shmSize
 	ctr.config.StaticDir = staticDir
@@ -718,7 +713,7 @@ func (s *SQLState) addContainer(ctr *Container) (err error) {
                     ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?
+                    ?, ?, ?, ?
                 );`
 		addCtrState = `INSERT INTO containerState VALUES (
                     ?, ?, ?, ?, ?,
@@ -800,7 +795,6 @@ func (s *SQLState) addContainer(ctr *Container) (err error) {
 		ctr.config.RootfsImageID,
 		ctr.config.RootfsImageName,
 		boolToSQL(ctr.config.ImageVolumes),
-		boolToSQL(ctr.config.ReadOnly),
 		ctr.config.ShmDir,
 		ctr.config.ShmSize,
 		ctr.config.StaticDir,

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -42,17 +42,17 @@ type State interface {
 	LookupPod(idOrName string) (*Pod, error)
 	// Checks if a pod with the given ID is present in the state
 	HasPod(id string) (bool, error)
-	// Get all the containers in a pod. Accepts full ID of pod.
-	PodContainers(id string) ([]*Container, error)
+	// Check if a pod has a container with the given ID
+	PodHasContainer(pod *Pod, ctrID string) (bool, error)
+	// Get the IDs of all containers in a pod
+	PodContainersByID(pod *Pod) ([]string, error)
+	// Get all the containers in a pod
+	PodContainers(pod *Pod) ([]*Container, error)
 	// Adds pod to state
-	// Only empty pods can be added to the state
 	AddPod(pod *Pod) error
 	// Removes pod from state
-	// Containers within a pod will not be removed from the state, and will
-	// not be changed to remove them from the now-removed pod
+	// Only empty pods can be removed from the state
 	RemovePod(pod *Pod) error
-	// UpdatePod updates a pod's state from the backing store
-	UpdatePod(pod *Pod) error
 	// AddContainerToPod adds a container to an existing pod
 	// The container given will be added to the state and the pod
 	AddContainerToPod(pod *Pod, ctr *Container) error

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -53,6 +53,11 @@ type State interface {
 	// Removes pod from state
 	// Only empty pods can be removed from the state
 	RemovePod(pod *Pod) error
+	// Remove all containers from a pod
+	// Used to simulataneously remove containers that might otherwise have
+	// dependency issues
+	// Will fail if a dependency outside the pod is encountered
+	RemovePodContainers(pod *Pod) error
 	// AddContainerToPod adds a container to an existing pod
 	// The container given will be added to the state and the pod
 	AddContainerToPod(pod *Pod, ctr *Container) error

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -1119,7 +1119,6 @@ func TestAddPodDuplicateNameFails(t *testing.T) {
 		err = state.AddPod(testPod2)
 		assert.Error(t, err)
 
-
 		allPods, err := state.AllPods()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(allPods))
@@ -1160,7 +1159,6 @@ func TestAddPodCtrIDConflictFails(t *testing.T) {
 		err = state.AddPod(testPod)
 		assert.Error(t, err)
 
-
 		allPods, err := state.AllPods()
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(allPods))
@@ -1180,7 +1178,6 @@ func TestAddPodCtrNameConflictFails(t *testing.T) {
 
 		err = state.AddPod(testPod)
 		assert.Error(t, err)
-
 
 		allPods, err := state.AllPods()
 		assert.NoError(t, err)
@@ -1270,7 +1267,6 @@ func TestRemovePodNotEmptyFails(t *testing.T) {
 		err = state.RemovePod(testPod)
 		assert.Error(t, err)
 
-
 		allPods, err := state.AllPods()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(allPods))
@@ -1305,7 +1301,7 @@ func TestRemovePodAfterEmptySucceeds(t *testing.T) {
 }
 
 func TestAllPodsEmptyOnEmptyState(t *testing.T) {
-	runForAllStates(t , func(t *testing.T, state State, lockPath string) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
 		allPods, err := state.AllPods()
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(allPods))

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,544 +80,834 @@ func getEmptySQLState() (s State, p string, p2 string, err error) {
 	return state, tmpDir, lockDir, nil
 }
 
-func runForAllStates(t *testing.T, testName string, testFunc func(*testing.T, State, string)) {
+func runForAllStates(t *testing.T, testFunc func(*testing.T, State, string)) {
 	for stateName, stateFunc := range testedStates {
 		state, path, lockPath, err := stateFunc()
 		if err != nil {
-			t.Fatalf("Error initializing state %s", stateName)
+			t.Fatalf("Error initializing state %s: %v", stateName, err)
 		}
 		defer os.RemoveAll(path)
 		defer state.Close()
 
-		testName = testName + "-" + stateName
-
-		success := t.Run(testName, func(t *testing.T) {
+		success := t.Run(stateName, func(t *testing.T) {
 			testFunc(t, state, lockPath)
 		})
 		if !success {
 			t.Fail()
-			t.Logf("%s failed for state %s", testName, stateName)
 		}
 	}
 }
 
-func TestAddAndGetContainer(t *testing.T) {
-	runForAllStates(t, "TestAddAndGetContainer", addAndGetContainer)
+func getTestCtrN(n, lockPath string) (*Container, error) {
+	return getTestContainer(strings.Repeat(n, 32), "test"+n, lockPath)
 }
 
-func addAndGetContainer(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+func getTestCtr1(lockPath string) (*Container, error) {
+	return getTestCtrN("1", lockPath)
+}
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+func getTestCtr2(lockPath string) (*Container, error) {
+	return getTestCtrN("2", lockPath)
+}
 
-	retrievedCtr, err := state.Container(testCtr.ID())
-	assert.NoError(t, err)
+func getTestPodN(n, lockPath string) (*Pod, error) {
+	return getTestPod(strings.Repeat(n, 32), "test"+n, lockPath)
+}
 
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr, retrievedCtr) {
-		assert.EqualValues(t, testCtr, retrievedCtr)
-	}
+func getTestPod1(lockPath string) (*Pod, error) {
+	return getTestPodN("1", lockPath)
+}
+
+func getTestPod2(lockPath string) (*Pod, error) {
+	return getTestPodN("2", lockPath)
+}
+
+func TestAddAndGetContainer(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		retrievedCtr, err := state.Container(testCtr.ID())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, retrievedCtr) {
+			assert.EqualValues(t, testCtr, retrievedCtr)
+		}
+	})
 }
 
 func TestAddAndGetContainerFromMultiple(t *testing.T) {
-	runForAllStates(t, "TestAddAndGetContainerFromMultiple", addAndGetContainerFromMultiple)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
+
+		retrievedCtr, err := state.Container(testCtr1.ID())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr1, retrievedCtr) {
+			assert.EqualValues(t, testCtr1, retrievedCtr)
+		}
+	})
 }
 
-func addAndGetContainerFromMultiple(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
-	assert.NoError(t, err)
+func TestGetContainerPodSameIDFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
-
-	retrievedCtr, err := state.Container(testCtr1.ID())
-	assert.NoError(t, err)
-
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr1, retrievedCtr) {
-		assert.EqualValues(t, testCtr1, retrievedCtr)
-	}
+		_, err = state.Container(testPod.ID())
+		assert.Error(t, err)
+	})
 }
 
 func TestAddInvalidContainerFails(t *testing.T) {
-	runForAllStates(t, "TestAddInvalidContainerFails", addInvalidContainerFails)
-}
-
-func addInvalidContainerFails(t *testing.T, state State, lockPath string) {
-	err := state.AddContainer(&Container{config: &ContainerConfig{ID: "1234"}})
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		err := state.AddContainer(&Container{config: &ContainerConfig{ID: "1234"}})
+		assert.Error(t, err)
+	})
 }
 
 func TestAddDuplicateCtrIDFails(t *testing.T) {
-	runForAllStates(t, "TestAddDuplicateCtrIDFails", addDuplicateCtrIDFails)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestContainer(testCtr1.ID(), "test2", lockPath)
+		assert.NoError(t, err)
 
-func addDuplicateCtrIDFails(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer(testCtr1.ID(), "test2", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
-
-	err = state.AddContainer(testCtr2)
-	assert.Error(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.Error(t, err)
+	})
 }
 
 func TestAddDuplicateCtrNameFails(t *testing.T) {
-	runForAllStates(t, "TestAddDuplicateCtrNameFails", addDuplicateCtrNameFails)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestContainer(strings.Repeat("2", 32), testCtr1.Name(), lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.Error(t, err)
+	})
 }
 
-func addDuplicateCtrNameFails(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", testCtr1.Name(), lockPath)
-	assert.NoError(t, err)
+func TestAddCtrPodDupIDFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+		testCtr, err := getTestContainer(testPod.ID(), "testCtr", lockPath)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.Error(t, err)
+		err = state.AddContainer(testCtr)
+		assert.Error(t, err)
+	})
+}
+
+func TestAddCtrPodDupNameFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+		testCtr, err := getTestContainer(strings.Repeat("2", 32), testPod.Name(), lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.Error(t, err)
+	})
 }
 
 func TestGetNonexistentContainerFails(t *testing.T) {
-	runForAllStates(t, "TestGetNonexistentContainerFails", getNonexistentContainerFails)
-}
-
-func getNonexistentContainerFails(t *testing.T, state State, lockPath string) {
-	_, err := state.Container("does not exist")
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.Container("does not exist")
+		assert.Error(t, err)
+	})
 }
 
 func TestGetContainerWithEmptyIDFails(t *testing.T) {
-	runForAllStates(t, "TestGetContainerWithEmptyIDFails", getContainerWithEmptyIDFails)
-}
-
-func getContainerWithEmptyIDFails(t *testing.T, state State, lockPath string) {
-	_, err := state.Container("")
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.Container("")
+		assert.Error(t, err)
+	})
 }
 
 func TestLookupContainerWithEmptyIDFails(t *testing.T) {
-	runForAllStates(t, "TestLookupContainerWithEmptyIDFails", lookupContainerWithEmptyIDFails)
-}
-
-func lookupContainerWithEmptyIDFails(t *testing.T, state State, lockPath string) {
-	_, err := state.LookupContainer("")
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.LookupContainer("")
+		assert.Error(t, err)
+	})
 }
 
 func TestLookupNonexistentContainerFails(t *testing.T) {
-	runForAllStates(t, "TestLookupNonexistantContainerFails", lookupNonexistentContainerFails)
-}
-
-func lookupNonexistentContainerFails(t *testing.T, state State, lockPath string) {
-	_, err := state.LookupContainer("does not exist")
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.LookupContainer("does not exist")
+		assert.Error(t, err)
+	})
 }
 
 func TestLookupContainerByFullID(t *testing.T) {
-	runForAllStates(t, "TestLookupContainerByFullID", lookupContainerByFullID)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func lookupContainerByFullID(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		retrievedCtr, err := state.LookupContainer(testCtr.ID())
+		assert.NoError(t, err)
 
-	retrievedCtr, err := state.LookupContainer(testCtr.ID())
-	assert.NoError(t, err)
-
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr, retrievedCtr) {
-		assert.EqualValues(t, testCtr, retrievedCtr)
-	}
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, retrievedCtr) {
+			assert.EqualValues(t, testCtr, retrievedCtr)
+		}
+	})
 }
 
 func TestLookupContainerByUniquePartialID(t *testing.T) {
-	runForAllStates(t, "TestLookupContainerByUniquePartialID", lookupContainerByUniquePartialID)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func lookupContainerByUniquePartialID(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		retrievedCtr, err := state.LookupContainer(testCtr.ID()[0:8])
+		assert.NoError(t, err)
 
-	retrievedCtr, err := state.LookupContainer(testCtr.ID()[0:8])
-	assert.NoError(t, err)
-
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr, retrievedCtr) {
-		assert.EqualValues(t, testCtr, retrievedCtr)
-	}
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, retrievedCtr) {
+			assert.EqualValues(t, testCtr, retrievedCtr)
+		}
+	})
 }
 
 func TestLookupContainerByNonUniquePartialIDFails(t *testing.T) {
-	runForAllStates(t, "TestLookupContainerByNonUniquePartialIDFails", lookupContainerByNonUniquePartialIDFails)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestContainer(strings.Repeat("0", 32), "test1", lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestContainer(strings.Repeat("0", 31)+"1", "test2", lockPath)
+		assert.NoError(t, err)
 
-func lookupContainerByNonUniquePartialIDFails(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("00000000000000000000000000000000", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("00000000000000000000000000000001", "test2", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
-
-	_, err = state.LookupContainer(testCtr1.ID()[0:8])
-	assert.Error(t, err)
+		_, err = state.LookupContainer(testCtr1.ID()[0:8])
+		assert.Error(t, err)
+	})
 }
 
 func TestLookupContainerByName(t *testing.T) {
-	runForAllStates(t, "TestLookupContainerByName", lookupContainerByName)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		retrievedCtr, err := state.LookupContainer(testCtr.Name())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, retrievedCtr) {
+			assert.EqualValues(t, testCtr, retrievedCtr)
+		}
+	})
 }
 
-func lookupContainerByName(t *testing.T, state State, lockPath string) {
-	state, path, lockPath, err := getEmptySQLState()
-	assert.NoError(t, err)
-	defer os.RemoveAll(path)
-	defer state.Close()
+func TestLookupCtrByPodNameFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
 
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		_, err = state.LookupContainer(testPod.Name())
+		assert.Error(t, err)
+	})
+}
 
-	retrievedCtr, err := state.LookupContainer(testCtr.Name())
-	assert.NoError(t, err)
+func TestLookupCtrByPodIDFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
 
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr, retrievedCtr) {
-		assert.EqualValues(t, testCtr, retrievedCtr)
-	}
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		_, err = state.LookupContainer(testPod.ID())
+		assert.Error(t, err)
+	})
 }
 
 func TestHasContainerEmptyIDFails(t *testing.T) {
-	runForAllStates(t, "TestHasContainerEmptyIDFails", hasContainerEmptyIDFails)
-}
-
-func hasContainerEmptyIDFails(t *testing.T, state State, lockPath string) {
-	_, err := state.HasContainer("")
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.HasContainer("")
+		assert.Error(t, err)
+	})
 }
 
 func TestHasContainerNoSuchContainerReturnsFalse(t *testing.T) {
-	runForAllStates(t, "TestHasContainerNoSuchContainerReturnsFalse", hasContainerNoSuchContainerReturnsFalse)
-}
-
-func hasContainerNoSuchContainerReturnsFalse(t *testing.T, state State, lockPath string) {
-	exists, err := state.HasContainer("does not exist")
-	assert.NoError(t, err)
-	assert.False(t, exists)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		exists, err := state.HasContainer("does not exist")
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
 }
 
 func TestHasContainerFindsContainer(t *testing.T) {
-	runForAllStates(t, "TestHasContainerFindsContainer", hasContainerFindsContainer)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		exists, err := state.HasContainer(testCtr.ID())
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
 }
 
-func hasContainerFindsContainer(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+func TestHasContainerPodIDIsFalse(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
 
-	exists, err := state.HasContainer(testCtr.ID())
-	assert.NoError(t, err)
-	assert.True(t, exists)
+		exists, err := state.HasContainer(testPod.ID())
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
 }
 
 func TestSaveAndUpdateContainer(t *testing.T) {
-	runForAllStates(t, "TestSaveAndUpdateContainer", saveAndUpdateContainer)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func saveAndUpdateContainer(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		retrievedCtr, err := state.Container(testCtr.ID())
+		assert.NoError(t, err)
 
-	retrievedCtr, err := state.Container(testCtr.ID())
-	assert.NoError(t, err)
+		retrievedCtr.state.State = ContainerStateStopped
+		retrievedCtr.state.ExitCode = 127
+		retrievedCtr.state.FinishedTime = time.Now()
 
-	retrievedCtr.state.State = ContainerStateStopped
-	retrievedCtr.state.ExitCode = 127
-	retrievedCtr.state.FinishedTime = time.Now()
+		err = state.SaveContainer(retrievedCtr)
+		assert.NoError(t, err)
 
-	err = state.SaveContainer(retrievedCtr)
-	assert.NoError(t, err)
+		err = state.UpdateContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.UpdateContainer(testCtr)
-	assert.NoError(t, err)
-
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr, retrievedCtr) {
-		assert.EqualValues(t, testCtr, retrievedCtr)
-	}
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, retrievedCtr) {
+			assert.EqualValues(t, testCtr, retrievedCtr)
+		}
+	})
 }
 
 func TestUpdateContainerNotInDatabaseReturnsError(t *testing.T) {
-	runForAllStates(t, "TestUpdateContainerNotInDatabaseReturnsError", updateContainerNotInDatabaseReturnsError)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func updateContainerNotInDatabaseReturnsError(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
-
-	err = state.UpdateContainer(testCtr)
-	assert.Error(t, err)
-	assert.False(t, testCtr.valid)
+		err = state.UpdateContainer(testCtr)
+		assert.Error(t, err)
+		assert.False(t, testCtr.valid)
+	})
 }
 
 func TestUpdateInvalidContainerReturnsError(t *testing.T) {
-	runForAllStates(t, "TestUpdateInvalidContainerReturnsError", updateInvalidContainerReturnsError)
-}
-
-func updateInvalidContainerReturnsError(t *testing.T, state State, lockPath string) {
-	err := state.UpdateContainer(&Container{config: &ContainerConfig{ID: "1234"}})
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		err := state.UpdateContainer(&Container{config: &ContainerConfig{ID: "1234"}})
+		assert.Error(t, err)
+	})
 }
 
 func TestSaveInvalidContainerReturnsError(t *testing.T) {
-	runForAllStates(t, "TestSaveInvalidContainerReturnsError", saveInvalidContainerReturnsError)
-}
-
-func saveInvalidContainerReturnsError(t *testing.T, state State, lockPath string) {
-	err := state.SaveContainer(&Container{config: &ContainerConfig{ID: "1234"}})
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		err := state.SaveContainer(&Container{config: &ContainerConfig{ID: "1234"}})
+		assert.Error(t, err)
+	})
 }
 
 func TestSaveContainerNotInStateReturnsError(t *testing.T) {
-	runForAllStates(t, "TestSaveContainerNotInStateReturnsError", saveContainerNotInStateReturnsError)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func saveContainerNotInStateReturnsError(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
-
-	err = state.SaveContainer(testCtr)
-	assert.Error(t, err)
-	assert.False(t, testCtr.valid)
+		err = state.SaveContainer(testCtr)
+		assert.Error(t, err)
+		assert.False(t, testCtr.valid)
+	})
 }
 
 func TestRemoveContainer(t *testing.T) {
-	runForAllStates(t, "TestRemoveContainer", removeContainer)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func removeContainer(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
 
-	ctrs, err := state.AllContainers()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(ctrs))
+		err = state.RemoveContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.RemoveContainer(testCtr)
-	assert.NoError(t, err)
-
-	ctrs2, err := state.AllContainers()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(ctrs2))
+		ctrs2, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs2))
+	})
 }
 
 func TestRemoveNonexistantContainerFails(t *testing.T) {
-	runForAllStates(t, "TestRemoveNonexistantContainerFails", removeNonexistantContainerFails)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func removeNonexistantContainerFails(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
-
-	err = state.RemoveContainer(testCtr)
-	assert.Error(t, err)
+		err = state.RemoveContainer(testCtr)
+		assert.Error(t, err)
+	})
 }
 
 func TestGetAllContainersOnNewStateIsEmpty(t *testing.T) {
-	runForAllStates(t, "TestGetAllContainersOnNewStateIsEmpty", getAllContainersOnNewStateIsEmpty)
-}
-
-func getAllContainersOnNewStateIsEmpty(t *testing.T, state State, lockPath string) {
-	ctrs, err := state.AllContainers()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(ctrs))
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
 }
 
 func TestGetAllContainersWithOneContainer(t *testing.T) {
-	runForAllStates(t, "TestGetAllContainersWithOneContainer", getAllContainersWithOneContainer)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
 
-func getAllContainersWithOneContainer(t *testing.T, state State, lockPath string) {
-	testCtr, err := getTestContainer("0123456789ABCDEF0123456789ABCDEF", "test", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr)
-	assert.NoError(t, err)
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
 
-	ctrs, err := state.AllContainers()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(ctrs))
-
-	// Use assert.EqualValues if the test fails to pretty print diff
-	// between actual and expected
-	if !testContainersEqual(testCtr, ctrs[0]) {
-		assert.EqualValues(t, testCtr, ctrs[0])
-	}
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, ctrs[0]) {
+			assert.EqualValues(t, testCtr, ctrs[0])
+		}
+	})
 }
 
 func TestGetAllContainersTwoContainers(t *testing.T) {
-	runForAllStates(t, "TestGetAllContainersTwoContainers", getAllContainersTwoContainers)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
 
-func getAllContainersTwoContainers(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
-
-	ctrs, err := state.AllContainers()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(ctrs))
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ctrs))
+	})
 }
 
 func TestContainerInUseInvalidContainer(t *testing.T) {
-	runForAllStates(t, "TestContainerInUseInvalidContainer", containerInUseInvalidContainer)
-}
-
-func containerInUseInvalidContainer(t *testing.T, state State, lockPath string) {
-	_, err := state.ContainerInUse(&Container{})
-	assert.Error(t, err)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.ContainerInUse(&Container{})
+		assert.Error(t, err)
+	})
 }
 
 func TestContainerInUseOneContainer(t *testing.T) {
-	runForAllStates(t, "TestContainerInUseOneContainer", containerInUseOneContainer)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
 
-func containerInUseOneContainer(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
-	assert.NoError(t, err)
+		testCtr2.config.UserNsCtr = testCtr1.config.ID
 
-	testCtr2.config.UserNsCtr = testCtr1.config.ID
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
-
-	ids, err := state.ContainerInUse(testCtr1)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(ids))
-	assert.Equal(t, testCtr2.config.ID, ids[0])
+		ids, err := state.ContainerInUse(testCtr1)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ids))
+		assert.Equal(t, testCtr2.config.ID, ids[0])
+	})
 }
 
 func TestContainerInUseTwoContainers(t *testing.T) {
-	runForAllStates(t, "TestContainerInUseTwoContainers", containerInUseTwoContainers)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr3, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+
+		testCtr2.config.UserNsCtr = testCtr1.config.ID
+		testCtr3.config.IPCNsCtr = testCtr1.config.ID
+
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr3)
+		assert.NoError(t, err)
+
+		ids, err := state.ContainerInUse(testCtr1)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ids))
+	})
 }
 
-func containerInUseTwoContainers(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
-	assert.NoError(t, err)
-	testCtr3, err := getTestContainer("33333333333333333333333333333333", "test3", lockPath)
-	assert.NoError(t, err)
+func TestContainerInUseOneContainerMultipleDependencies(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
 
-	testCtr2.config.UserNsCtr = testCtr1.config.ID
-	testCtr3.config.IPCNsCtr = testCtr1.config.ID
+		testCtr2.config.UserNsCtr = testCtr1.config.ID
+		testCtr2.config.IPCNsCtr = testCtr1.config.ID
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr3)
-	assert.NoError(t, err)
-
-	ids, err := state.ContainerInUse(testCtr1)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(ids))
+		ids, err := state.ContainerInUse(testCtr1)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ids))
+		assert.Equal(t, testCtr2.config.ID, ids[0])
+	})
 }
 
 func TestCannotRemoveContainerWithDependency(t *testing.T) {
-	runForAllStates(t, "TestCannotRemoveContainerWithDependency", cannotRemoveContainerWithDependency)
-}
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
 
-func cannotRemoveContainerWithDependency(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
-	assert.NoError(t, err)
+		testCtr2.config.UserNsCtr = testCtr1.config.ID
 
-	testCtr2.config.UserNsCtr = testCtr1.config.ID
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
-
-	err = state.RemoveContainer(testCtr1)
-	assert.Error(t, err)
+		err = state.RemoveContainer(testCtr1)
+		assert.Error(t, err)
+	})
 }
 
 func TestCanRemoveContainerAfterDependencyRemoved(t *testing.T) {
-	runForAllStates(t, "TestCanRemoveContainerAfterDependencyRemoved", canRemoveContainerAfterDependencyRemoved)
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr2.config.UserNsCtr = testCtr1.ID()
+
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainer(testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainer(testCtr1)
+		assert.NoError(t, err)
+	})
 }
 
-func canRemoveContainerAfterDependencyRemoved(t *testing.T, state State, lockPath string) {
-	testCtr1, err := getTestContainer("11111111111111111111111111111111", "test1", lockPath)
-	assert.NoError(t, err)
-	testCtr2, err := getTestContainer("22222222222222222222222222222222", "test2", lockPath)
-	assert.NoError(t, err)
+func TestCanRemoveContainerAfterDependencyRemovedDuplicate(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr1, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		testCtr2, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
 
-	testCtr2.config.UserNsCtr = testCtr1.config.ID
+		testCtr2.config.UserNsCtr = testCtr1.ID()
+		testCtr2.config.IPCNsCtr = testCtr1.ID()
 
-	err = state.AddContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
 
-	err = state.AddContainer(testCtr2)
-	assert.NoError(t, err)
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.RemoveContainer(testCtr2)
-	assert.NoError(t, err)
+		err = state.RemoveContainer(testCtr2)
+		assert.NoError(t, err)
 
-	err = state.RemoveContainer(testCtr1)
-	assert.NoError(t, err)
+		err = state.RemoveContainer(testCtr1)
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetPodDoesNotExist(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.Pod("doesnotexist")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetPodEmptyID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.Pod("")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetPodOnePod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		statePod, err := state.Pod(testPod.ID())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod, statePod) {
+			assert.EqualValues(t, testPod, statePod)
+		}
+	})
+}
+
+func TestGetOnePodFromTwo(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.NoError(t, err)
+
+		statePod, err := state.Pod(testPod1.ID())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod1, statePod) {
+			assert.EqualValues(t, testPod1, statePod)
+		}
+	})
+}
+
+func TestGetNotExistPodWithPods(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.NoError(t, err)
+
+		_, err = state.Pod("notexist")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetPodByCtrID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		_, err = state.Pod(testCtr.ID())
+		assert.Error(t, err)
+	})
+}
+
+func TestLookupPodEmptyID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.LookupPod("")
+		assert.Error(t, err)
+	})
+}
+
+func TestLookupNotExistPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.LookupPod("doesnotexist")
+		assert.Error(t, err)
+	})
+}
+
+func TestLookupPodFullID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		statePod, err := state.LookupPod(testPod.ID())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod, statePod) {
+			assert.EqualValues(t, testPod, statePod)
+		}
+	})
+}
+
+func TestLookupPodUniquePartialID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		statePod, err := state.LookupPod(testPod.ID()[0:8])
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod, statePod) {
+			assert.EqualValues(t, testPod, statePod)
+		}
+	})
+}
+
+func TestLookupPodNonUniquePartialID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod(strings.Repeat("1", 32), "test1", lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod(strings.Repeat("1", 31)+"2", "test2", lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.NoError(t, err)
+
+		_, err = state.LookupPod(testPod1.ID()[0:8])
+		assert.Error(t, err)
+	})
+}
+
+func TestLookupPodByName(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		statePod, err := state.LookupPod(testPod.Name())
+		assert.NoError(t, err)
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod, statePod) {
+			assert.EqualValues(t, testPod, statePod)
+		}
+	})
+}
+
+func TestLookupPodByCtrID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		_, err = state.LookupPod(testCtr.ID())
+		assert.Error(t, err)
+	})
+}
+
+func TestLookupPodByCtrName(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		_, err = state.LookupPod(testCtr.Name())
+		assert.Error(t, err)
+	})
 }

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -197,6 +197,10 @@ func TestAddDuplicateCtrIDFails(t *testing.T) {
 
 		err = state.AddContainer(testCtr2)
 		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
 	})
 }
 
@@ -212,6 +216,10 @@ func TestAddDuplicateCtrNameFails(t *testing.T) {
 
 		err = state.AddContainer(testCtr2)
 		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
 	})
 }
 
@@ -227,6 +235,10 @@ func TestAddCtrPodDupIDFails(t *testing.T) {
 
 		err = state.AddContainer(testCtr)
 		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
 	})
 }
 
@@ -242,6 +254,32 @@ func TestAddCtrPodDupNameFails(t *testing.T) {
 
 		err = state.AddContainer(testCtr)
 		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestAddCtrInPodFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
 	})
 }
 
@@ -510,6 +548,7 @@ func TestRemoveNonexistantContainerFails(t *testing.T) {
 
 		err = state.RemoveContainer(testCtr)
 		assert.Error(t, err)
+		assert.False(t, testCtr.valid)
 	})
 }
 
@@ -656,6 +695,10 @@ func TestCannotRemoveContainerWithDependency(t *testing.T) {
 
 		err = state.RemoveContainer(testCtr1)
 		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ctrs))
 	})
 }
 
@@ -679,6 +722,10 @@ func TestCanRemoveContainerAfterDependencyRemoved(t *testing.T) {
 
 		err = state.RemoveContainer(testCtr1)
 		assert.NoError(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
 	})
 }
 
@@ -703,6 +750,48 @@ func TestCanRemoveContainerAfterDependencyRemovedDuplicate(t *testing.T) {
 
 		err = state.RemoveContainer(testCtr1)
 		assert.NoError(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestCannotUsePodAsDependency(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		testPod, err := getTestPod2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr.config.UserNsCtr = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestCannotUseBadIDAsDependency(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr.config.UserNsCtr = strings.Repeat("5", 32)
+
+		err = state.AddContainer(testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
 	})
 }
 
@@ -909,5 +998,1351 @@ func TestLookupPodByCtrName(t *testing.T) {
 
 		_, err = state.LookupPod(testCtr.Name())
 		assert.Error(t, err)
+	})
+}
+
+func TestHasPodEmptyIDErrors(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.HasPod("")
+		assert.Error(t, err)
+	})
+}
+
+func TestHasPodNoSuchPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		exist, err := state.HasPod("notexist")
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+}
+
+func TestHasPodWrongIDFalse(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		exist, err := state.HasPod(strings.Repeat("a", 32))
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+}
+
+func TestHasPodRightIDTrue(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		exist, err := state.HasPod(testPod.ID())
+		assert.NoError(t, err)
+		assert.True(t, exist)
+	})
+}
+
+func TestHasPodCtrIDFalse(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		exist, err := state.HasPod(testCtr.ID())
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+}
+
+func TestAddPodInvalidPodErrors(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		err := state.AddPod(&Pod{})
+		assert.Error(t, err)
+	})
+}
+
+func TestAddPodValidPodSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod, allPods[0]) {
+			assert.EqualValues(t, testPod, allPods[0])
+		}
+	})
+}
+
+func TestAddPodDuplicateIDFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod(testPod1.ID(), "testpod2", lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.Error(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+	})
+}
+
+func TestAddPodDuplicateNameFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod(strings.Repeat("2", 32), testPod1.Name(), lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.Error(t, err)
+
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+	})
+}
+
+func TestAddPodNonDuplicateSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(allPods))
+	})
+}
+
+func TestAddPodCtrIDConflictFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		testPod, err := getTestPod(testCtr.ID(), "testpod1", lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.Error(t, err)
+
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods))
+	})
+}
+
+func TestAddPodCtrNameConflictFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		testPod, err := getTestPod(strings.Repeat("3", 32), testCtr.Name(), lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.Error(t, err)
+
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods))
+	})
+}
+
+func TestRemovePodInvalidPodErrors(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		err := state.RemovePod(&Pod{})
+		assert.Error(t, err)
+	})
+}
+
+func TestRemovePodNotInStateFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.RemovePod(testPod)
+		assert.Error(t, err)
+		assert.False(t, testPod.valid)
+	})
+}
+
+func TestRemovePodSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.RemovePod(testPod)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods))
+	})
+}
+
+func TestRemovePodFromPods(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod2)
+		assert.NoError(t, err)
+
+		err = state.RemovePod(testPod1)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod2, allPods[0]) {
+			assert.EqualValues(t, testPod2, allPods[0])
+		}
+	})
+}
+
+func TestRemovePodNotEmptyFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		err = state.RemovePod(testPod)
+		assert.Error(t, err)
+
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+	})
+}
+
+func TestRemovePodAfterEmptySucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		err = state.RemovePod(testPod)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods))
+	})
+}
+
+func TestAllPodsEmptyOnEmptyState(t *testing.T) {
+	runForAllStates(t , func(t *testing.T, state State, lockPath string) {
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods))
+	})
+}
+
+func TestAllPodsFindsPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testPodsEqual(testPod, allPods[0]) {
+			assert.EqualValues(t, testPod, allPods[0])
+		}
+	})
+}
+
+func TestAllPodsMultiplePods(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod1, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod2, err := getTestPod2(lockPath)
+		assert.NoError(t, err)
+
+		testPod3, err := getTestPodN("3", lockPath)
+		assert.NoError(t, err)
+
+		allPods1, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods1))
+
+		err = state.AddPod(testPod1)
+		assert.NoError(t, err)
+
+		allPods2, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods2))
+
+		err = state.AddPod(testPod2)
+		assert.NoError(t, err)
+
+		allPods3, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(allPods3))
+
+		err = state.AddPod(testPod3)
+		assert.NoError(t, err)
+
+		allPods4, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(allPods4))
+	})
+}
+
+func TestPodHasContainerNoSuchPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.PodHasContainer(&Pod{}, strings.Repeat("0", 32))
+		assert.Error(t, err)
+	})
+}
+
+func TestPodHasContainerEmptyCtrID(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		_, err = state.PodHasContainer(testPod, "")
+		assert.Error(t, err)
+	})
+}
+
+func TestPodHasContainerNoSuchCtr(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		exist, err := state.PodHasContainer(testPod, strings.Repeat("2", 32))
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+}
+
+func TestPodHasContainerCtrNotInPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		exist, err := state.PodHasContainer(testPod, testCtr.ID())
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+}
+
+func TestPodHasContainerSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		exist, err := state.PodHasContainer(testPod, testCtr.ID())
+		assert.NoError(t, err)
+		assert.True(t, exist)
+	})
+}
+
+func TestPodContainersByIDInvalidPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.PodContainersByID(&Pod{})
+		assert.Error(t, err)
+	})
+}
+
+func TestPodContainerdByIDPodNotInState(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		_, err = state.PodContainersByID(testPod)
+		assert.Error(t, err)
+		assert.False(t, testPod.valid)
+	})
+}
+
+func TestPodContainersByIDEmptyPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestPodContainersByIDOneContainer(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
+		assert.Equal(t, testCtr.ID(), ctrs[0])
+	})
+}
+
+func TestPodContainersByIDMultipleContainers(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+
+		testCtr3, err := getTestCtrN("4", lockPath)
+		assert.NoError(t, err)
+		testCtr3.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		ctrs0, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs0))
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		ctrs1, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs1))
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		ctrs2, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ctrs2))
+
+		err = state.AddContainerToPod(testPod, testCtr3)
+		assert.NoError(t, err)
+
+		ctrs3, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(ctrs3))
+	})
+}
+
+func TestPodContainersInvalidPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		_, err := state.PodContainers(&Pod{})
+		assert.Error(t, err)
+	})
+}
+
+func TestPodContainerdPodNotInState(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		_, err = state.PodContainers(testPod)
+		assert.Error(t, err)
+		assert.False(t, testPod.valid)
+	})
+}
+
+func TestPodContainersEmptyPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestPodContainersOneContainer(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, ctrs[0]) {
+			assert.EqualValues(t, testCtr, ctrs[0])
+		}
+	})
+}
+
+func TestPodContainersMultipleContainers(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+
+		testCtr3, err := getTestCtrN("4", lockPath)
+		assert.NoError(t, err)
+		testCtr3.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		ctrs0, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs0))
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		ctrs1, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs1))
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		ctrs2, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ctrs2))
+
+		err = state.AddContainerToPod(testPod, testCtr3)
+		assert.NoError(t, err)
+
+		ctrs3, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(ctrs3))
+	})
+}
+
+func TestRemovePodContainersInvalidPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		err := state.RemovePodContainers(&Pod{})
+		assert.Error(t, err)
+	})
+}
+
+func TestRemovePodContainersPodNotInState(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		assert.Error(t, err)
+		assert.False(t, testPod.valid)
+	})
+}
+
+func TestRemovePodContainersNoContainers(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestRemovePodContainersOneContainer(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestRemovePodContainersPreservesCtrOutsidePod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allCtrs))
+	})
+}
+
+func TestRemovePodContainersTwoContainers(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestRemovePodContainerDependencyInPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+		testCtr2.config.IPCNsCtr = testCtr1.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestRemovePodContainerDependencyNotInPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.IPCNsCtr = testCtr1.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemovePodContainers(testPod)
+		t.Logf("Err %v", err)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
+	})
+}
+
+func TestAddContainerToPodInvalidPod(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(&Pod{}, testCtr)
+		assert.Error(t, err)
+	})
+}
+
+func TestAddContainerToPodInvalidCtr(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, &Container{config: &ContainerConfig{ID: "1234"}})
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainersByID(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestAddContainerToPodPodNotInState(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.Error(t, err)
+		assert.False(t, testPod.valid)
+	})
+}
+
+func TestAddContainerToPodSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allCtrs))
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr, ctrs[0]) {
+			assert.EqualValues(t, testCtr, ctrs[0])
+		}
+		if !testContainersEqual(allCtrs[0], ctrs[0]) {
+			assert.EqualValues(t, allCtrs[0], ctrs[0])
+		}
+	})
+}
+
+func TestAddContainerToPodTwoContainers(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(allCtrs))
+	})
+}
+
+func TestAddContainerToPodWithAddContainer(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr2)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(allCtrs))
+
+		// Use assert.EqualValues if the test fails to pretty print diff
+		// between actual and expected
+		if !testContainersEqual(testCtr1, ctrs[0]) {
+			assert.EqualValues(t, testCtr1, ctrs[0])
+		}
+	})
+}
+
+func TestAddContainerToPodCtrIDConflict(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr2, err := getTestContainer(testCtr1.ID(), "testCtr3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allCtrs))
+	})
+}
+
+func TestAddContainerToPodCtrNameConflict(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		testCtr2, err := getTestContainer(strings.Repeat("4", 32), testCtr1.Name(), lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allCtrs))
+	})
+}
+
+func TestAddContainerToPodPodIDConflict(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestContainer(testPod.ID(), "testCtr", lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allCtrs))
+	})
+}
+
+func TestAddContainerToPodPodNameConflict(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestContainer(strings.Repeat("2", 32), testPod.Name(), lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allCtrs))
+	})
+}
+
+func TestAddContainerToPodAddsDependencies(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+		testCtr2.config.IPCNsCtr = testCtr1.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		deps, err := state.ContainerInUse(testCtr1)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(deps))
+		assert.Equal(t, testCtr2.ID(), deps[0])
+	})
+}
+
+func TestAddContainerToPodPodDependencyFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+		testCtr.config.IPCNsCtr = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestAddContainerToPodBadDependencyFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+		testCtr.config.IPCNsCtr = strings.Repeat("8", 32)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+	})
+}
+
+func TestRemoveContainerFromPodBadPodFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(&Pod{}, testCtr)
+		assert.Error(t, err)
+	})
+}
+
+func TestRemoveContainerFromPodPodNotInStateFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.RemoveContainerFromPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		assert.False(t, testPod.valid)
+	})
+}
+
+func TestRemoveContainerFromPodCtrNotInStateFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		assert.False(t, testCtr.valid)
+	})
+}
+
+func TestRemoveContainerFromPodCtrNotInPodFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr)
+		assert.Error(t, err)
+
+		assert.True(t, testCtr.valid)
+
+		ctrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(ctrs))
+	})
+}
+
+func TestRemoveContainerFromPodSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr.config.Pod = testPod.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allCtrs))
+	})
+}
+
+func TestRemoveContainerFromPodWithDependencyFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+		testCtr2.config.IPCNsCtr = testCtr1.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr1)
+		assert.Error(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(allCtrs))
+	})
+}
+
+func TestRemoveContainerFromPodWithDependencySucceedsAfterDepRemoved(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testCtr1, err := getTestCtr2(lockPath)
+		assert.NoError(t, err)
+		testCtr1.config.Pod = testPod.ID()
+
+		testCtr2, err := getTestCtrN("3", lockPath)
+		assert.NoError(t, err)
+		testCtr2.config.Pod = testPod.ID()
+		testCtr2.config.IPCNsCtr = testCtr1.ID()
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		err = state.AddContainerToPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr2)
+		assert.NoError(t, err)
+
+		err = state.RemoveContainerFromPod(testPod, testCtr1)
+		assert.NoError(t, err)
+
+		ctrs, err := state.PodContainers(testPod)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(ctrs))
+
+		allCtrs, err := state.AllContainers()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allCtrs))
 	})
 }

--- a/libpod/test_common.go
+++ b/libpod/test_common.go
@@ -21,7 +21,6 @@ func getTestContainer(id, name, locksDir string) (*Container, error) {
 			RootfsImageID:   id,
 			RootfsImageName: "testimg",
 			ImageVolumes:    true,
-			ReadOnly:        true,
 			StaticDir:       "/does/not/exist/",
 			LogPath:         "/does/not/exist/",
 			Stdin:           true,

--- a/vendor/github.com/mattn/go-sqlite3/sqlite3.go
+++ b/vendor/github.com/mattn/go-sqlite3/sqlite3.go
@@ -313,7 +313,7 @@ func (ai *aggInfo) Done(ctx *C.sqlite3_context) {
 // Commit transaction.
 func (tx *SQLiteTx) Commit() error {
 	_, err := tx.c.exec(context.Background(), "COMMIT", nil)
-	if err != nil && err.(Error).Code == C.SQLITE_BUSY {
+	if err != nil { // && err.(Error).Code == C.SQLITE_BUSY {
 		// sqlite3 will leave the transaction open in this scenario.
 		// However, database/sql considers the transaction complete once we
 		// return from Commit() - we must clean up to honour its semantics.


### PR DESCRIPTION
Finish backend work for pods. Implement basic pod operations in both in-memory and SQL states. Implement runtime's RemovePod.

Also yanks ReadOnly out of the database as that's in the spec already

Still needs: More unit tests, unified pod/container name and ID registries to ensure that pods and containers cannot share names and/or IDs