### PR TITLE
Match podman inspect output to docker inspect

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/formats"
@@ -163,8 +164,8 @@ func getCtrInspectInfo(ctr *libpod.Container, ctrInspectData *inspect.ContainerI
 	}
 
 	data := &inspect.ContainerData{
-		CtrInspectData: ctrInspectData,
-		HostConfig: &inspect.HostConfig{
+		ctrInspectData,
+		&inspect.HostConfig{
 			ConsoleSize:          spec.Process.ConsoleSize,
 			OomScoreAdj:          spec.Process.OOMScoreAdj,
 			CPUShares:            shares,
@@ -210,7 +211,7 @@ func getCtrInspectInfo(ctr *libpod.Container, ctrInspectData *inspect.ContainerI
 			Ulimits:              createArtifact.Resources.Ulimit,
 			SecurityOpt:          createArtifact.SecurityOpts,
 		},
-		Config: &inspect.CtrConfig{
+		&inspect.CtrConfig{
 			Hostname:    spec.Hostname,
 			User:        spec.Process.User,
 			Env:         spec.Process.Env,

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -79,6 +79,16 @@ Display the total file size if the type is a container
 }
 ```
 
+```
+# podman inspect a04 --format "{{.ImageName}}"
+fedora
+```
+
+```
+# sudo podman inspect a04 --format "{{.GraphDriver.Name}}"
+overlay
+```
+
 ## SEE ALSO
 podman(1)
 

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -12,9 +12,9 @@ import (
 
 // ContainerData holds the podman inspect data for a container
 type ContainerData struct {
-	CtrInspectData *ContainerInspectData `json:"CtrInspectData"`
-	HostConfig     *HostConfig           `json:"HostConfig"`
-	Config         *CtrConfig            `json:"Config"`
+	*ContainerInspectData
+	HostConfig *HostConfig `json:"HostConfig"`
+	Config     *CtrConfig  `json:"Config"`
 }
 
 // HostConfig represents the host configuration for the container

--- a/test/demos.sh
+++ b/test/demos.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+echo "This is a demo of the podman search command."
+echo ""
+
+read -p "--> cat /etc/containers/registries.conf"
+cat /etc/containers/registries.conf
+echo ""
+
+read -p "--> podman search fedora"
+podman search fedora
+echo ""
+
+read -p "--> podman search --filter stars=34 fedora"
+podman search --filter stars=34 fedora
+echo ""
+
+read -p "--> podman search --filter is-automated=false --filter stars=34 --filter is-official fedora"
+podman search --filter is-automated=false --filter stars=34 --filter is-official fedora
+echo ""
+
+read -p "--> podman search --no-trunc --limit 3 fedora"
+podman search --no-trunc --limit 3 fedora
+echo ""
+
+read -p "--> podman search --registry registry.access.redhat.com rhel7"
+podman search --registry registry.access.redhat.com rhel7
+echo ""
+
+read -p "--> podman search --format \"table {{.Name}} {{.Description}}\" fedora"
+podman search --format "table {{.Name}} {{.Description}}" fedora
+echo ""
+
+read -p "Demo of a few podman run and create options"
+echo ""
+
+read -p "--> podman run --memory 80m fedora cat /sys/fs/cgroup/memory/memory.limit_in_bytes"
+podman run --rm --memory 80m fedora cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+echo ""
+
+read -p "--> podman run --memory 80m --memory-reservation 40m fedora cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes"
+podman run --rm --memory 80m --memory-reservation 40m fedora cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes
+echo ""
+
+read -p "--> podman run --memory 40m --memory-reservation 80m fedora cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes"
+podman run --rm --memory 40m --memory-reservation 80m fedora cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes
+echo ""
+
+read -p "--> podman run --memory-swappiness 15 fedora cat /sys/fs/cgroup/memory/memory.swappiness"
+podman run --rm --memory-swappiness 15 fedora cat /sys/fs/cgroup/memory/memory.swappiness
+echo ""
+
+read -p "--> podman run --kernel-memory 40m fedora cat /sys/fs/cgroup/memory/memory.kmem.limit_in_bytes"
+podman run --rm --kernel-memory 40m fedora cat /sys/fs/cgroup/memory/memory.kmem.limit_in_bytes
+echo ""
+
+read -p "--> podman run --cpu-period 5000 fedora cat /sys/fs/cgroup/cpu/cpu.cfs_period_us"
+podman run --rm --cpu-period 5000 fedora cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+echo ""
+
+read -p "--> podman run --cpu-quota 15000 --cpu-period 5000 fedora cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+podman run --rm --cpu-quota 15000 --cpu-period 5000 fedora cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+echo ""
+
+read -p "--> podman run --cpus 0.5 fedora /bin/bash"
+read -p "cat /sys/fs/cgroup/cpu/cpu.cfs_period_us"
+podman run --rm --cpus 0.5 fedora cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+read -p "cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+podman run --rm --cpus 0.5 fedora cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+echo ""
+
+read -p "--> podman run --cpu-shares 2 fedora cat /sys/fs/cgroup/cpu/cpu.shares"
+podman run --rm --cpu-shares 2 fedora cat /sys/fs/cgroup/cpu/cpu.shares
+echo ""
+
+read -p "--> podman run --cpuset-cpus=0,2 fedora cat /sys/fs/cgroup/cpuset/cpuset.cpus"
+podman run --rm --cpuset-cpus=0,2 fedora cat /sys/fs/cgroup/cpuset/cpuset.cpus
+echo ""
+
+read -p "--> podman run --sysctl net.core.somaxconn=65535 alpine sysctl net.core.somaxconn"
+podman run --rm --sysctl net.core.somaxconn=65535 alpine sysctl net.core.somaxconn
+echo ""
+
+read -p "--> podman run --ulimit nofile=1024:1028 fedora ulimit -n"
+podman run --rm --ulimit nofile=1024:1028 fedora ulimit -n
+echo ""
+
+read -p "--> podman run --blkio-weight 15 fedora cat /sys/fs/cgroup/blkio/blkio.weight"
+podman run --rm --blkio-weight 15 fedora cat /sys/fs/cgroup/blkio/blkio.weight
+echo ""
+
+read -p "End of Demo."
+echo "Thank you!"

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Podman create", func() {
 		check := podmanTest.Podman([]string{"inspect", "-l"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectContainerToJSON()
-		Expect(data.CtrInspectData.ID).To(ContainSubstring(cid))
+		Expect(data.ID).To(ContainSubstring(cid))
 	})
 
 	It("podman create container based on a remote image", func() {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -3,9 +3,10 @@ package integration
 import (
 	"os"
 
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strings"
 )
 
 var _ = Describe("Podman inspect", func() {
@@ -69,6 +70,6 @@ var _ = Describe("Podman inspect", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		conData := result.InspectContainerToJSON()
-		Expect(conData.CtrInspectData.SizeRootFs).To(BeNumerically(">", 0))
+		Expect(conData.SizeRootFs).To(BeNumerically(">", 0))
 	})
 })


### PR DESCRIPTION
Made a change to make sure that the output paths of podman inspect
matches that of docker inspect. For example to get the stop signal
you should be able to do podman inspect ctr --format {{.Config.StopSignal}}
and the same thing in docker will give the same results.

Signed-off-by: umohnani8 <umohnani@redhat.com>