### PR TITLE
WIP: Relax locking on container exec

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -469,6 +469,5 @@ func (r *OCIRuntime) unpauseContainer(ctr *Container) error {
 
 //execContiner executes a command in a running container
 func (r *OCIRuntime) execContainer(c *Container, cmd []string, globalOpts runcGlobalOptions, commandOpts runcExecOptions) error {
-	r.RuncExec(c, cmd, globalOpts, commandOpts)
-	return nil
+	return r.RuncExec(c, cmd, globalOpts, commandOpts)
 }


### PR DESCRIPTION
At present, we lock until the exec'd process exits. That is far too aggressive, and blocks any other API operation while an exec session is running. Only lock while we're checking the status of the container.

There may be issues around cleanup caused by this. We may need more active tracking of exec sessions to make sure we don't clean up storage while an exec is running.