### PR TITLE
Implement podman run option --cgroup-parent

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -72,12 +72,17 @@ func runCmd(c *cli.Context) error {
 	options = append(options, libpod.WithUser(createConfig.User))
 	options = append(options, libpod.WithShmDir(createConfig.ShmDir))
 	options = append(options, libpod.WithShmSize(createConfig.Resources.ShmSize))
+	options = append(options, libpod.WithCgroupParent(createConfig.CgroupParent))
 	ctr, err := runtime.NewContainer(runtimeSpec, options...)
 	if err != nil {
 		return err
 	}
 
 	logrus.Debug("new container created ", ctr.ID())
+
+	p, _ := ctr.CGroupPath()("")
+	logrus.Debugf("createConfig.CgroupParent %v for %v", p, ctr.ID())
+
 	if err := ctr.Init(); err != nil {
 		// This means the command did not exist
 		exitCode = 126

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -72,7 +72,13 @@ func runCmd(c *cli.Context) error {
 	options = append(options, libpod.WithUser(createConfig.User))
 	options = append(options, libpod.WithShmDir(createConfig.ShmDir))
 	options = append(options, libpod.WithShmSize(createConfig.Resources.ShmSize))
-	options = append(options, libpod.WithCgroupParent(createConfig.CgroupParent))
+
+	// Default used if not overridden on command line
+
+	if createConfig.CgroupParent != "" {
+		options = append(options, libpod.WithCgroupParent(createConfig.CgroupParent))
+	}
+
 	ctr, err := runtime.NewContainer(runtimeSpec, options...)
 	if err != nil {
 		return err

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -84,10 +84,12 @@ func runCmd(c *cli.Context) error {
 		return err
 	}
 
-	logrus.Debug("new container created ", ctr.ID())
+	if logrus.GetLevel() == logrus.DebugLevel {
+		logrus.Debugf("New container created %q", ctr.ID())
 
-	p, _ := ctr.CGroupPath()("")
-	logrus.Debugf("createConfig.CgroupParent %v for %v", p, ctr.ID())
+		p, _ := ctr.CGroupPath()("")
+		logrus.Debugf("container %q has CgroupParent %q", ctr.ID(), p)
+	}
 
 	if err := ctr.Init(); err != nil {
 		// This means the command did not exist
@@ -106,8 +108,6 @@ func runCmd(c *cli.Context) error {
 	if err := ctr.AddArtifact("create-config", createConfigJSON); err != nil {
 		return err
 	}
-
-	logrus.Debug("new container created ", ctr.ID())
 
 	if c.String("cidfile") != "" {
 		if err := libpod.WriteFile(ctr.ID(), c.String("cidfile")); err != nil {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -37,7 +37,7 @@ const (
 	ContainerStatePaused ContainerStatus = iota
 )
 
-// CgroupParent is the default prefix to a cgroup path in libpod
+// DefaultCgroupParent is the default prefix to a cgroup path in libpod
 var DefaultCgroupParent = "/libpod_parent"
 
 // LinuxNS represents a Linux namespace

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -38,7 +38,7 @@ const (
 )
 
 // CgroupParent is the default prefix to a cgroup path in libpod
-var CgroupParent = "/libpod_parent"
+var DefaultCgroupParent = "/libpod_parent"
 
 // LinuxNS represents a Linux namespace
 type LinuxNS int

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -146,7 +146,7 @@ func newContainer(rspec *spec.Spec, lockDir string) (*Container, error) {
 	ctr.config.CreatedTime = time.Now()
 
 	ctr.config.ShmSize = DefaultShmSize
-	ctr.config.CgroupParent = CgroupParent
+	ctr.config.CgroupParent = DefaultCgroupParent
 
 	// Path our lock file will reside at
 	lockPath := filepath.Join(lockDir, ctr.config.ID)

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -656,6 +656,7 @@ func WithLogPath(path string) CtrCreateOption {
 }
 
 // WithCgroupParent sets the Cgroup Parent of the new container
+// Default used if not overridden on command line
 func WithCgroupParent(parent string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -663,7 +664,7 @@ func WithCgroupParent(parent string) CtrCreateOption {
 		}
 
 		if parent == "" {
-			return errors.Wrapf(ErrInvalidArg, "cgroup parent cannot be empty")
+			return nil
 		}
 
 		ctr.config.CgroupParent = parent

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -656,7 +656,6 @@ func WithLogPath(path string) CtrCreateOption {
 }
 
 // WithCgroupParent sets the Cgroup Parent of the new container
-// Default used if not overridden on command line
 func WithCgroupParent(parent string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -664,7 +663,7 @@ func WithCgroupParent(parent string) CtrCreateOption {
 		}
 
 		if parent == "" {
-			return nil
+			return errors.Wrapf(ErrInvalidArg, "cgroup parent cannot be empty")
 		}
 
 		ctr.config.CgroupParent = parent

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -1,0 +1,58 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman run with --cgroup-parent", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
+		podmanTest.RestoreArtifact(fedoraMinimal)
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+
+	})
+
+	Specify("valid --cgroup-parent using cgroupfs", func() {
+		cgroup := "/zzz"
+		run := podmanTest.Podman([]string{"run", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/self/cgroup"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(Equal(0))
+		ok, _ := run.GrepString(cgroup)
+		Expect(ok).To(BeTrue())
+	})
+
+	Specify("no --cgroup-parent", func() {
+		cgroup := "/libpod_parent"
+		run := podmanTest.Podman([]string{"run", fedoraMinimal, "cat", "/proc/self/cgroup"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(Equal(0))
+		ok, _ := run.GrepString(cgroup)
+		Expect(ok).To(BeTrue())
+	})
+
+	Specify("valid --cgroup-parent using slice", func() {
+		cgroup := "aaaa.slice"
+		run := podmanTest.Podman([]string{"run", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/1/cgroup"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(Equal(0))
+		ok, _ := run.GrepString(cgroup)
+		Expect(ok).To(BeTrue())
+	})
+})


### PR DESCRIPTION
Example:

sudo /usr/local/bin/podman run --cgroup-parent=/zzz fedora cat /proc/self/cgroup

Signed-off-by: Jhon Honce <jhonce@redhat.com>

Fixes #359 