### PR TITLE
Honor ENTRYPOINT in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     e2fslibs-dev \
     gawk \
     gettext \
+    go-md2man \
     iptables \
     pkg-config \
     libaio-dev \
@@ -95,6 +96,14 @@ RUN set -x \
        && go install github.com/kubernetes-incubator/cri-tools/cmd/crictl \
        && cp "$GOPATH"/bin/crictl /usr/bin/ \
        && rm -rf "$GOPATH"
+
+# Install buildah
+RUN set -x \
+       && export GOPATH=/go \
+       && git clone https://github.com/projectatomic/buildah "$GOPATH/src/github.com/projectatomic/buildah" \
+       && cd "$GOPATH/src/github.com/projectatomic/buildah" \
+       && make \
+       && make install
 
 # Install ginkgo
 RUN set -x \

--- a/Dockerfile.CentOS
+++ b/Dockerfile.CentOS
@@ -9,6 +9,7 @@ RUN yum -y install btrfs-progs-devel \
               glib2-devel \
               gnupg \
               golang \
+              golang-github-cpuguy83-go-md2man \
               gpgme-devel \
               libassuan-devel \
               libseccomp-devel \
@@ -33,6 +34,14 @@ RUN set -x \
        && mkdir -p /usr/libexec/cni \
        && cp bin/* /usr/libexec/cni \
        && rm -rf "$GOPATH"
+
+# Install buildah
+RUN set -x \
+       && export GOPATH=/go \
+       && git clone https://github.com/projectatomic/buildah "$GOPATH/src/github.com/projectatomic/buildah" \
+       && cd "$GOPATH/src/github.com/projectatomic/buildah" \
+       && make \
+       && make install
 
 # Install ginkgo
 RUN set -x \

--- a/Dockerfile.Fedora
+++ b/Dockerfile.Fedora
@@ -10,6 +10,7 @@ RUN dnf -y install btrfs-progs-devel \
               glib2-devel \
               gnupg \
               golang \
+              golang-github-cpuguy83-go-md2man \
               gpgme-devel \
               libassuan-devel \
               libseccomp-devel \
@@ -35,6 +36,14 @@ RUN set -x \
        && mkdir -p /usr/libexec/cni \
        && cp bin/* /usr/libexec/cni \
        && rm -rf "$GOPATH"
+
+# Install buildah
+RUN set -x \
+       && export GOPATH=/go \
+       && git clone https://github.com/projectatomic/buildah "$GOPATH/src/github.com/projectatomic/buildah" \
+       && cd "$GOPATH/src/github.com/projectatomic/buildah" \
+       && make \
+       && make install
 
 # Install ginkgo
 RUN set -x \

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -173,7 +173,7 @@ var createFlags = []cli.Flag{
 		Name:  "dns-search",
 		Usage: "Set custom DNS search domains",
 	},
-	cli.StringFlag{
+	cli.StringSliceFlag{
 		Name:  "entrypoint",
 		Usage: "Overwrite the default ENTRYPOINT of the image",
 	},

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -223,7 +224,7 @@ func getCtrInspectInfo(ctr *libpod.Container, ctrInspectData *inspect.ContainerI
 			OpenStdin:   config.Stdin,
 			StopSignal:  config.StopSignal,
 			Cmd:         config.Spec.Process.Args,
-			Entrypoint:  createArtifact.Entrypoint,
+			Entrypoint:  strings.Join(createArtifact.Entrypoint, " "),
 		},
 	}
 	return data, nil

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -449,3 +449,14 @@ func (p *PodmanTest) GetContainerStatus() string {
 	session.WaitWithDefaultTimeout()
 	return session.OutputToString()
 }
+
+// BuildImage uses podman build and buildah to build an image
+// called imageName based on a string dockerfile
+func (p *PodmanTest) BuildImage(dockerfile, imageName string) {
+	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile")
+	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+	Expect(err).To(BeNil())
+	session := p.Podman([]string{"build", "-t", imageName, "--file", dockerfilePath, p.TempDir})
+	session.Wait(120)
+	Expect(session.ExitCode()).To(Equal(0))
+}

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -1,0 +1,100 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman run entrypoint", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreArtifact(ALPINE)
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+
+	})
+
+	It("podman run entrypoint", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(3))
+	})
+
+	It("podman run entrypoint with cmd", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+CMD [ "-v"]
+ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(5))
+	})
+
+	It("podman run entrypoint with user cmd overrides image cmd", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+CMD [ "-v"]
+ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest", "-i"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(6))
+	})
+
+	It("podman run entrypoint with user cmd no image cmd", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest", "-i"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(6))
+	})
+
+	It("podman run user entrypoint overrides image entrypoint and image cmd", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+CMD ["-i"]
+ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "--entrypoint=uname", "foobar.com/entrypoint:latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOuputStartsWith("Linux")).To(BeTrue())
+	})
+
+	It("podman run user entrypoint with command overrides image entrypoint and image cmd", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+CMD ["-i"]
+ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "--entrypoint=uname", "foobar.com/entrypoint:latest", "-r"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOuputStartsWith("Linux")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
When an image has an ENTRYPOINT defined, we should be honoring it. The
problem is described in issue #321.

Also, added buildah binary to test runtimes for testing entrypoint and
will also allow us to test podman build as well.

Signed-off-by: baude <bbaude@redhat.com>