### PR TITLE
Include tmpfs in inspect

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -241,6 +241,7 @@ func getCtrInspectInfo(ctr *libpod.Container, ctrInspectData *inspect.ContainerI
 			Memory:               createArtifact.Resources.Memory,
 			Ulimits:              createArtifact.Resources.Ulimit,
 			SecurityOpt:          createArtifact.SecurityOpts,
+			Tmpfs:                createArtifact.Tmpfs,
 		},
 		&inspect.CtrConfig{
 			Hostname:    spec.Hostname,

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -74,6 +74,7 @@ type HostConfig struct {
 	CPUPercent           int                         `json:"CPUPercent"`         //check type, TODO
 	IOMaximumIOps        int                         `json:"IOMaximumIOps"`      //check type, TODO
 	IOMaximumBandwidth   int                         `json:"IOMaximumBandwidth"` //check type, TODO
+	Tmpfs                []string                    `json:"Tmpfs"`
 }
 
 // CtrConfig holds information about the container configuration


### PR DESCRIPTION
Other container runtimes include the tmpfs mount points in their inspect
output.  Podman should as well.  It is under hostconfig.

Resolves: #483

Signed-off-by: baude <bbaude@redhat.com>