### PR TITLE
Run gofmt and lint just for one Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,14 @@ jobs:
       script:
         - make gofmt
         - make lint
+      go: 1.9.x
+    - script:
         - make testunit
-        - make docs
         - make
       go: 1.8.x
     - stage: Build and Verify
       script:
-        - make gofmt
-        - make lint
         - make testunit
-        - make docs
         - make
       go: 1.9.x
     - stage: Integration Test


### PR DESCRIPTION
Also, "make docs" is part of "make all" so the step was being repeated.

This PR was created for a comment that @rhatdna made here: https://github.com/kubernetes-incubator/cri-o/pull/1412#issuecomment-370239969