### PR TITLE
Tagging an image alias by shortname

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -127,7 +127,9 @@ func iterateInput(c *cli.Context, args []string, runtime *libpod.Runtime, inspec
 				break
 			}
 		case inspectTypeImage:
-			image, err := runtime.GetImage(input)
+			newImage := runtime.NewImage(input)
+			newImage.GetLocalImageName()
+			image, err := runtime.GetImage(newImage.LocalName)
 			if err != nil {
 				inspectError = errors.Wrapf(err, "error getting image %q", input)
 				break
@@ -140,7 +142,9 @@ func iterateInput(c *cli.Context, args []string, runtime *libpod.Runtime, inspec
 		case inspectAll:
 			ctr, err := runtime.LookupContainer(input)
 			if err != nil {
-				image, err := runtime.GetImage(input)
+				newImage := runtime.NewImage(input)
+				newImage.GetLocalImageName()
+				image, err := runtime.GetImage(newImage.LocalName)
 				if err != nil {
 					inspectError = errors.Wrapf(err, "error getting image %q", input)
 					break

--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -30,7 +30,10 @@ func tagCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	img, err := runtime.GetImage(args[0])
+	newImage := runtime.NewImage(args[0])
+	newImage.GetLocalImageName()
+
+	img, err := runtime.GetImage(newImage.LocalName)
 	if err != nil {
 		return err
 	}

--- a/docs/podman-tag.1.md
+++ b/docs/podman-tag.1.md
@@ -6,20 +6,14 @@
 podman tag - Add an additional name to a local image
 
 ## SYNOPSIS
-**podman tag**
+**podman [GLOBAL OPTIONS] tag IMAGE[:TAG] TARGET_NAME[:TAG]**
 [**--help**|**-h**]
 
 ## DESCRIPTION
-Assigns a new alias to an image in a registry.  An alias refers to the entire image name, including the optional **TAG** after the ':'
+Assigns a new alias to an image.  An alias refers to the entire image name, including the optional
+**TAG** after the ':' If you do not provide a :TAG, podman will assume a :TAG of "latest" for both
+the IMAGE and the TARGET_NAME.
 
-**podman [GLOBAL OPTIONS]**
-
-**podman [GLOBAL OPTIONS] tag [OPTIONS]**
-
-## GLOBAL OPTIONS
-
-**--help, -h**
-  Print usage statement
 
 ## EXAMPLES
 

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -66,4 +66,18 @@ var _ = Describe("Podman tag", func() {
 		Expect(StringInSlice("docker.io/library/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
 		Expect(StringInSlice("foobar:new", inspectData[0].RepoTags)).To(BeTrue())
 	})
+
+	It("podman tag shortname image no tag", func() {
+		session := podmanTest.Podman([]string{"tag", ALPINE, "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"tag", "foobar", "barfoo"})
+		results.WaitWithDefaultTimeout()
+		Expect(results.ExitCode()).To(Equal(0))
+
+		verify := podmanTest.Podman([]string{"inspect", "barfoo"})
+		verify.WaitWithDefaultTimeout()
+		Expect(verify.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
When trying to tag an alias (tag) of an image using only the shortname
and no tag, we were unable to find the image in storage.  This corrects
that issue and adds an integration test to protect against regression. I
also updated the man page per the filed issue.

While writing the integration test, I discovered that inspect could also
not find a tagged image without its :tag.

Resolves Issue #385
Resolves Issue #384

Signed-off-by: baude <bbaude@redhat.com>