### PR TITLE
No registries warning

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -151,6 +151,11 @@ func main() {
 			Usage: "used to pass an option to the storage driver",
 		},
 	}
+	if _, err := os.Stat("/etc/containers/registries.conf"); err != nil {
+		if os.IsNotExist(err) {
+			logrus.Warn("unable to find /etc/containers/registries.conf. some podman (image shortnames) commands may be limited")
+		}
+	}
 	if err := app.Run(os.Args); err != nil {
 		if debug {
 			logrus.Errorf(err.Error())


### PR DESCRIPTION
When no /etc/containers/registries.conf is found, log a warning message.

Signed-off-by: baude <bbaude@redhat.com>