### PR TITLE
make shell: build, test and run in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ integration.fedora:
 integration.centos:
 	DIST=CentOS sh .papr_prepare.sh
 
+shell: libpodimage
+	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -it --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} sh
+
 testunit: libpodimage
 	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make localunit
 
@@ -223,4 +226,5 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man
 	install \
 	lint \
 	pause \
-	uninstall
+	uninstall \
+	shell

--- a/test/README.md
+++ b/test/README.md
@@ -57,3 +57,12 @@ make integration.fedora
 
 This will run lint, git-validation, and gofmt tests and then execute unit and integration
 tests as well.
+
+### Run tests in a container
+In case you have issue running the tests locally on your machine, you can run
+them in a container:
+```
+make shell
+```
+
+This will run a container and give you a shell and you can follow the instructions above.


### PR DESCRIPTION
Some of the paths in the e2e tests are hard-coded, which complicates
testing a bit on systems with different paths for runc, conmon, etc.
Add a make shell target to the Makefile, which will build and run the
libpod containers, giving a shell to the user in which podman can be
built, run, tested etc.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>