### PR TITLE
ps displays incorrect exit code

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -441,7 +441,7 @@ func getTemplateOutput(containers []*libpod.Container, opts psOptions) ([]psTemp
 
 		switch batchInfo.conState {
 		case libpod.ContainerStateStopped:
-			status = fmt.Sprintf("Exited (%d) %s ago", exitCode, runningFor)
+			status = fmt.Sprintf("Exited (%d) %s ago", batchInfo.exitCode, runningFor)
 		case libpod.ContainerStateRunning:
 			status = "Up " + runningFor + " ago"
 		case libpod.ContainerStatePaused:


### PR DESCRIPTION
The exit code should be derived in the batch operation and pulled
from the batchinfo struct.

Resolves issue #407

Signed-off-by: baude <bbaude@redhat.com>