### PR TITLE
Add accessors to all container config and state fields

### DIFF
--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -95,7 +95,7 @@ func mountCmd(c *cli.Context) error {
 			return errors.Wrapf(err2, "error reading list of all containers")
 		}
 		for _, container := range containers {
-			mountPoint, err := container.MountPoint()
+			mountPoint, err := container.Mountpoint()
 			if err != nil {
 				return errors.Wrapf(err, "error getting mountpoint for %q", container.ID())
 			}


### PR DESCRIPTION
This way we won't have to grab the entire config to look up individual items

Note: does not have accessors for the spec yet