### PR TITLE
Add authfile, cert-dir and creds params to build

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -11,9 +11,23 @@ import (
 
 var (
 	buildFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
 		cli.StringSliceFlag{
 			Name:  "build-arg",
 			Usage: "`argument=value` to supply to the builder",
+		},
+		cli.StringFlag{
+			Name:  "cert-dir",
+			Value: "",
+			Usage: "use certificates at the specified path to access the registry",
+		},
+		cli.StringFlag{
+			Name:  "creds",
+			Value: "",
+			Usage: "use `[username[:password]]` for accessing the registry",
 		},
 		cli.StringSliceFlag{
 			Name:  "file, f",
@@ -68,8 +82,17 @@ func buildCmd(c *cli.Context) error {
 
 	budCmdArgs := []string{"bud"}
 
+	if c.IsSet("authfile") {
+		budCmdArgs = append(budCmdArgs, "--authfile", c.String("authfile"))
+	}
 	for _, buildArg := range c.StringSlice("build-arg") {
 		budCmdArgs = append(budCmdArgs, "--build-arg", buildArg)
+	}
+	if c.IsSet("cert-dir") {
+		budCmdArgs = append(budCmdArgs, "--cert-dir", c.String("cert-dir"))
+	}
+	if c.IsSet("creds") {
+		budCmdArgs = append(budCmdArgs, "--creds", c.String("creds"))
 	}
 	for _, fileName := range c.StringSlice("file") {
 		budCmdArgs = append(budCmdArgs, "--file", fileName)

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -700,15 +700,18 @@ _podman_build() {
   "
 
      local options_with_args="
-     --signature-policy
-     --runtime
-     --runtime-flag
-     --tag
-     -t
+     --authfile
+     --build-arg
+     --cert-dir
+     --creds
      --file
      -f
-     --build-arg
      --format
+     --runtime
+     --runtime-flag
+     --signature-policy
+     --tag
+     -t
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -24,12 +24,27 @@ to do the actual building.
 
 ## OPTIONS
 
+**--authfile** *path*
+
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
 **--build-arg** *arg=value*
 
 Specifies a build argument and its value, which will be interpolated in
 instructions read from the Dockerfiles in the same way that environment
 variables are, but which will not be added to environment variable list in the
 resulting image's configuration.
+
+**--cert-dir** *path*
+
+Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
+
+**--creds** *creds*
+
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **-f, --file** *Dockerfile*
 
@@ -95,6 +110,12 @@ podman build -t imageName .
 podman build --tls-verify=true -t imageName -f Dockerfile.simple
 
 podman build --tls-verify=false -t imageName .
+
+podman bud --runtime-flag log-format=json .
+
+podman bud --runtime-flag debug .
+
+podman bud --authfile /tmp/auths/myauths.json --cert-dir ~/auth --tls-verify=true --creds=username:password -t imageName -f Dockerfile.simple
 
 ## SEE ALSO
 podman(1), buildah(1)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add the authfile, cert-dir and creds parameters to the podman build command.  They were recently added to Buildah.  Also touched up the man page to include a few runtime param examples that @umohnani8 recently cooked up for the Buildah side.