### PR TITLE
podman load dont panic when no repotags

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -624,7 +624,17 @@ func (r *Runtime) getPullListFromRef(srcRef types.ImageReference, imgName string
 			}
 			pullStructs = append(pullStructs, pullInfo)
 		} else {
-			pullInfo, err := r.getPullStruct(srcRef, manifest[0].RepoTags[0])
+			var dest string
+			if len(manifest[0].RepoTags) > 0 {
+				dest = manifest[0].RepoTags[0]
+			} else {
+				// If the input image has no repotags, we need to feed it a dest anyways
+				dest, err = getImageDigest(srcRef, sc)
+				if err != nil {
+					return nil, err
+				}
+			}
+			pullInfo, err := r.getPullStruct(srcRef, dest)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
When performing a podman load, if there were no repotags in the image, podman would panic. In
the case that the incoming image does have repotags, it should be imported as a none:none image
so it can still be used by the user.

Resolves issue #403

Signed-off-by: baude <bbaude@redhat.com>