### PR TITLE
Run podman inside a podman container

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -15,6 +15,7 @@ timeout: 45m
 tests:
   -  sh .papr_prepare.sh
 
+context: "FAH27"
 ---
 
 inherit: true
@@ -31,4 +32,24 @@ extra-repos:
       baseurl: https://cbs.centos.org/repos/virt7-container-common-candidate/$basearch/os
       gpgcheck: 0
 
-context: centos/7/atomic/smoketested
+context: "CAH smoketested"
+
+---
+
+inherit: true
+host:
+    distro: fedora/27/cloud
+    specs:
+        ram: 8192
+        cpus: 4
+extra-repos:
+    - name: crio_copr
+      baseurl: https://copr-be.cloud.fedoraproject.org/results/baude/Upstream_CRIO_Family/fedora-27-x86_64/
+      gpgcheck: 0
+packages:
+    - podman
+    - buildah
+tests:
+    - CONTAINER_RUNTIME="podman" sh .papr_prepare.sh
+required: false
+context: "Fedora fedora/27/cloud Podman"

--- a/.papr_prepare.sh
+++ b/.papr_prepare.sh
@@ -2,6 +2,7 @@
 set -xeuo pipefail
 
 DIST=${DIST:=Fedora}
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:=docker}
 IMAGE=fedorapodmanbuild
 PYTHON=python3
 if [[ ${DIST} != "Fedora" ]]; then
@@ -10,7 +11,7 @@ if [[ ${DIST} != "Fedora" ]]; then
 fi
 
 # Build the test image
-docker build -t ${IMAGE} -f Dockerfile.${DIST} .
+${CONTAINER_RUNTIME} build -t ${IMAGE} -f Dockerfile.${DIST} .
 
 # Run the tests
-docker run --rm --privileged -v $PWD:/go/src/github.com/projectatomic/libpod --workdir /go/src/github.com/projectatomic/libpod -e PYTHON=$PYTHON -e STORAGE_OPTIONS="--storage-driver=vfs" -e CRIO_ROOT="/go/src/github.com/projectatomic/libpod" -e PODMAN_BINARY="/usr/bin/podman" -e CONMON_BINARY="/usr/libexec/crio/conmon" -e DIST=$DIST $IMAGE sh .papr.sh
+${CONTAINER_RUNTIME} run --rm --privileged --net=host -v $PWD:/go/src/github.com/projectatomic/libpod --workdir /go/src/github.com/projectatomic/libpod -e PYTHON=$PYTHON -e STORAGE_OPTIONS="--storage-driver=vfs" -e CRIO_ROOT="/go/src/github.com/projectatomic/libpod" -e PODMAN_BINARY="/usr/bin/podman" -e CONMON_BINARY="/usr/libexec/crio/conmon" -e DIST=$DIST $IMAGE sh .papr.sh

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ginkgo:
 	ginkgo -v test/e2e/
 
 localintegration: test-binaries
-	ginkgo -v -cover -flakeAttempts 3 -progress -trace test/e2e/.
+	ginkgo -v -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
 vagrant-check:
 	BOX=$(BOX) sh ./vagrant.sh

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -460,3 +460,23 @@ func (p *PodmanTest) BuildImage(dockerfile, imageName string) {
 	session.Wait(120)
 	Expect(session.ExitCode()).To(Equal(0))
 }
+
+//GetHostDistribution returns the dist in string format. If the
+//distribution cannot be determined, an empty string will be returned.
+func (p *PodmanTest) GetHostDistribution() string {
+	content, err := ioutil.ReadFile("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	for _, line := range content {
+		if strings.HasPrefix(fmt.Sprintf("%s", line), "ID") {
+			fields := strings.Split(fmt.Sprintf("%s", line), "=")
+			if len(fields) < 2 {
+				return ""
+			}
+			return strings.Trim(fields[1], "\"")
+
+		}
+	}
+	return ""
+}

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -61,16 +61,11 @@ var _ = Describe("Podman privileged container tests", func() {
 	})
 
 	It("podman cap-drop CapEff", func() {
-		cap := podmanTest.SystemExec("grep", []string{"CapAmb", "/proc/self/status"})
-		cap.WaitWithDefaultTimeout()
-		Expect(cap.ExitCode()).To(Equal(0))
 		session := podmanTest.Podman([]string{"run", "--cap-drop", "all", "busybox", "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-
-		capAmp := strings.Split(cap.OutputToString(), " ")
 		capEff := strings.Split(session.OutputToString(), " ")
-		Expect(capAmp[1]).To(Equal(capEff[1]))
+		Expect("0000000000000000").To(Equal(capEff[1]))
 	})
 
 	It("podman non-privileged should have very few devices", func() {


### PR DESCRIPTION
We should be able to run nested podman containers in particular
for our testing environment. i.e. eat our own dog food.

Some privileges had to be corrected in order for this to work
correctly.

Added a third papr target that runs podman tests inside podman.  I
marked the test as not required right now as we get more confident
in the results

Signed-off-by: baude <bbaude@redhat.com>