### PR TITLE
Remove build alias

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -69,7 +69,6 @@ var (
 	buildDescription = "podman build launches the Buildah command to build an OCI Image. Buildah must be installed for this command to work."
 	buildCommand     = cli.Command{
 		Name:        "build",
-		Aliases:     []string{"build"},
 		Usage:       "Build an image using instructions in a Dockerfile",
 		Description: buildDescription,
 		Flags:       buildFlags,


### PR DESCRIPTION
Currently help output for podman shows
```
$ podman
NAME:
   podman - manage pods and images

USAGE:
   podman [global options] command [command options] [arguments...]

COMMANDS:
     attach           Attach to a running container
     commit           Create new image based on the changed container
     build, build     Build an image using instructions in a Dockerfile <--
     create           create but do not start a container
```

This removes the alias that is the same as the name to prevent it from being shown twice.