### PR TITLE
Fix podman save when redirecting output

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -392,7 +392,7 @@ func imageData(c *cli.Context, runtime *libpod.Runtime, image string) (string, s
 		// Pull the image
 		var writer io.Writer
 		if !c.Bool("quiet") {
-			writer = os.Stdout
+			writer = os.Stderr
 		}
 		createImage.Pull(writer)
 	}

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -93,7 +93,7 @@ func loadCmd(c *cli.Context) error {
 
 	var writer io.Writer
 	if !c.Bool("quiet") {
-		writer = os.Stdout
+		writer = os.Stderr
 	}
 
 	options := libpod.CopyOptions{

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"fmt"
+
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
@@ -90,7 +91,7 @@ func pullCmd(c *cli.Context) error {
 
 	var writer io.Writer
 	if !c.Bool("quiet") {
-		writer = os.Stdout
+		writer = os.Stderr
 	}
 
 	options := libpod.CopyOptions{

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -118,7 +118,7 @@ func pushCmd(c *cli.Context) error {
 
 	var writer io.Writer
 	if !c.Bool("quiet") {
-		writer = os.Stdout
+		writer = os.Stderr
 	}
 
 	var manifestType string

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -75,7 +75,7 @@ func saveCmd(c *cli.Context) error {
 
 	var writer io.Writer
 	if !c.Bool("quiet") {
-		writer = os.Stdout
+		writer = os.Stderr
 	}
 
 	output := c.String("output")


### PR DESCRIPTION
podman save would write the progress bar to the image tar file
when the output was redirected with >.
Fixed the writer to not write the status bar when the output is redirected.

Fixes https://github.com/projectatomic/libpod/issues/352

Signed-off-by: umohnani8 <umohnani@redhat.com>