### PR TITLE
Add StopWithTimeout API function for containers

### DIFF
--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -101,7 +101,7 @@ func stopCmd(c *cli.Context) error {
 		} else {
 			stopTimeout = ctr.StopTimeout()
 		}
-		if err := ctr.Stop(stopTimeout); err != nil {
+		if err := ctr.StopWithTimeout(stopTimeout); err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -299,7 +299,7 @@ func (r *Runtime) Shutdown(force bool) error {
 			logrus.Errorf("Error retrieving containers from database: %v", err)
 		} else {
 			for _, ctr := range ctrs {
-				if err := ctr.Stop(CtrRemoveTimeout); err != nil {
+				if err := ctr.StopWithTimeout(CtrRemoveTimeout); err != nil {
 					logrus.Errorf("Error stopping container %s: %v", ctr.ID(), err)
 				}
 			}


### PR DESCRIPTION
Normal Stop should not need a timeout, and should use the default. Add a function that does accept a timeout aside it so we still have the ability to set timeouts.
