### PR TITLE
podman-images: return correct image list

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -182,15 +182,20 @@ func getImagesTemplateOutput(runtime *libpod.Runtime, images []inspect.ImageResu
 		if !opts.noTrunc {
 			imageID = shortID(img.ID)
 		}
-		params := imagesTemplateParams{
-			Repository: img.Repository,
-			Tag:        img.Tag,
-			ID:         imageID,
-			Digest:     img.Digest,
-			Created:    units.HumanDuration(time.Since((createdTime))) + " ago",
-			Size:       units.HumanSizeWithPrecision(float64(*img.Size), 3),
+		// get all specified repo:tag pairs and print them separately
+		for repo, tags := range libpod.ReposToMap(img.RepoTags) {
+			for _, tag := range tags {
+				params := imagesTemplateParams{
+					Repository: repo,
+					Tag:        tag,
+					ID:         imageID,
+					Digest:     img.Digest,
+					Created:    units.HumanDuration(time.Since((createdTime))) + " ago",
+					Size:       units.HumanSizeWithPrecision(float64(*img.Size), 3),
+				}
+				imagesOutput = append(imagesOutput, params)
+			}
 		}
-		imagesOutput = append(imagesOutput, params)
 	}
 	return
 }

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -37,6 +37,28 @@ var _ = Describe("Podman images", func() {
 		Expect(session.LineInOuputStartsWith("docker.io/library/busybox")).To(BeTrue())
 	})
 
+	It("podman images with multiple tags", func() {
+		// tag "docker.io/library/alpine:latest" to "foo:{a,b,c}"
+		session := podmanTest.Podman([]string{"tag", ALPINE, "foo:a", "foo:b", "foo:c"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		// tag "foo:c" to "bar:{a,b}"
+		session = podmanTest.Podman([]string{"tag", "foo:c", "bar:a", "bar:b"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		// check all previous and the newly tagged images
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session.LineInOutputContainsTag("docker.io/library/alpine", "latest")
+		session.LineInOutputContainsTag("docker.io/library/busybox", "glibc")
+		session.LineInOutputContainsTag("foo", "a")
+		session.LineInOutputContainsTag("foo", "b")
+		session.LineInOutputContainsTag("foo", "c")
+		session.LineInOutputContainsTag("bar", "a")
+		session.LineInOutputContainsTag("bar", "b")
+	})
+
 	It("podman images with digests", func() {
 		session := podmanTest.Podman([]string{"images", "--digests"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Return and print the correct list of images by add all specified
RepoTags to one image object, and priting them separately in
repository:repotag pairs.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>