### PR TITLE
podman stats add networking

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -632,7 +632,7 @@ func (c *Container) NamespacePath(ns LinuxNS) (string, error) {
 
 // CGroupPath returns a cgroups "path" for a given container.
 func (c *Container) CGroupPath() cgroups.Path {
-	return cgroups.StaticPath(filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-conmon-%s", c.ID())))
+	return cgroups.StaticPath(filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-conmon-%s/%s", c.ID(), c.ID())))
 }
 
 // RootFsSize returns the root FS size of the container


### PR DESCRIPTION
Add networking information to podman stats output.  Also correct an issue filed
where memory constraints of the cgroup were not reflected in the stats output. And
finally, fix issue with PID count.

Resolves issue #364

Signed-off-by: baude <bbaude@redhat.com>