### PR TITLE
ci/papr: Disable and remove docker on FAH27

### DIFF
--- a/.papr-reboot-wait.sh
+++ b/.papr-reboot-wait.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/bash
+set -xeuo pipefail
+host=$1
+
+ssh_args="-o UserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no -o GSSAPIAuthentication=no root@${host}"
+dossh() {
+    ssh ${ssh_args} "$@"
+}
+get_bootid() {
+    dossh cat /proc/sys/kernel/random/boot_id
+}
+
+# The bootid approach is taken from rpm-ostree's libvm.sh;
+# the key problem we're trying to avoid is racing back in
+# via ssh to the system as it's shutting down.
+bootid=$(get_bootid)
+
+dossh systemctl reboot || true
+
+for x in $(seq 10); do
+    # Be more verbose on the last attempt
+    new_bootid=$(get_bootid 2>/dev/null || true)
+    if test -n "${new_bootid}" && test ${new_bootid} != ${bootid}; then
+       exit 0
+    fi
+    sleep 3
+done
+echo "Failed to wait for $host; trying one more time with verbose for debugging"
+ssh -vv ${ssh_args} true
+exit 1

--- a/.papr.yml
+++ b/.papr.yml
@@ -3,17 +3,25 @@ branches:
   - auto
   - try
 
-host:
-  distro: fedora/27/atomic
-  specs:
-     ram: 8192
-     cpus: 4
+cluster:
+  hosts:
+    - name: testnode
+      distro: fedora/27/atomic
+      specs:
+        ram: 8192
+        cpus: 4
+  container:
+    image: registry.fedoraproject.org/fedora:27
 
 required: true
 timeout: 45m
 
 tests:
-  -  sh .papr_prepare.sh
+  # Docker's iptables rules can conflict with podman; though long term we
+  # are going to have to make the two always work together
+  - ssh testnode /bin/sh -c 'systemctl stop docker && rpm-ostree override remove docker{,-common,-rhel-push-plugin} cockpit-docker'
+  - ./.papr-reboot-wait.sh testnode
+  - "scp .papr_prepare.sh testnode: && ssh testnode ./.papr_prepare.sh"
 
 context: "FAH27"
 ---
@@ -34,6 +42,9 @@ extra-repos:
 
 context: "CAH smoketested"
 
+tests:
+  - CONTAINER_RUNTIME=docker ./.papr_prepare.sh
+
 ---
 
 inherit: true
@@ -50,6 +61,6 @@ packages:
     - podman
     - buildah
 tests:
-    - CONTAINER_RUNTIME="podman" sh .papr_prepare.sh
+    - ./.papr_prepare.sh
 required: false
 context: "Fedora fedora/27/cloud Podman"

--- a/.papr_prepare.sh
+++ b/.papr_prepare.sh
@@ -1,8 +1,24 @@
 #!/bin/bash
 set -xeuo pipefail
 
+# Provision the previous version of podman to use for our tests by default
+cat >/etc/yum.repos.d/crio-copr.repo <<EOF
+[crio-copr]
+baseurl=https://copr-be.cloud.fedoraproject.org/results/baude/Upstream_CRIO_Family/fedora-27-x86_64/
+gpgcheck=0
+EOF
+
+pkg_install() {
+    if test -x /usr/bin/yum; then
+        yum -y install "$@"
+    else
+        rpm-ostree install "$@" && rpm-ostree ex livefs
+    fi
+}
+pkg_install podman buildah
+
 DIST=${DIST:=Fedora}
-CONTAINER_RUNTIME=${CONTAINER_RUNTIME:=docker}
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:=podman}
 IMAGE=fedorapodmanbuild
 PYTHON=python3
 if [[ ${DIST} != "Fedora" ]]; then


### PR DESCRIPTION
For now, per discussion e.g. `iptables` rules can interfere.