### PR TITLE
Do not strip binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
 
 # Update VPATH so make finds .gopathok
 VPATH := $(VPATH):$(GOPATH)
-SHRINKFLAGS := -s -w
-BASE_LDFLAGS := ${SHRINKFLAGS} -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO}
+BASE_LDFLAGS := -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO}
 LDFLAGS := -ldflags '${BASE_LDFLAGS}'
 LDFLAGS_PODMAN := -ldflags '${BASE_LDFLAGS}'
 


### PR DESCRIPTION
We should not strip binaries in Make. That should be left to packages.  Also,
we can not debug stripped binaries so this allows us to debug better as well.

Signed-off-by: baude <bbaude@redhat.com>