### PR TITLE
Restrict top output to container's pids only

### DIFF
--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -70,11 +70,11 @@ func topCmd(c *cli.Context) error {
 
 	psArgs = append(psArgs, psOpts...)
 
-	results, err := container.GetContainerPidInformation(psArgs)
+	psOutput, err := container.GetContainerPidInformation(psArgs)
 	if err != nil {
 		return err
 	}
-	for _, line := range results {
+	for _, line := range psOutput {
 		fmt.Println(line)
 	}
 	return nil

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -59,14 +59,26 @@ var _ = Describe("Podman top", func() {
 		Expect(len(result.OutputToStringArray())).To(BeNumerically(">", 1))
 	})
 
-	It("podman top on non-running container", func() {
+	It("podman top with options", func() {
 		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "top", "-d", "2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"top", session.OutputToString(), "-o", "fuser,f,comm,label"})
+		result := podmanTest.Podman([]string{"top", session.OutputToString(), "-o", "pid,fuser,f,comm,label"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(len(result.OutputToStringArray())).To(BeNumerically(">", 1))
 	})
+
+	It("podman top on container invalid options", func() {
+		sleep := podmanTest.RunSleepContainer("")
+		sleep.WaitWithDefaultTimeout()
+		Expect(sleep.ExitCode()).To(Equal(0))
+		cid := sleep.OutputToString()
+
+		result := podmanTest.Podman([]string{"top", cid, "-o time"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+	})
+
 })


### PR DESCRIPTION
Due to the way ps arguments work, it was possible to display pids
that dont below to the container in top output. We now filter pids
that dont belong to the container out of the output.  This also means
the pid column must be present in the output or we throw an error.

This resolves issue #391
Signed-off-by: baude <bbaude@redhat.com>