### PR TITLE
Add --time to podman stop

### DIFF
--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -85,4 +85,13 @@ var _ = Describe("Podman stop", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
+	It("podman stop --time compatibilty", func() {
+		session := podmanTest.RunSleepContainer("test1")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"stop", "-l", "--time", "1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
Adding --time option to podman stop for compatibilty reasons.  The option
is not documented and also hidden from podman stop --help. If this option
is provided, it overrides --timeout.

Resolves issue #366

Signed-off-by: baude <bbaude@redhat.com>