### PR TITLE
Resolve contention between copr and fedora repos

### DIFF
--- a/contrib/spec/podman.spec
+++ b/contrib/spec/podman.spec
@@ -44,8 +44,8 @@
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           podman
-Version:        0
-Release:        0.3.git%{shortcommit}%{?dist}
+Version:        0.2.3
+Release:        git%{shortcommit}%{?dist}
 Summary:        Manage Pods, Containers and Container Images
 License:        ASL 2.0
 URL:            https://%{provider_prefix}


### PR DESCRIPTION
In order for the podman in podman tests to work, we need to install a copr
RPM that has the function we need (and is not in a fedora build yet).  Because
the copr rpms are not versioned correctly (relative to the fedora ones), we now
set the version in the copr rpm.

Signed-off-by: baude <bbaude@redhat.com>