### PR TITLE
CreateContainerStorage by image id

### DIFF
--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -67,7 +67,7 @@ func (r *storageService) CreateContainerStorage(systemContext *types.SystemConte
 		return ContainerInfo{}, ErrEmptyID
 	}
 	//// Check if we have the specified image.
-	ref, err := istorage.Transport.ParseStoreReference(r.store, imageName)
+	ref, err := istorage.Transport.ParseStoreReference(r.store, imageID)
 	if err != nil {
 		return ContainerInfo{}, err
 	}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -31,23 +31,20 @@ var _ = Describe("Podman run", func() {
 
 	It("podman run a container based on local image", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "ls"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-
 	})
 
 	It("podman run a container based on local image with short options", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", ALPINE, "ls"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-
 	})
 
 	It("podman run a container based on remote image", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", BB_GLIBC, "ls"})
-		session.Wait(45)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-
 	})
 
 	It("podman run selinux grep test", func() {
@@ -56,7 +53,7 @@ var _ = Describe("Podman run", func() {
 			Skip("SELinux not enabled")
 		}
 		session := podmanTest.Podman([]string{"run", "-it", "--security-opt", "label=level:s0:c1,c2", ALPINE, "cat", "/proc/self/attr/current"})
-		session.Wait(30)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		match, _ := session.GrepString("s0:c1,c2")
 		Expect(match).Should(BeTrue())
@@ -64,45 +61,45 @@ var _ = Describe("Podman run", func() {
 
 	It("podman run capabilities test", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--cap-add", "all", ALPINE, "cat", "/proc/self/status"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--cap-add", "sys_admin", ALPINE, "cat", "/proc/self/status"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--cap-drop", "all", ALPINE, "cat", "/proc/self/status"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--cap-drop", "setuid", ALPINE, "cat", "/proc/self/status"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman run environment test", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR", ALPINE, "printenv", "FOO"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		match, _ := session.GrepString("BAR")
 		Expect(match).Should(BeTrue())
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "PATH=/bin", ALPINE, "printenv", "PATH"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		match, _ = session.GrepString("/bin")
 		Expect(match).Should(BeTrue())
 
 		os.Setenv("FOO", "BAR")
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		match, _ = session.GrepString("BAR")
 		Expect(match).Should(BeTrue())
 		os.Unsetenv("FOO")
 
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		// This currently does not work
@@ -117,25 +114,25 @@ var _ = Describe("Podman run", func() {
 	It("podman run limits test", func() {
 		podmanTest.RestoreArtifact(fedoraMinimal)
 		session := podmanTest.Podman([]string{"run", "--rm", "--ulimit", "rtprio=99", "--cap-add=sys_nice", fedoraMinimal, "cat", "/proc/self/sched"})
-		session.Wait(45)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--ulimit", "nofile=2048:2048", fedoraMinimal, "ulimit", "-n"})
-		session.Wait(45)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("2048"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--ulimit", "nofile=1024:1028", fedoraMinimal, "ulimit", "-n"})
-		session.Wait(45)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("1024"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--oom-kill-disable=true", fedoraMinimal, "echo", "memory-hog"})
-		session.Wait(45)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--oom-score-adj=100", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
-		session.Wait(45)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("100"))
 	})
@@ -145,28 +142,28 @@ var _ = Describe("Podman run", func() {
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		os.Mkdir(mountPath, 0755)
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/run/test", mountPath), ALPINE, "cat", "/proc/self/mountinfo"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("/run/test rw,relatime"))
 
 		mountPath = filepath.Join(podmanTest.TempDir, "secrets")
 		os.Mkdir(mountPath, 0755)
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/run/test:ro", mountPath), ALPINE, "cat", "/proc/self/mountinfo"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("/run/test ro,relatime"))
 
 		mountPath = filepath.Join(podmanTest.TempDir, "secrets")
 		os.Mkdir(mountPath, 0755)
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/run/test:shared", mountPath), ALPINE, "cat", "/proc/self/mountinfo"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("/run/test rw,relatime, shared"))
 	})
 
 	It("podman run with cidfile", func() {
 		session := podmanTest.Podman([]string{"run", "--cidfile", "/tmp/cidfile", ALPINE, "ls"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		err := os.Remove("/tmp/cidfile")
 		Expect(err).To(BeNil())
@@ -174,14 +171,14 @@ var _ = Describe("Podman run", func() {
 
 	It("podman run sysctl test", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--sysctl", "net.core.somaxconn=65535", ALPINE, "sysctl", "net.core.somaxconn"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("net.core.somaxconn = 65535"))
 	})
 
 	It("podman run blkio-weight test", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--blkio-weight=15", ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.weight"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("15"))
 	})
@@ -190,7 +187,7 @@ var _ = Describe("Podman run", func() {
 		sock := "/run/sock"
 		os.Setenv("NOTIFY_SOCKET", sock)
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "NOTIFY_SOCKET"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		match, _ := session.GrepString(sock)
 		Expect(match).Should(BeTrue())
@@ -200,12 +197,23 @@ var _ = Describe("Podman run", func() {
 	It("podman run log-opt", func() {
 		log := filepath.Join(podmanTest.TempDir, "/container.log")
 		session := podmanTest.Podman([]string{"run", "--rm", "--log-opt", fmt.Sprintf("path=%s", log), ALPINE, "ls"})
-		session.Wait(10)
+		session.WaitWithDefaultTimeout()
 		fmt.Println(session.OutputToString())
 		Expect(session.ExitCode()).To(Equal(0))
 		_, err := os.Stat(log)
 		Expect(err).To(BeNil())
 		_ = os.Remove(log)
+	})
+
+	It("podman run tagged image", func() {
+		tag := podmanTest.Podman([]string{"tag", "busybox", "bb"})
+		tag.WaitWithDefaultTimeout()
+		Expect(tag.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"run", "--rm", "bb", "ls"})
+		session.WaitWithDefaultTimeout()
+		fmt.Println(session.OutputToString())
+		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 })


### PR DESCRIPTION
When creating container storage by name, if that name is a tagged image then the storage
could not be found.  We now use the image id which seems more reliable. Also added an
integration test to protect against regression.

Signed-off-by: baude <bbaude@redhat.com>