### PR TITLE
[WIP] runtime_img: search registries: right trim slashes

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -553,7 +553,7 @@ func getRegistriesToTry(image string, store storage.Store, defaultTransport stri
 				" the image name '%s' is incomplete.", imageName)
 		}
 		for _, searchRegistry := range searchRegistries {
-			pImage.registry = searchRegistry
+			pImage.registry = strings.TrimRight(searchRegistry, "/")
 			srcRef, err := alltransports.ParseImageName(pImage.returnFQName())
 			if err != nil {
 				return nil, errors.Errorf("unable to parse '%s'", pImage.returnFQName())


### PR DESCRIPTION
Right trim slashes of search registries to avoid double slashes when
looking up images.  Otherwise, registries set to ["foo.com/bar/"] will
ultimately lead to an invalid "foo.com/bar//" reference.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>