### PR TITLE
Set default configuration container type annotation to sandbox

### DIFF
--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -439,7 +439,7 @@ func getDefaultAnnotations() map[string]string {
 	annotations[ann.Annotations] = ""
 	annotations[ann.ContainerID] = ""
 	annotations[ann.ContainerName] = ""
-	annotations[ann.ContainerType] = ""
+	annotations[ann.ContainerType] = "sandbox"
 	annotations[ann.Created] = ""
 	annotations[ann.HostName] = ""
 	annotations[ann.IP] = ""

--- a/cmd/podman/spec_test.go
+++ b/cmd/podman/spec_test.go
@@ -23,6 +23,12 @@ func TestCreateConfig_GetVolumeMounts(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(data, specMount[0]))
 }
 
+func TestCreateConfig_GetAnnotations(t *testing.T) {
+	config := createConfig{}
+	annotations := config.GetAnnotations()
+	assert.True(t, reflect.DeepEqual("sandbox", annotations["io.kubernetes.cri-o.ContainerType"]))
+}
+
 func TestCreateConfig_GetTmpfsMounts(t *testing.T) {
 	data := spec.Mount{
 		Destination: "/homer",


### PR DESCRIPTION
This allows podman to provide sufficient hints to
start containers with Intel Clear Containers:
https://github.com/clearcontainers/runtime/blob/master/docs/architecture/architecture.md#oci-annotations

Signed-off-by: Naadir Jeewa <naadir@randomvariable.co.uk>