### PR TITLE
podman ps command string too long

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -435,6 +435,11 @@ func getTemplateOutput(containers []*libpod.Container, opts psOptions) ([]psTemp
 		}
 
 		command := strings.Join(batchInfo.conConfig.Spec.Process.Args, " ")
+		if !opts.noTrunc {
+			if len(command) > 20 {
+				command = command[:19] + "..."
+			}
+		}
 		ports := portsToString(batchInfo.conConfig.PortMappings)
 		mounts := getMounts(createArtifact.Volumes, opts.noTrunc)
 		labels := formatLabels(ctr.Labels())
@@ -471,6 +476,7 @@ func getTemplateOutput(containers []*libpod.Container, opts psOptions) ([]psTemp
 			Mounts:     mounts,
 			PID:        batchInfo.pid,
 		}
+
 		if opts.namespace {
 			params.Cgroup = ns.Cgroup
 			params.IPC = ns.IPC


### PR DESCRIPTION
The default outout for podman ps should limit itself if the command is long. If the command
is more than 20 characters, we truncate the command and add an elipses to it.

Resolves: #464

Signed-off-by: baude <bbaude@redhat.com>