### PR TITLE
No entrypoint, cmd, or command

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -587,6 +587,10 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 		command = append(command, data.ContainerConfig.Cmd...)
 	}
 
+	if len(command) == 0 {
+		return nil, errors.Errorf("No command specified on command line or as CMD or ENTRYPOINT in this image")
+	}
+
 	// EXPOSED PORTS
 	portBindings, err := exposedPorts(c, data.ContainerConfig.ExposedPorts)
 	if err != nil {

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -28,6 +28,17 @@ var _ = Describe("Podman run entrypoint", func() {
 
 	})
 
+	It("podman run no command, entrypoint, or cmd", func() {
+		dockerfile := `FROM docker.io/library/alpine:latest
+ENTRYPOINT []
+CMD []
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest")
+		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+	})
+
 	It("podman run entrypoint", func() {
 		dockerfile := `FROM docker.io/library/alpine:latest
 ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]


### PR DESCRIPTION
When an image does not have an ENTRYPOINT nor a CMD and the
user does not provide a command in the CLI, we should fail
gracefully.

This resolves issue #328

Signed-off-by: baude <bbaude@redhat.com>