### PR TITLE
Update c/image to match CRI-O master

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 #
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/image 3ab2e31e6ff9fc2b21b81188c1f6cf545658ff4a
+github.com/containers/image 701221f0891d76aeac3f25912e6bb9f84e88de1c
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/ostreedev/ostree-go master
 github.com/containers/storage 1824cf917a6b42d8c41179e807bb20a5fd6c0f0a

--- a/vendor/github.com/containers/image/copy/manifest.go
+++ b/vendor/github.com/containers/image/copy/manifest.go
@@ -46,6 +46,11 @@ func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMEType
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
+	normalizedSrcType := manifest.NormalizedMIMEType(srcType)
+	if srcType != normalizedSrcType {
+		logrus.Debugf("Source manifest MIME type %s, treating it as %s", srcType, normalizedSrcType)
+		srcType = normalizedSrcType
+	}
 
 	if forceManifestMIMEType != "" {
 		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}

--- a/vendor/github.com/containers/image/image/docker_schema1.go
+++ b/vendor/github.com/containers/image/image/docker_schema1.go
@@ -95,7 +95,7 @@ func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
 // This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
 // (most importantly it forces us to download the full layers even if they are already present at the destination).
 func (m *manifestSchema1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
-	return options.ManifestMIMEType == manifest.DockerV2Schema2MediaType
+	return (options.ManifestMIMEType == manifest.DockerV2Schema2MediaType || options.ManifestMIMEType == imgspecv1.MediaTypeImageManifest)
 }
 
 // UpdatedImage returns a types.Image modified according to options.


### PR DESCRIPTION
Update our C/Image to keep the version consistent with CRI-O. Not strictly necessary, but eases any pain that might happen when we start integrating the two.

Ref: https://github.com/kubernetes-incubator/cri-o/pull/1352