### PR TITLE
Add new default location for conmon

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -15,6 +15,7 @@ runtime_path = [
 
 # Paths to look for the Conmon container manager binary
 conmon_path = [
+	    "/usr/libexec/podman/conmon",
 	    "/usr/libexec/crio/conmon",
 	    "/usr/local/libexec/crio/conmon",
 	    "/usr/bin/conmon",

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -117,6 +117,10 @@ func PodmanCreate(tempDir string) PodmanTest {
 		podmanBinary = os.Getenv("PODMAN_BINARY")
 	}
 	conmonBinary := filepath.Join("/usr/libexec/crio/conmon")
+	altConmonBinary := "/usr/libexec/podman/conmon"
+	if _, err := os.Stat(altConmonBinary); err == nil {
+		conmonBinary = altConmonBinary
+	}
 	if os.Getenv("CONMON_BINARY") != "" {
 		conmonBinary = os.Getenv("CONMON_BINARY")
 	}


### PR DESCRIPTION
This will allow overriding the CRI-O version of conmon in our packages (and elsewhere, if we need to). No change on systems without a binary at that path, we'll just fall through to the next possible path (the old default)
