### PR TITLE
docs: podman-top: fix nonworking example

### DIFF
--- a/docs/podman-top.1.md
+++ b/docs/podman-top.1.md
@@ -33,10 +33,10 @@ to run containers such as CRI-O, the last started container could be from either
 ```
 
 ```
-#podman --log-level=debug top f5a62a71b07 -o fuser,f,comm,label
-FUSER    F COMMAND         LABEL
-root     4 bash            system_u:system_r:container_t:s0:c429,c1016
-root     0 vi              system_u:system_r:container_t:s0:c429,c1016
+#podman --log-level=debug top f5a62a71b07 -o pid,fuser,f,comm,label
+  PID FUSER    F COMMAND         LABEL
+18715 root     4 bash            system_u:system_r:container_t:s0:c429,c1016
+18741 root     0 vi              system_u:system_r:container_t:s0:c429,c1016
 #
 ```
 ## SEE ALSO


### PR DESCRIPTION
(minor) One example in the podman-top man page results in an
error when actually invoked:

    unable to find PID field in ps output. try a different set of ps arguments

Cause: commit 6cb1c31d (PR #400) has to check PIDs in order to
filter those in the container.

Solution: add 'pid' to the list of requested output fields in
the sample command.

Signed-off-by: Ed Santiago <santiago@redhat.com>