### PR TITLE
remove shebang from bash completion

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 __podman_previous_extglob_setting=$(shopt -p extglob)


### PR DESCRIPTION
shebang presence causes rpmlint error:

"non-executable-script
/usr/share/bash-completion/completions/podman 644 /bin/bash"

completions aren't executable in themselves so there's no need for
a shebang there.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@mheon @rhatdan @TomSweeneyRedHat @baude PTAL