### PR TITLE
Instead of erroring on exit file not being found, log an error

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -394,7 +394,7 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container) error {
 		if err != nil {
 			ctr.state.ExitCode = -1
 			ctr.state.FinishedTime = time.Now()
-			logrus.Errorf("No exit file for container %s found: %v", ctr.ID())
+			logrus.Errorf("No exit file for container %s found: %v", ctr.ID(), err)
 			return nil
 		}
 

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -394,7 +394,8 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container) error {
 		if err != nil {
 			ctr.state.ExitCode = -1
 			ctr.state.FinishedTime = time.Now()
-			return errors.Wrapf(err, "no exit file for container %s found", ctr.ID())
+			logrus.Errorf("No exit file for container %s found: %v", ctr.ID())
+			return nil
 		}
 
 		ctr.state.FinishedTime = getFinishedTime(fi)


### PR DESCRIPTION
Erroring can cause us to get into an state where a container which has no exit file cannot be shown in PS, cannot be removed, etc.
