### PR TITLE
CNIPluginDir: check "/usr/lib/cni"

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -89,7 +89,7 @@ var (
 		MaxLogSize:    -1,
 		NoPivotRoot:   false,
 		CNIConfigDir:  "/etc/cni/net.d/",
-		CNIPluginDir:  []string{"/usr/libexec/cni", "/opt/cni/bin"},
+		CNIPluginDir:  []string{"/usr/libexec/cni", "/usr/lib/cni", "/opt/cni/bin"},
 	}
 )
 


### PR DESCRIPTION
Also consider "/usr/lib/cni" as a potential directory for CNI plugins.
On some distributions, e.g., on openSUSE, %{_libexecdir} evaluates to
"/usr/lib".

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>