### PR TITLE
Stage3 Image Library

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/projectatomic/libpod/pkg/inspect"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -299,7 +300,7 @@ func isPortInPortBindings(pb map[nat.Port][]nat.PortBinding, port nat.Port) bool
 	for _, i := range pb {
 		hostPorts = append(hostPorts, i[0].HostPort)
 	}
-	return libpod.StringInSlice(port.Port(), hostPorts)
+	return util.StringInSlice(port.Port(), hostPorts)
 }
 
 // isPortInImagePorts determines if an exposed host port was given to us by metadata
@@ -625,7 +626,7 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 	}
 
 	// Check for . and dns-search domains
-	if libpod.StringInSlice(".", c.StringSlice("dns-search")) && len(c.StringSlice("dns-search")) > 1 {
+	if util.StringInSlice(".", c.StringSlice("dns-search")) && len(c.StringSlice("dns-search")) > 1 {
 		return nil, errors.Errorf("cannot pass additional search domains when also specifying '.'")
 	}
 

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/urfave/cli"
 )
 
@@ -89,7 +90,7 @@ func execCmd(c *cli.Context) error {
 	// key and value to the environment variables.  this is needed to set
 	// PATH for example.
 	for k, v := range defaultEnvVariables {
-		if !libpod.StringInSlice(k, userEnvKeys) {
+		if !util.StringInSlice(k, userEnvKeys) {
 			envs = append(envs, fmt.Sprintf("%s=%s", k, v))
 		}
 	}

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projectatomic/libpod/cmd/podman/formats"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/projectatomic/libpod/pkg/inspect"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -68,7 +69,7 @@ func inspectCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	if !libpod.StringInSlice(inspectType, []string{inspectTypeContainer, inspectTypeImage, inspectAll}) {
+	if !util.StringInSlice(inspectType, []string{inspectTypeContainer, inspectTypeImage, inspectAll}) {
 		return errors.Errorf("the only recognized types are %q, %q, and %q", inspectTypeContainer, inspectTypeImage, inspectAll)
 	}
 

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/formats"
 	"github.com/projectatomic/libpod/libpod"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"k8s.io/apimachinery/pkg/fields"
@@ -275,7 +276,7 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			return false
 		}, nil
 	case "status":
-		if !libpod.StringInSlice(filterValue, []string{"created", "restarting", "running", "paused", "exited", "unknown"}) {
+		if !util.StringInSlice(filterValue, []string{"created", "restarting", "running", "paused", "exited", "unknown"}) {
 			return nil, errors.Errorf("%s is not a valid status", filterValue)
 		}
 		return func(c *libpod.Container) bool {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	crioAnnotations "github.com/projectatomic/libpod/pkg/annotations"
 	"github.com/projectatomic/libpod/pkg/chrootuser"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/ulule/deepcopier"
 	"golang.org/x/sys/unix"
@@ -642,7 +643,7 @@ func (c *Container) generateResolvConf() (string, error) {
 	if len(c.config.DNSSearch) > 0 {
 		resolv.searchDomains = nil
 		// The . character means the user doesnt want any search domains in the container
-		if !StringInSlice(".", c.config.DNSSearch) {
+		if !util.StringInSlice(".", c.config.DNSSearch) {
 			resolv.searchDomains = append(resolv.searchDomains, c.Config().DNSSearch...)
 		}
 	}

--- a/libpod/container_top.go
+++ b/libpod/container_top.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/projectatomic/libpod/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -91,7 +92,7 @@ func filterPids(psOutput string, pids []string) ([]string, error) {
 		}
 		cols := fieldsASCII(l)
 		pid := cols[pidIndex]
-		if StringInSlice(pid, pids) {
+		if util.StringInSlice(pid, pids) {
 			output = append(output, l)
 		}
 	}

--- a/libpod/image/docker_registry_options.go
+++ b/libpod/image/docker_registry_options.go
@@ -1,0 +1,46 @@
+package image
+
+import "github.com/containers/image/types"
+
+// DockerRegistryOptions encapsulates settings that affect how we connect or
+// authenticate to a remote registry.
+type DockerRegistryOptions struct {
+	// DockerRegistryCreds is the user name and password to supply in case
+	// we need to pull an image from a registry, and it requires us to
+	// authenticate.
+	DockerRegistryCreds *types.DockerAuthConfig
+	// DockerCertPath is the location of a directory containing CA
+	// certificates which will be used to verify the registry's certificate
+	// (all files with names ending in ".crt"), and possibly client
+	// certificates and private keys (pairs of files with the same name,
+	// except for ".cert" and ".key" suffixes).
+	DockerCertPath string
+	// DockerInsecureSkipTLSVerify turns off verification of TLS
+	// certificates and allows connecting to registries without encryption.
+	DockerInsecureSkipTLSVerify bool
+}
+
+// GetSystemContext constructs a new system context from the given signaturePolicy path and the
+// values in the DockerRegistryOptions
+func (o DockerRegistryOptions) GetSystemContext(signaturePolicyPath, authFile string, forceCompress bool) *types.SystemContext {
+	sc := &types.SystemContext{
+		SignaturePolicyPath:         signaturePolicyPath,
+		DockerAuthConfig:            o.DockerRegistryCreds,
+		DockerCertPath:              o.DockerCertPath,
+		DockerInsecureSkipTLSVerify: o.DockerInsecureSkipTLSVerify,
+		AuthFilePath:                authFile,
+		DirForceCompress:            forceCompress,
+	}
+	return sc
+}
+
+// GetSystemContext Constructs a new containers/image/types.SystemContext{} struct from the given signaturePolicy path
+func GetSystemContext(signaturePolicyPath, authFilePath string, forceCompress bool) *types.SystemContext {
+	sc := &types.SystemContext{}
+	if signaturePolicyPath != "" {
+		sc.SignaturePolicyPath = signaturePolicyPath
+	}
+	sc.AuthFilePath = authFilePath
+	sc.DirForceCompress = forceCompress
+	return sc
+}

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -47,10 +47,16 @@ func decompose(input string) (imageParts, error) {
 		name:        imageName,
 		tag:         tag,
 		isTagged:    isTagged,
+		transport:   DefaultTransport,
 	}, nil
 }
 
 // assemble concatenates an image's parts into a string
 func (ip *imageParts) assemble() string {
 	return fmt.Sprintf("%s/%s:%s", ip.registry, ip.name, ip.tag)
+}
+
+// assemble concatenates an image's parts with transport into a string
+func (ip *imageParts) assembleWithTransport() string {
+	return fmt.Sprintf("%s%s/%s:%s", ip.transport, ip.registry, ip.name, ip.tag)
 }

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -1,0 +1,246 @@
+package image
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	cp "github.com/containers/image/copy"
+	"github.com/containers/image/directory"
+	"github.com/containers/image/docker"
+	dockerarchive "github.com/containers/image/docker/archive"
+	"github.com/containers/image/docker/tarfile"
+	ociarchive "github.com/containers/image/oci/archive"
+	"github.com/containers/image/pkg/sysregistries"
+	is "github.com/containers/image/storage"
+	"github.com/containers/image/tarball"
+	"github.com/containers/image/transports/alltransports"
+	"github.com/containers/image/types"
+	"github.com/pkg/errors"
+)
+
+var (
+	// DockerArchive is the transport we prepend to an image name
+	// when saving to docker-archive
+	DockerArchive = dockerarchive.Transport.Name()
+	// OCIArchive is the transport we prepend to an image name
+	// when saving to oci-archive
+	OCIArchive = ociarchive.Transport.Name()
+	// DirTransport is the transport for pushing and pulling
+	// images to and from a directory
+	DirTransport = directory.Transport.Name()
+	// TransportNames are the supported transports in string form
+	TransportNames = [...]string{DefaultTransport, DockerArchive, OCIArchive, "ostree:", "dir:"}
+	// TarballTransport is the transport for importing a tar archive
+	// and creating a filesystem image
+	TarballTransport = tarball.Transport.Name()
+	// DockerTransport is the transport for docker registries
+	DockerTransport = docker.Transport.Name() + "://"
+	// AtomicTransport is the transport for atomic registries
+	AtomicTransport = "atomic"
+	// DefaultTransport is a prefix that we apply to an image name
+	DefaultTransport = DockerTransport
+)
+
+type pullStruct struct {
+	image  string
+	srcRef types.ImageReference
+	dstRef types.ImageReference
+}
+
+func (ir *Runtime) getPullStruct(srcRef types.ImageReference, destName string) (*pullStruct, error) {
+	reference := destName
+	if srcRef.DockerReference() != nil {
+		reference = srcRef.DockerReference().String()
+	}
+	destRef, err := is.Transport.ParseStoreReference(ir.store, reference)
+	if err != nil {
+		return nil, errors.Errorf("error parsing dest reference name: %v", err)
+	}
+	return &pullStruct{
+		image:  destName,
+		srcRef: srcRef,
+		dstRef: destRef,
+	}, nil
+}
+
+// returns a list of pullStruct with the srcRef and DstRef based on the transport being used
+func (ir *Runtime) getPullListFromRef(srcRef types.ImageReference, imgName string, sc *types.SystemContext) ([]*pullStruct, error) {
+	var pullStructs []*pullStruct
+	splitArr := strings.Split(imgName, ":")
+	archFile := splitArr[len(splitArr)-1]
+
+	// supports pulling from docker-archive, oci, and registries
+	if srcRef.Transport().Name() == DockerArchive {
+		tarSource, err := tarfile.NewSourceFromFile(archFile)
+		if err != nil {
+			return nil, err
+		}
+		manifest, err := tarSource.LoadTarManifest()
+
+		if err != nil {
+			return nil, errors.Errorf("error retrieving manifest.json: %v", err)
+		}
+		// to pull the first image stored in the tar file
+		if len(manifest) == 0 {
+			// use the hex of the digest if no manifest is found
+			reference, err := getImageDigest(srcRef, sc)
+			if err != nil {
+				return nil, err
+			}
+			pullInfo, err := ir.getPullStruct(srcRef, reference)
+			if err != nil {
+				return nil, err
+			}
+			pullStructs = append(pullStructs, pullInfo)
+		} else {
+			var dest string
+			if len(manifest[0].RepoTags) > 0 {
+				dest = manifest[0].RepoTags[0]
+			} else {
+				// If the input image has no repotags, we need to feed it a dest anyways
+				dest, err = getImageDigest(srcRef, sc)
+				if err != nil {
+					return nil, err
+				}
+			}
+			pullInfo, err := ir.getPullStruct(srcRef, dest)
+			if err != nil {
+				return nil, err
+			}
+			pullStructs = append(pullStructs, pullInfo)
+		}
+	} else if srcRef.Transport().Name() == OCIArchive {
+		// retrieve the manifest from index.json to access the image name
+		manifest, err := ociarchive.LoadManifestDescriptor(srcRef)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error loading manifest for %q", srcRef)
+		}
+
+		if manifest.Annotations == nil || manifest.Annotations["org.opencontainers.image.ref.name"] == "" {
+			return nil, errors.Errorf("error, archive doesn't have a name annotation. Cannot store image with no name")
+		}
+		pullInfo, err := ir.getPullStruct(srcRef, manifest.Annotations["org.opencontainers.image.ref.name"])
+		if err != nil {
+			return nil, err
+		}
+		pullStructs = append(pullStructs, pullInfo)
+	} else if srcRef.Transport().Name() == DirTransport {
+		// supports pull from a directory
+		image := splitArr[1]
+		// remove leading "/"
+		if image[:1] == "/" {
+			image = image[1:]
+		}
+		pullInfo, err := ir.getPullStruct(srcRef, image)
+		if err != nil {
+			return nil, err
+		}
+		pullStructs = append(pullStructs, pullInfo)
+	} else {
+		pullInfo, err := ir.getPullStruct(srcRef, imgName)
+		if err != nil {
+			return nil, err
+		}
+		pullStructs = append(pullStructs, pullInfo)
+	}
+	return pullStructs, nil
+}
+
+// pullImage pulls an image from configured registries
+// By default, only the latest tag (or a specific tag if requested) will be
+// pulled.
+func (i *Image) pullImage(writer io.Writer, authfile, signaturePolicyPath string, signingOptions SigningOptions, dockerOptions *DockerRegistryOptions) (string, error) {
+	// pullImage copies the image from the source to the destination
+	var pullStructs []*pullStruct
+	sc := GetSystemContext(signaturePolicyPath, authfile, false)
+	srcRef, err := alltransports.ParseImageName(i.InputName)
+	if err != nil {
+		// could be trying to pull from registry with short name
+		pullStructs, err = i.createNamesToPull()
+		if err != nil {
+			return "", errors.Wrap(err, "error getting default registries to try")
+		}
+	} else {
+		pullStructs, err = i.imageruntime.getPullListFromRef(srcRef, i.InputName, sc)
+		if err != nil {
+			return "", errors.Wrapf(err, "error getting pullStruct info to pull image %q", i.InputName)
+		}
+	}
+	policyContext, err := getPolicyContext(sc)
+	if err != nil {
+		return "", err
+	}
+	defer policyContext.Destroy()
+
+	copyOptions := getCopyOptions(writer, signaturePolicyPath, dockerOptions, nil, signingOptions, authfile, "", false)
+	for _, imageInfo := range pullStructs {
+		// Print the following statement only when pulling from a docker or atomic registry
+		if writer != nil && (imageInfo.srcRef.Transport().Name() == DockerTransport || imageInfo.srcRef.Transport().Name() == AtomicTransport) {
+			io.WriteString(writer, fmt.Sprintf("Trying to pull %s...\n", imageInfo.image))
+		}
+		if err = cp.Image(policyContext, imageInfo.dstRef, imageInfo.srcRef, copyOptions); err != nil {
+			if writer != nil {
+				io.WriteString(writer, "Failed\n")
+			}
+		} else {
+			return imageInfo.image, nil
+		}
+	}
+	return "", errors.Wrapf(err, "error pulling image from")
+}
+
+// createNamesToPull looks at a decomposed image and determines the possible
+// images names to try pulling in combination with the registries.conf file as well
+func (i *Image) createNamesToPull() ([]*pullStruct, error) {
+	var pullNames []*pullStruct
+	decomposedImage, err := decompose(i.InputName)
+	if err != nil {
+		return nil, err
+	}
+	if decomposedImage.hasRegistry {
+		srcRef, err := alltransports.ParseImageName(decomposedImage.assembleWithTransport())
+		if err != nil {
+			return nil, errors.Errorf("unable to parse '%s'", i.InputName)
+		}
+		ps := pullStruct{
+			image:  i.InputName,
+			srcRef: srcRef,
+		}
+		pullNames = append(pullNames, &ps)
+
+	} else {
+		registryConfigPath := ""
+		envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")
+		if len(envOverride) > 0 {
+			registryConfigPath = envOverride
+		}
+		searchRegistries, err := sysregistries.GetRegistries(&types.SystemContext{SystemRegistriesConfPath: registryConfigPath})
+		if err != nil {
+			return nil, err
+		}
+		for _, registry := range searchRegistries {
+			decomposedImage.registry = registry
+			srcRef, err := alltransports.ParseImageName(decomposedImage.assembleWithTransport())
+			if err != nil {
+				return nil, errors.Errorf("unable to parse '%s'", i.InputName)
+			}
+			ps := pullStruct{
+				image:  decomposedImage.assemble(),
+				srcRef: srcRef,
+			}
+			pullNames = append(pullNames, &ps)
+		}
+	}
+
+	for _, pStruct := range pullNames {
+		destRef, err := is.Transport.ParseStoreReference(i.imageruntime.store, pStruct.image)
+		if err != nil {
+			return nil, errors.Errorf("error parsing dest reference name: %v", err)
+		}
+		pStruct.dstRef = destRef
+	}
+
+	return pullNames, nil
+}

--- a/libpod/image/signing_options.go
+++ b/libpod/image/signing_options.go
@@ -1,0 +1,10 @@
+package image
+
+// SigningOptions encapsulates settings that control whether or not we strip or
+// add signatures to images when writing them.
+type SigningOptions struct {
+	// RemoveSignatures directs us to remove any signatures which are already present.
+	RemoveSignatures bool
+	// SignBy is a key identifier of some kind, indicating that a signature should be generated using the specified private key and stored with the image.
+	SignBy string
+}

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectatomic/libpod/libpod/common"
 	"github.com/projectatomic/libpod/libpod/driver"
 	"github.com/projectatomic/libpod/pkg/inspect"
+	"github.com/projectatomic/libpod/pkg/util"
 )
 
 // Runtime API
@@ -312,7 +313,7 @@ func (k *Image) Decompose() error {
 		if err != nil {
 			return nil
 		}
-		if StringInSlice(k.Registry, registries) {
+		if util.StringInSlice(k.Registry, registries) {
 			return nil
 		}
 		// We need to check if the registry name is legit

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -39,16 +39,6 @@ func WriteFile(content string, path string) error {
 	return nil
 }
 
-// StringInSlice determines if a string is in a string slice, returns bool
-func StringInSlice(s string, sl []string) bool {
-	for _, i := range sl {
-		if i == s {
-			return true
-		}
-	}
-	return false
-}
-
 // FuncTimer helps measure the execution time of a function
 // For debug purposes, do not leave in code
 // used like defer FuncTimer("foo")

--- a/libpod/util_test.go
+++ b/libpod/util_test.go
@@ -5,19 +5,6 @@ import (
 	"testing"
 )
 
-var (
-	sliceData = []string{"one", "two", "three", "four"}
-)
-
-func TestStringInSlice(t *testing.T) {
-	// string is in the slice
-	assert.True(t, StringInSlice("one", sliceData))
-	// string is not in the slice
-	assert.False(t, StringInSlice("five", sliceData))
-	// string is not in empty slice
-	assert.False(t, StringInSlice("one", []string{}))
-}
-
 func TestRemoveScientificNotationFromFloat(t *testing.T) {
 	numbers := []float64{0.0, .5, 1.99999932, 1.04e+10}
 	results := []float64{0.0, .5, 1.99999932, 1.04}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -44,3 +44,13 @@ func ParseRegistryCreds(creds string) (*types.DockerAuthConfig, error) {
 		Password: password,
 	}, nil
 }
+
+// StringInSlice determines if a string is in a string slice, returns bool
+func StringInSlice(s string, sl []string) bool {
+	for _, i := range sl {
+		if i == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	sliceData = []string{"one", "two", "three", "four"}
+)
+
+func TestStringInSlice(t *testing.T) {
+	// string is in the slice
+	assert.True(t, StringInSlice("one", sliceData))
+	// string is not in the slice
+	assert.False(t, StringInSlice("five", sliceData))
+	// string is not in empty slice
+	assert.False(t, StringInSlice("one", []string{}))
+}


### PR DESCRIPTION
This represents the stage3 implementation for the image library.  At this point, we
are moving the image-centric functions to pkg/image including migration of args and
object-oriented references.  This is a not a one-for-one migration of funcs and some
funcs will need to continue to reside in runtime_img as they are overly specific to
libpod and probably not useful to others.

Signed-off-by: baude <bbaude@redhat.com>