### PR TITLE
Refactor Spec Generation in libpod into a function

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -468,6 +468,21 @@ func (c *Container) RuntimeName() string {
 	return c.runtime.ociRuntime.name
 }
 
+// Runtime spec accessors
+// Unlocked
+
+// Hostname gets the container's hostname
+func (c *Container) Hostname() string {
+	if c.config.Spec.Hostname != "" {
+		return c.config.Spec.Hostname
+	}
+
+	if len(c.ID()) < 11 {
+		return c.ID()
+	}
+	return c.ID()[:12]
+}
+
 // State Accessors
 // Require locking
 
@@ -644,16 +659,4 @@ func (c *Container) RWSize() (int64, error) {
 		}
 	}
 	return c.rwSize()
-}
-
-// Hostname gets the container's hostname
-func (c *Container) Hostname() string {
-	if c.config.Spec.Hostname != "" {
-		return c.config.Spec.Hostname
-	}
-
-	if len(c.ID()) < 11 {
-		return c.ID()
-	}
-	return c.ID()[:12]
 }

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -645,3 +645,15 @@ func (c *Container) RWSize() (int64, error) {
 	}
 	return c.rwSize()
 }
+
+// Hostname gets the container's hostname
+func (c *Container) Hostname() string {
+	if c.config.Spec.Hostname != "" {
+		return c.config.Spec.Hostname
+	}
+
+	if len(c.ID()) < 11 {
+		return c.ID()
+	}
+	return c.ID()[:12]
+}


### PR DESCRIPTION
Move generation of the OCI spec into a function so we can call it from other places. Necessary for further work on Pod API and container restart.