### PR TITLE
Add podman info to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -42,4 +42,10 @@ Briefly describe the problem you are having in a few paragraphs.
 (paste your output here)
 ```
 
+**Output of `podman info`:**
+
+```
+(paste your output here)
+```
+
 **Additional environment details (AWS, VirtualBox, physical, etc.):**


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Added `podman info` to the issue template.  Verified that `docker events` is already listed as not supported in the transfer.md, no change there.