### PR TITLE
Update test-related makefile targets

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -13,7 +13,7 @@ export GITVALIDATE_TIP=$(cd $GOSRC; git log -2 --pretty='%H' | tail -n 1)
 export TAGS="seccomp $($GOSRC/hack/btrfs_tag.sh) $($GOSRC/hack/libdm_tag.sh) $($GOSRC/hack/btrfs_installed_tag.sh) $($GOSRC/hack/ostree_tag.sh) $($GOSRC/hack/selinux_tag.sh)"
 
 make gofmt TAGS="${TAGS}"
-make testunit TAGS="${TAGS}"
+make localunit TAGS="${TAGS}"
 
 make install.tools TAGS="${TAGS}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ jobs:
         - make lint
       go: 1.9.x
     - script:
-        - make testunit
+        - make localunit
         - make
       go: 1.8.x
     - stage: Build and Verify
       script:
-        - make testunit
+        - make localunit
         - make
       go: 1.9.x
     - stage: Integration Test

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,11 @@ libpodimage:
 dbuild: libpodimage
 	docker run --name=${LIBPOD_INSTANCE} --privileged ${LIBPOD_IMAGE} -v ${PWD}:/go/src/${PROJECT} --rm make binaries
 
+test: libpodimage
+	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all localunit localintegration
+
 integration: libpodimage
-	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make localintegration
+	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all localintegration
 
 integration.fedora:
 	DIST=Fedora sh .papr_prepare.sh
@@ -114,7 +117,10 @@ integration.fedora:
 integration.centos:
 	DIST=CentOS sh .papr_prepare.sh
 
-testunit:
+testunit: libpodimage
+	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make localunit
+
+localunit:
 	$(GO) test -tags "$(BUILDTAGS)" -cover $(PACKAGES)
 
 ginkgo:


### PR DESCRIPTION
Add a global 'test' target that runs unit and integration tests in a container.

Change the default unit test target to run the unit tests in a container, so they can be run as root

Always rebuild binaries when doing containerized integration tests, to prevent issues with mismatched libraries.