### PR TITLE
Change un/pwd handling to match Buildah's

### DIFF
--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
-
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/projectatomic/libpod/libpod/common"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -80,19 +78,11 @@ func pullCmd(c *cli.Context) error {
 	image := args[0]
 
 	var registryCreds *types.DockerAuthConfig
-	if c.String("creds") != "" {
-		creds, err := common.ParseRegistryCreds(c.String("creds"))
+
+	if c.IsSet("creds") {
+		creds, err := util.ParseRegistryCreds(c.String("creds"))
 		if err != nil {
-			if err == common.ErrNoPassword {
-				fmt.Print("Password: ")
-				password, err := terminal.ReadPassword(0)
-				if err != nil {
-					return errors.Wrapf(err, "could not read password from terminal")
-				}
-				creds.Password = string(password)
-			} else {
-				return err
-			}
+			return err
 		}
 		registryCreds = creds
 	}

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/projectatomic/libpod/libpod/common"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -97,25 +97,15 @@ func pushCmd(c *cli.Context) error {
 		}
 	}
 
-	registryCredsString := c.String("creds")
 	certPath := c.String("cert-dir")
 	skipVerify := !c.BoolT("tls-verify")
 	removeSignatures := c.Bool("remove-signatures")
 	signBy := c.String("sign-by")
 
-	if registryCredsString != "" {
-		creds, err := common.ParseRegistryCreds(registryCredsString)
+	if c.IsSet("creds") {
+		creds, err := util.ParseRegistryCreds(c.String("creds"))
 		if err != nil {
-			if err == common.ErrNoPassword {
-				fmt.Print("Password: ")
-				password, err := terminal.ReadPassword(0)
-				if err != nil {
-					return errors.Wrapf(err, "could not read password from terminal")
-				}
-				creds.Password = string(password)
-			} else {
-				return err
-			}
+			return err
 		}
 		registryCreds = creds
 	}

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -65,7 +65,9 @@ Pathname of a directory containing TLS certificates and keys
 
 **--creds**
 
-Credentials (USERNAME:PASSWORD) to use for authenticating to a registry
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **--quiet, -q**
 

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -53,7 +53,9 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 
 **--creds="CREDENTIALS"**
 
-Credentials (USERNAME:PASSWORD) to use for authenticating to a registry
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **cert-dir="PATHNAME"**
 

--- a/libpod/common/common.go
+++ b/libpod/common/common.go
@@ -2,17 +2,9 @@ package common
 
 import (
 	"io"
-	"strings"
-	"syscall"
 
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/types"
-	"github.com/pkg/errors"
-)
-
-var (
-	// ErrNoPassword is returned if the user did not supply a password
-	ErrNoPassword = errors.Wrapf(syscall.EINVAL, "password was not supplied")
 )
 
 // GetCopyOptions constructs a new containers/image/copy.Options{} struct from the given parameters
@@ -59,24 +51,4 @@ func IsFalse(str string) bool {
 // IsValidBool determines whether the given string equals "true" or "false"
 func IsValidBool(str string) bool {
 	return IsTrue(str) || IsFalse(str)
-}
-
-// ParseRegistryCreds takes a credentials string in the form USERNAME:PASSWORD
-// and returns a DockerAuthConfig
-func ParseRegistryCreds(creds string) (*types.DockerAuthConfig, error) {
-	if creds == "" {
-		return nil, errors.New("no credentials supplied")
-	}
-	if !strings.Contains(creds, ":") {
-		return &types.DockerAuthConfig{
-			Username: creds,
-			Password: "",
-		}, ErrNoPassword
-	}
-	v := strings.SplitN(creds, ":", 2)
-	cfg := &types.DockerAuthConfig{
-		Username: v[0],
-		Password: v[1],
-	}
-	return cfg, nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/image/types"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Helper function to determine the username/password passed
+// in the creds string.  It could be either or both.
+func parseCreds(creds string) (string, string) {
+	if creds == "" {
+		return "", ""
+	}
+	up := strings.SplitN(creds, ":", 2)
+	if len(up) == 1 {
+		return up[0], ""
+	}
+	return up[0], up[1]
+}
+
+// ParseRegistryCreds takes a credentials string in the form USERNAME:PASSWORD
+// and returns a DockerAuthConfig
+func ParseRegistryCreds(creds string) (*types.DockerAuthConfig, error) {
+	username, password := parseCreds(creds)
+	if username == "" {
+		fmt.Print("Username: ")
+		fmt.Scanln(&username)
+	}
+	if password == "" {
+		fmt.Print("Password: ")
+		termPassword, err := terminal.ReadPassword(0)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not read password from terminal")
+		}
+		password = string(termPassword)
+	}
+
+	return &types.DockerAuthConfig{
+		Username: username,
+		Password: password,
+	}, nil
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Changes the un/pwd handling to match Buildah's.  The username, password or a blank can be passed to the creds param.  The user will be prompted for the unsupplied values.  The username will be echo'd, the password will not.  

Removes the password handling from the pull and push code into the common code.