### PR TITLE
Update pause tests per QE suggestions and convert to gingko

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ The dependencies for integration really consists of three things:
 The following instructions assume your GOPATH is ~/go. Adjust as needed for your
 environment.
 
-### Installing ginko
+### Installing ginkgo
 Fetch and build ginkgo with the following command:
 ```
 GOPATH=~/go go get -u github.com/onsi/ginkgo/ginkgo

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -439,3 +439,13 @@ func (s *PodmanSession) LineInOuputContains(term string) bool {
 	}
 	return false
 }
+
+//GetContainerStatus returns the containers state.
+// This function assumes only one container is active.
+func (p *PodmanTest) GetContainerStatus() string {
+	var podmanArgs = []string{"ps"}
+	podmanArgs = append(podmanArgs, "--all", "--format={{.Status}}")
+	session := p.Podman(podmanArgs)
+	session.WaitWithDefaultTimeout()
+	return session.OutputToString()
+}

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -1,0 +1,213 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman pause", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	pausedState := "Paused"
+	createdState := "Created"
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+
+	})
+
+	It("podman pause bogus container", func() {
+		session := podmanTest.Podman([]string{"pause", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
+
+	It("podman unpause bogus container", func() {
+		session := podmanTest.Podman([]string{"unpause", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
+
+	It("podman pause a created container by id", func() {
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"pause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(createdState))
+	})
+
+	It("podman pause a running container by id", func() {
+		session := podmanTest.RunSleepContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"pause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"unpause", cid})
+		result.WaitWithDefaultTimeout()
+	})
+
+	It("podman unpause a running container by id", func() {
+		session := podmanTest.RunSleepContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"unpause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(125))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+	})
+
+	It("podman remove a paused container by id", func() {
+		session := podmanTest.RunSleepContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"pause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"rm", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(125))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"rm", "--force", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(125))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"unpause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		result = podmanTest.Podman([]string{"rm", "--force", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+	})
+
+	It("podman stop a paused container by id", func() {
+		session := podmanTest.RunSleepContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"pause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"stop", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(125))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"unpause", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		result = podmanTest.Podman([]string{"rm", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		result = podmanTest.Podman([]string{"rm", "-f", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+	})
+
+	It("podman pause a running container by name", func() {
+		session := podmanTest.RunSleepContainer("test1")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"pause", "test1"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(Equal(pausedState))
+
+		result = podmanTest.Podman([]string{"unpause", "test1"})
+		result.WaitWithDefaultTimeout()
+	})
+
+	It("podman pause a running container by id and another by name", func() {
+		session1 := podmanTest.RunSleepContainer("test1")
+		session1.WaitWithDefaultTimeout()
+		Expect(session1.ExitCode()).To(Equal(0))
+
+		session2 := podmanTest.RunSleepContainer("")
+		session2.WaitWithDefaultTimeout()
+		Expect(session2.ExitCode()).To(Equal(0))
+		cid2 := session2.OutputToString()
+
+		result := podmanTest.Podman([]string{"pause", cid2})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		result = podmanTest.Podman([]string{"pause", "test1"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"unpause", "test1"})
+		result.WaitWithDefaultTimeout()
+		result = podmanTest.Podman([]string{"unpause", cid2})
+		result.WaitWithDefaultTimeout()
+	})
+
+})


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Per @baude's suggestion, converting to gingko testing.  

Updates the podman pause test per suggetions from QE in https://trello.com/c/u25tqDA7/677-2-kpod-provide-kpod-pause-qe-tips.  In short they suggested pausing two containers at once and using the id for one and the name for the other to reference them.  