### PR TITLE
Add support for Libpod configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ PREFIX ?= ${DESTDIR}/usr/local
 BINDIR ?= ${PREFIX}/bin
 LIBEXECDIR ?= ${PREFIX}/libexec
 MANDIR ?= ${PREFIX}/share/man
+SHAREDIR_CONTAINERS ?= ${PREFIX}/share/containers
 ETCDIR ?= ${DESTDIR}/etc
 ETCDIR_LIBPOD ?= ${ETCDIR}/crio
-ETCDIR_CONTAINERS ?= ${ETCDIR}/containers
 BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh)
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
@@ -151,7 +151,7 @@ install.man: docs
 	install ${SELINUXOPT} -m 644 $(filter %.1,$(MANPAGES)) -t $(MANDIR)/man1
 
 install.config:
-	install ${SELINUXOPT} -D -m 644 libpod.conf ${ETCDIR_CONTAINERS}/libpod.conf
+	install ${SELINUXOPT} -D -m 644 libpod.conf ${SHAREDIR_CONTAINERS}/libpod.conf
 	install ${SELINUXOPT} -D -m 644 seccomp.json $(ETCDIR_LIBPOD)/seccomp.json
 	install ${SELINUXOPT} -D -m 644 crio-umount.conf $(OCIUMOUNTINSTALLDIR)/crio-umount.conf
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LIBEXECDIR ?= ${PREFIX}/libexec
 MANDIR ?= ${PREFIX}/share/man
 ETCDIR ?= ${DESTDIR}/etc
 ETCDIR_LIBPOD ?= ${ETCDIR}/crio
+ETCDIR_CONTAINERS ?= ${ETCDIR}/containers
 BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh)
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
@@ -150,6 +151,7 @@ install.man: docs
 	install ${SELINUXOPT} -m 644 $(filter %.1,$(MANPAGES)) -t $(MANDIR)/man1
 
 install.config:
+	install ${SELINUXOPT} -D -m 644 libpod.conf ${ETCDIR_CONTAINERS}/libpod.conf
 	install ${SELINUXOPT} -D -m 644 seccomp.json $(ETCDIR_LIBPOD)/seccomp.json
 	install ${SELINUXOPT} -D -m 644 crio-umount.conf $(OCIUMOUNTINSTALLDIR)/crio-umount.conf
 

--- a/libpod.conf
+++ b/libpod.conf
@@ -1,0 +1,54 @@
+# libpod.conf is the default configuration file for all tools using libpod to
+# manage containers
+
+# Default transport method for pulling and pushing for images
+image_default_transport = "docker://"
+
+# Paths to look for a valid OCI runtime (runc, runv, etc)
+runtime_path = [
+	     "/usr/bin/runc",
+	     "/usr/sbin/runc",
+	     "/sbin/runc",
+	     "/bin/runc",
+	     "/usr/lib/cri-o-runc/sbin/runc"
+]
+
+# Paths to look for the Conmon container manager binary
+conmon_path = [
+	    "/usr/libexec/crio/conmon",
+	    "/usr/local/libexec/crio/conmon",
+	    "/usr/bin/conmon",
+	    "/usr/sbin/conmon",
+	    "/usr/lib/crio/bin/conmon"
+]
+
+# Environment variables to pass into conmon
+conmon_env_vars = [
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+]
+
+# CGroup Manager - valid values are "systemd" and "cgroupfs"
+cgroup_manager = "cgroupfs"
+
+# Directory for persistent libpod files (database, etc)
+static_dir = "/var/lib/containers/storage/libpod"
+
+# Directory for temporary files. Must be tmpfs (wiped after reboot)
+tmp_dir = "/var/run/libpod"
+
+# Maximum size of log files (in bytes)
+# -1 is unlimited
+max_log_size = -1
+
+# Whether to use chroot instead of pivot_root in the runtime
+no_pivot_root = false
+
+# Directory containing CNI plugin configuration files
+cni_config_dir = "/etc/cni/net.d/"
+
+# Directories where the CNI plugin binaries may be located
+cni_plugin_dir = [
+	       "/usr/libexec/cni",
+	       "/usr/lib/cni",
+	       "/opt/cni/bin"
+]

--- a/libpod.conf
+++ b/libpod.conf
@@ -31,7 +31,10 @@ conmon_env_vars = [
 cgroup_manager = "cgroupfs"
 
 # Directory for persistent libpod files (database, etc)
-static_dir = "/var/lib/containers/storage/libpod"
+# By default, this will be configured relative to where containers/storage
+# stores containers
+# Uncomment to change location from this default
+#static_dir = "/var/lib/containers/storage/libpod"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 tmp_dir = "/var/run/libpod"

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -101,7 +101,11 @@ func WithOCIRuntime(runtimePath string) RuntimeOption {
 			return ErrRuntimeFinalized
 		}
 
-		rt.config.RuntimePath = runtimePath
+		if runtimePath == "" {
+			return errors.Wrapf(ErrInvalidArg, "must provide a valid path")
+		}
+
+		rt.config.RuntimePath = []string{runtimePath}
 
 		return nil
 	}
@@ -114,10 +118,13 @@ func WithConmonPath(path string) RuntimeOption {
 		if rt.valid {
 			return ErrRuntimeFinalized
 		}
-		// TODO Once libkpod is eliminated, "" should throw an error
-		if path != "" {
-			rt.config.ConmonPath = path
+
+		if path == "" {
+			return errors.Wrapf(ErrInvalidArg, "must provide a valid path")
 		}
+
+		rt.config.ConmonPath = []string{path}
+
 		return nil
 	}
 }

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -277,7 +277,7 @@ func makeRuntime(runtime *Runtime) error {
 	if !foundConmon {
 		return errors.Wrapf(ErrInvalidArg,
 			"could not find a working conmon binary (configured options: %v)",
-			runtime.config.RuntimePath)
+			runtime.config.ConmonPath)
 	}
 
 	// Set up containers/storage

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -81,7 +81,7 @@ type RuntimeConfig struct {
 	// images
 	ImageDefaultTransport string `toml:"image_default_transport"`
 	// SignaturePolicyPath is the path to a signature policy to use for
-	// validationg images
+	// validating images
 	// If left empty, the containers/image default signature policy will
 	// be used
 	SignaturePolicyPath string `toml:"signature_policy_path,omitempty"`
@@ -217,7 +217,7 @@ func NewRuntimeFromConfig(configPath string, options ...RuntimeOption) (runtime 
 
 	// Check to see if the given configuration file exists
 	if _, err := os.Stat(configPath); err != nil {
-		return nil, errors.Wrapf(err, "error stating configuration file %s", configPath)
+		return nil, errors.Wrapf(err, "error checking existence of configuration file %s", configPath)
 	}
 
 	// Read contents of the config file


### PR DESCRIPTION
Add a configuration file (`/etc/containerd/libpod.conf`) that we can read to override our default configuration. This file is optional, and if not present we'll use our baked-in defaults as before.