### PR TITLE
libpod/container_api: Set hostname in ENV

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -268,6 +268,9 @@ func (c *Container) Init() (err error) {
 	c.runningSpec.Annotations[crioAnnotations.Created] = c.config.CreatedTime.Format(time.RFC3339Nano)
 	c.runningSpec.Annotations["org.opencontainers.image.stopSignal"] = fmt.Sprintf("%d", c.config.StopSignal)
 
+	// Set the hostname in the env variables
+	c.runningSpec.Process.Env = append(c.runningSpec.Process.Env, fmt.Sprintf("HOSTNAME=%s", c.config.Spec.Hostname))
+
 	fileJSON, err := json.Marshal(c.runningSpec)
 	if err != nil {
 		return errors.Wrapf(err, "error exporting runtime spec for container %s to JSON", c.ID())


### PR DESCRIPTION
The container's hostname should be set as an environment
variable for the container.

Signed-off-by: baude <bbaude@redhat.com>