### PR TITLE
avoid period character at the beginning of newline

### DIFF
--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -620,8 +620,8 @@ This should list the message sent to logger.
 
 ### Attaching to one or more from STDIN, STDOUT, STDERR
 
-If you do not specify -a then podman will attach everything (stdin,stdout,stderr)
-. You can specify to which of the three standard streams (stdin, stdout, stderr)
+If you do not specify -a then podman will attach everything (stdin,stdout,stderr).
+You can specify to which of the three standard streams (stdin, stdout, stderr)
 you'd like to connect instead, as in:
 
     # podman run -a stdin -a stdout -i -t fedora /bin/bash


### PR DESCRIPTION
Otherwise causes rpmlint error for manpage

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@rhatdan @baude @TomSweeneyRedHat PTAL