### PR TITLE
Remove references to container restart on create/run command

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -396,8 +396,6 @@ its root filesystem mounted as read only prohibiting any writes.
 
 **--rm**=*true*|*false*
    Automatically remove the container when it exits. The default is *false*.
-   `--rm` flag can work together with `-d`, and auto-removal will be done on daemon side. Note that it's
-incompatible with any restart policy other than `none`.
 
 **--security-opt**=[]
    Security Options

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -397,8 +397,6 @@ its root filesystem mounted as read only prohibiting any writes.
 
 **--rm**=*true*|*false*
    Automatically remove the container when it exits. The default is *false*.
-   `--rm` flag can work together with `-d`, and auto-removal will be done on daemon side. Note that it's
-incompatible with any restart policy other than `none`.
 
 **--security-opt**=[]
    Security Options


### PR DESCRIPTION
podman does not support autorestart.  Should use systemd if you
want containers to restart

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Fixes https://github.com/projectatomic/libpod/issues/486