### PR TITLE
Fix --cert-dir path for podman login

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/containers/image/docker"
@@ -75,7 +74,7 @@ func loginCmd(c *cli.Context) error {
 	}
 	sc.DockerInsecureSkipTLSVerify = !c.BoolT("tls-verify")
 	if c.String("cert-dir") != "" {
-		sc.DockerCertPath = filepath.Join(c.String("cert-dir"), server)
+		sc.DockerCertPath = c.String("cert-dir")
 	}
 
 	if err = docker.CheckAuth(context.TODO(), sc, username, password, server); err == nil {


### PR DESCRIPTION
podman login would add on the registry name to the cert-dir path
making containers/image look in a directory that did not exist for
certificates.

@TomSweeneyRedHat caught this bug!

Signed-off-by: umohnani8 <umohnani@redhat.com>