### PR TITLE
Correct exit code 126 and 127

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -80,9 +80,9 @@ func runCmd(c *cli.Context) error {
 	logrus.Debug("new container created ", ctr.ID())
 	if err := ctr.Init(); err != nil {
 		// This means the command did not exist
-		exitCode = 126
+		exitCode = 127
 		if strings.Index(err.Error(), "permission denied") > -1 {
-			exitCode = 127
+			exitCode = 126
 		}
 		return err
 	}

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -35,13 +35,13 @@ var _ = Describe("Podman run exit", func() {
 	})
 
 	It("podman run exit 126", func() {
-		result := podmanTest.Podman([]string{"run", ALPINE, "foobar"})
+		result := podmanTest.Podman([]string{"run", ALPINE, "/etc"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(126))
 	})
 
 	It("podman run exit 127", func() {
-		result := podmanTest.Podman([]string{"run", ALPINE, "/etc"})
+		result := podmanTest.Podman([]string{"run", ALPINE, "foobar"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(127))
 	})


### PR DESCRIPTION
The exit codes for 126 and 127 were reversed.  For the record, the exit
codes used are as follows:

* 125 if ‘chroot’ itself fails
* 126 if COMMAND is found but cannot be invoked
* 127 if COMMAND cannot be found

This resolves issue #367

Signed-off-by: baude <bbaude@redhat.com>