### PR TITLE
podman info add registries

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -392,5 +392,20 @@ func (r *Runtime) Info() ([]InfoData, error) {
 	}
 	info = append(info, InfoData{Type: "store", Data: storeInfo})
 
+	reg, err := GetRegistries()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting registries")
+	}
+	registries := make(map[string]interface{})
+	registries["registries"] = reg
+	info = append(info, InfoData{Type: "registries", Data: registries})
+
+	i, err := GetInsecureRegistries()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting registries")
+	}
+	insecureRegistries := make(map[string]interface{})
+	insecureRegistries["registries"] = i
+	info = append(info, InfoData{Type: "insecure registries", Data: insecureRegistries})
 	return info, nil
 }


### PR DESCRIPTION
add registries and insecure registries to the podman info output.  this gives us
some capatibility with other container runtimes.

Resolves issue #420

Signed-off-by: baude <bbaude@redhat.com>