### PR TITLE
Implement --image-volumes for create and run

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -197,6 +197,11 @@ var createFlags = []cli.Flag{
 		Name:  "hostname",
 		Usage: "Set container hostname",
 	},
+	cli.StringFlag{
+		Name:  "image-volume, builtin-volume",
+		Usage: "Tells podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore' (default 'bind')",
+		Value: "bind",
+	},
 	cli.BoolFlag{
 		Name:  "interactive, i",
 		Usage: "Keep STDIN open even if not attached",

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -54,6 +54,7 @@ func runCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	useImageVolumes := createConfig.ImageVolumeType == "bind"
 
 	runtimeSpec, err := createConfigToOCISpec(createConfig)
 	if err != nil {
@@ -66,7 +67,7 @@ func runCmd(c *cli.Context) error {
 	}
 
 	// Gather up the options for NewContainer which consist of With... funcs
-	options = append(options, libpod.WithRootFSFromImage(createConfig.ImageID, createConfig.Image, true))
+	options = append(options, libpod.WithRootFSFromImage(createConfig.ImageID, createConfig.Image, useImageVolumes))
 	options = append(options, libpod.WithSELinuxLabels(createConfig.ProcessLabel, createConfig.MountLabel))
 	options = append(options, libpod.WithLabels(createConfig.Labels))
 	options = append(options, libpod.WithUser(createConfig.User))

--- a/cmd/podman/spec_test.go
+++ b/cmd/podman/spec_test.go
@@ -18,7 +18,7 @@ func TestCreateConfig_GetVolumeMounts(t *testing.T) {
 	config := createConfig{
 		Volumes: []string{"foobar:/foobar:ro"},
 	}
-	specMount, err := config.GetVolumeMounts()
+	specMount, err := config.GetVolumeMounts([]spec.Mount{})
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(data, specMount[0]))
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1042,6 +1042,7 @@ _podman_container_run() {
 		--attach -a
 		--blkio-weight
 		--blkio-weight-device
+		--builtin-volume
 		--cap-add
 		--cap-drop
 		--cgroup-parent
@@ -1068,6 +1069,7 @@ _podman_container_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--image-volume
 		--init-path
 		--ip
 		--ip6

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -217,6 +217,14 @@ inside of the container.
 **--help**
   Print usage statement
 
+**--image-volume**, **builtin-volume**=*bind*|*tmpfs*|*ignore*
+    Tells podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore' (default 'bind').
+    bind: A directory is created inside the container state directory and bind mounted into
+        the container for the volumes.
+    tmpfs: The volume is mounted onto the container as a tmpfs, which allows the users to create
+        content that dissapears when the container is stopped.
+    ignore: All volumes are just ignored and no action is taken.
+
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -214,6 +214,14 @@ inside of the container.
 **--help**
    Print usage statement
 
+**--image-volume**, **builtin-volume**=*bind*|*tmpfs*|*ignore*
+    Tells podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore' (default 'bind')
+    bind: A directory is created inside the container state directory and bind mounted into
+        the container for the volumes.
+    tmpfs: The volume is mounted onto the container as a tmpfs, which allows the users to create
+        content that dissapears when the container is stopped.
+    ignore: All volumes are just ignored and no action is taken.
+
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
 

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -144,6 +144,13 @@ func (c *Container) Init() (err error) {
 	}
 	g.AddMount(hostnameMnt)
 
+	// Bind builtin image volumes
+	if c.config.ImageVolumes {
+		if err = c.addImageVolumes(&g); err != nil {
+			return errors.Wrapf(err, "error mounting image volumes")
+		}
+	}
+
 	if c.config.User != "" {
 		if !c.state.Mounted {
 			return errors.Wrapf(ErrCtrStateInvalid, "container %s must be mounted in order to translate User field", c.ID())

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/containers/image/signature"
 	"github.com/containers/image/types"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 // Runtime API constants
@@ -95,4 +96,14 @@ func RemoveScientificNotationFromFloat(x float64) (float64, error) {
 		return x, errors.Wrapf(err, "unable to remove scientific number from calculations")
 	}
 	return result, nil
+}
+
+// MountExists returns true if dest exists in the list of mounts
+func MountExists(specMounts []spec.Mount, dest string) bool {
+	for _, m := range specMounts {
+		if m.Destination == dest {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
--image-volumes tells podman what to do with the image volumes in the image config
There are 3 options: bind, tmpfs, and ignore
bind puts the volume contents in /var/lib/containers/storage/container-id/volumes/vol-dir
and bind mounts it into the container at /vol-dir
tmpfs mounts /vol-dir as a tmps into the container
ignore doesn't mount the image volumes onto the container

Signed-off-by: umohnani8 <umohnani@redhat.com>