### PR TITLE
Change image for sleep containers away from Alpine

### DIFF
--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -370,7 +370,7 @@ func (p *PodmanTest) RunSleepContainer(name string) *PodmanSession {
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
 	}
-	podmanArgs = append(podmanArgs, "-d", ALPINE, "sleep", "90")
+	podmanArgs = append(podmanArgs, "-d", fedoraMinimal, "sleep", "90")
 	return p.Podman(podmanArgs)
 }
 


### PR DESCRIPTION
Alpine uses a sleep that cannot be interrupted by SIGTERM, which causes a lot of tests to have to wait for 'podman rm -fa' to time out when removing containers.
