### PR TITLE
sysfs should be mounted rw for privileged

### DIFF
--- a/test/e2e/privileged_test.go
+++ b/test/e2e/privileged_test.go
@@ -1,0 +1,39 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman privileged container tests", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+
+	})
+
+	It("podman privileged make sure sys is mounted rw", func() {
+		session := podmanTest.Podman([]string{"run", "--privileged", "busybox", "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		ok, lines := session.GrepString("sysfs")
+		Expect(ok).To(BeTrue())
+		Expect(lines[0]).To(ContainSubstring("sysfs (rw,"))
+	})
+})

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Podman rm", func() {
 
 		result := podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(result.ExitCode()).To(Equal(125))
 	})
 
 	It("podman rm created container", func() {


### PR DESCRIPTION
sysfs should be mounted rw for a privileged container.

Signed-off-by: baude <bbaude@redhat.com>