### PR TITLE
podman import, load, and commit are too verbose

### DIFF
--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -25,6 +25,10 @@ var (
 			Name:  "message, m",
 			Usage: "Set commit message for imported image",
 		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "Suppress output",
+		},
 	}
 	importDescription = `Create a container image from the contents of the specified tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz).
 	 Note remote tar balls can be specified, via web address.
@@ -84,6 +88,11 @@ func importCmd(c *cli.Context) error {
 	}
 
 	opts.ImageConfig = config
+	opts.Writer = nil
+
+	if !c.Bool("quiet") {
+		opts.Writer = os.Stderr
+	}
 
 	// if source is a url, download it and save to a temp file
 	u, err := url.ParseRequestURI(source)
@@ -96,7 +105,11 @@ func importCmd(c *cli.Context) error {
 		source = file
 	}
 
-	return runtime.ImportImage(source, opts)
+	img, err := runtime.ImportImage(source, opts)
+	if err == nil {
+		fmt.Println(img.ID)
+	}
+	return err
 }
 
 // donwloadFromURL downloads an image in the format "https:/example.com/myimage.tar"

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -672,6 +672,8 @@ _podman_commit() {
 	-h
 	--pause
 	-p
+	--quiet
+	-q
      "
     _complete_ "$options_with_args" "$boolean_options"
 
@@ -816,6 +818,8 @@ _podman_import() {
     local boolean_options="
 	--help
 	-h
+	--quiet
+	-q
      "
     _complete_ "$options_with_args" "$boolean_options"
 
@@ -1409,7 +1413,8 @@ _podman_save() {
      "
      local boolean_options="
 	 --compress
-     --quiet -q
+	 -q
+	 --quiet
      "
      _complete_ "$options_with_args" "$boolean_options"
 }
@@ -1529,7 +1534,8 @@ _podman_load() {
     --signature-policy
     "
     local boolean_options="
-    --quiet -q
+    --quiet
+    -q
     "
     _complete_ "$options_with_args" "$boolean_options"
 }

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -12,6 +12,7 @@ podman commit - Create new image based on the changed container
 [**--change**|**-c**]
 [**--message**|**-m**]
 [**--help**|**-h**]
+[**--verbose**]
 
 ## DESCRIPTION
 **podman commit** creates an image based on a changed container. The author of the
@@ -19,7 +20,8 @@ image can be set using the **--author** flag. Various image instructions can be
 configured with the **--change** flag and a commit message can be set using the
 **--message** flag. The container and its processes are paused while the image is
 committed. This minimizes the likelihood of data corruption when creating the new
-image. If this is not desired, the **--pause** flag can be set to false.
+image. If this is not desired, the **--pause** flag can be set to false. When the commit
+is complete, podman will print out the ID of the new image.
 
 **podman [GLOBAL OPTIONS]**
 
@@ -43,6 +45,9 @@ Set commit message for committed image
 **--pause, -p**
 Pause the container when creating an image
 
+**--quiet, -q**
+Suppress output
+
 ## EXAMPLES
 
 ```
@@ -54,39 +59,22 @@ Copying config sha256:c16a6d30f3782288ec4e7521c754acc29d37155629cb39149756f486da
  448 B / 448 B [============================================================] 0s
 Writing manifest to image destination
 Storing signatures
+e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
 ```
 
 ```
-# podman commit --message "committing container to image" reverent_golick image-commited
-Getting image source signatures
-Copying blob sha256:b41deda5a2feb1f03a5c1bb38c598cbc12c9ccd675f438edc6acd815f7585b86
- 25.80 MB / 25.80 MB [======================================================] 0s
-Copying config sha256:af376cdda5c0ac1d9592bf56567253d203f8de6a8edf356c683a645d75221540
- 376 B / 376 B [============================================================] 0s
-Writing manifest to image destination
-Storing signatures
+# podman commit -q --message "committing container to image" reverent_golick image-commited
+e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
 ```
 
 ```
-# podman commit --author "firstName lastName" reverent_golick
-Getting image source signatures
-Copying blob sha256:b41deda5a2feb1f03a5c1bb38c598cbc12c9ccd675f438edc6acd815f7585b86
- 25.80 MB / 25.80 MB [======================================================] 0s
-Copying config sha256:d61387b4d5edf65edee5353e2340783703074ffeaaac529cde97a8357eea7645
- 378 B / 378 B [============================================================] 0s
-Writing manifest to image destination
-Storing signatures
+# podman commit -q --author "firstName lastName" reverent_golick
+e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
 ```
 
 ```
-# podman commit --pause=false reverent_golick image-commited
-Getting image source signatures
-Copying blob sha256:b41deda5a2feb1f03a5c1bb38c598cbc12c9ccd675f438edc6acd815f7585b86
- 25.80 MB / 25.80 MB [======================================================] 0s
-Copying config sha256:5813fe8a3b18696089fd09957a12e88bda43dc1745b5240879ffffe93240d29a
- 419 B / 419 B [============================================================] 0s
-Writing manifest to image destination
-Storing signatures
+# podman commit -q --pause=false reverent_golick image-commited
+e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
 ```
 
 ## SEE ALSO

--- a/docs/podman-import.1.md
+++ b/docs/podman-import.1.md
@@ -11,6 +11,7 @@ podman import - Import a tarball and save it as a filesystem image
 [**--change**|**-c**]
 [**--message**|**-m**]
 [**--help**|**-h**]
+[**-verbose**]
 
 ## DESCRIPTION
 **podman import** imports a tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz)
@@ -34,6 +35,9 @@ Can be set multiple times
 **--message, -m**
 Set commit message for imported image
 
+**--quiet, -q**
+Shows progress on the import
+
 ## EXAMPLES
 
 ```
@@ -45,17 +49,12 @@ Copying config sha256:c16a6d30f3782288ec4e7521c754acc29d37155629cb39149756f486da
  448 B / 448 B [============================================================] 0s
 Writing manifest to image destination
 Storing signatures
+db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```
 
 ```
-# cat ctr.tar | podman import --message "importing the ctr.tar tarball" - image-imported
-Getting image source signatures
-Copying blob sha256:b41deda5a2feb1f03a5c1bb38c598cbc12c9ccd675f438edc6acd815f7585b86
- 25.80 MB / 25.80 MB [======================================================] 0s
-Copying config sha256:af376cdda5c0ac1d9592bf56567253d203f8de6a8edf356c683a645d75221540
- 376 B / 376 B [============================================================] 0s
-Writing manifest to image destination
-Storing signatures
+# cat ctr.tar | podman -q import --message "importing the ctr.tar tarball" - image-imported
+db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```
 
 ```
@@ -67,6 +66,7 @@ Copying config sha256:d61387b4d5edf65edee5353e2340783703074ffeaaac529cde97a8357e
  378 B / 378 B [============================================================] 0s
 Writing manifest to image destination
 Storing signatures
+db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```
 
 ```
@@ -79,6 +79,7 @@ Copying config sha256:5813fe8a3b18696089fd09957a12e88bda43dc1745b5240879ffffe932
  419 B / 419 B [============================================================] 0s
 Writing manifest to image destination
 Storing signatures
+db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```
 
 ## SEE ALSO

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/containers/storage"
 	"github.com/docker/docker/daemon/caps"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/term"
@@ -557,19 +558,19 @@ func (c *Container) Inspect(size bool) (*inspect.ContainerInspectData, error) {
 
 // Commit commits the changes between a container and its image, creating a new
 // image
-func (c *Container) Commit(pause bool, options CopyOptions) error {
+func (c *Container) Commit(pause bool, options CopyOptions) (*storage.Image, error) {
 	if !c.locked {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 
 		if err := c.syncContainer(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if c.state.State == ContainerStateRunning && pause {
 		if err := c.runtime.ociRuntime.pauseContainer(c); err != nil {
-			return errors.Wrapf(err, "error pausing container %q", c.ID())
+			return nil, errors.Wrapf(err, "error pausing container %q", c.ID())
 		}
 		defer func() {
 			if err := c.runtime.ociRuntime.unpauseContainer(c); err != nil {
@@ -580,13 +581,13 @@ func (c *Container) Commit(pause bool, options CopyOptions) error {
 
 	tempFile, err := ioutil.TempFile(c.runtime.config.TmpDir, "podman-commit")
 	if err != nil {
-		return errors.Wrapf(err, "error creating temp file")
+		return nil, errors.Wrapf(err, "error creating temp file")
 	}
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
 	if err := c.export(tempFile.Name()); err != nil {
-		return err
+		return nil, err
 	}
 	return c.runtime.ImportImage(tempFile.Name(), options)
 }


### PR DESCRIPTION
The progress should not be show for import, load, and commit.  It makes machine
parsing of the output much more difficult.  Also, each command should output an
image ID or name for the user.

Added a --verbose flag for users that still want to see progress.

Resolves issue #450

Signed-off-by: baude <bbaude@redhat.com>