### PR TITLE
sleep does not catch SIGTERM

### DIFF
--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -45,11 +45,11 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to multiple containers", func() {
-		session := podmanTest.RunSleepContainer("test1")
+		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.RunSleepContainer("test2")
+		session = podmanTest.RunTopContainer("test2")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec simple command", func() {
-		setup := podmanTest.RunSleepContainer("test1")
+		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
@@ -51,7 +51,7 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec simple command using latest", func() {
-		setup := podmanTest.RunSleepContainer("test1")
+		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill a running container by id", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -48,7 +48,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill a running container by id with TERM", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -60,7 +60,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill a running container by name", func() {
-		session := podmanTest.RunSleepContainer("test1")
+		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -71,7 +71,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill a running container by id with a bogus signal", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -83,7 +83,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill latest container", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -363,14 +363,14 @@ func (p *PodmanTest) RestoreAllArtifacts() error {
 	return nil
 }
 
-//RunSleepContainer runs a simple container in the background that
-// sleeps.  If the name passed != "", it will have a name
-func (p *PodmanTest) RunSleepContainer(name string) *PodmanSession {
+//RunTopContainer runs a simple container in the background that
+// runs top.  If the name passed != "", it will have a name
+func (p *PodmanTest) RunTopContainer(name string) *PodmanSession {
 	var podmanArgs = []string{"run"}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
 	}
-	podmanArgs = append(podmanArgs, "-d", ALPINE, "sleep", "90")
+	podmanArgs = append(podmanArgs, "-d", ALPINE, "top")
 	return p.Podman(podmanArgs)
 }
 

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman pause a running container by id", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -75,7 +75,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman unpause a running container by id", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -89,7 +89,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman remove a paused container by id", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -130,7 +130,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman stop a paused container by id", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -167,7 +167,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman pause a running container by name", func() {
-		session := podmanTest.RunSleepContainer("test1")
+		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -183,11 +183,11 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman pause a running container by id and another by name", func() {
-		session1 := podmanTest.RunSleepContainer("test1")
+		session1 := podmanTest.RunTopContainer("test1")
 		session1.WaitWithDefaultTimeout()
 		Expect(session1.ExitCode()).To(Equal(0))
 
-		session2 := podmanTest.RunSleepContainer("")
+		session2 := podmanTest.RunTopContainer("")
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
 		cid2 := session2.OutputToString()

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps default", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -164,7 +164,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps id filter flag", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		fullCid := session.OutputToString()

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Podman rm", func() {
 	})
 
 	It("podman rm refuse to remove a running container", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -60,7 +60,7 @@ var _ = Describe("Podman rm", func() {
 	})
 
 	It("podman rm created container", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -97,7 +97,7 @@ var _ = Describe("Podman rm", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.RunSleepContainer("")
+		session = podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Podman stats", func() {
 		Expect(session.ExitCode()).To(Equal(125))
 	})
 
-	It("podman on a running container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "-t", ALPINE, "sleep", "99"})
+	It("podman stats on a running container", func() {
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -49,8 +49,8 @@ var _ = Describe("Podman stats", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
-	It("podman on a running container no id", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "-t", ALPINE, "sleep", "99"})
+	It("podman stats on a running container no id", func() {
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stats", "--no-stream"})
@@ -59,7 +59,7 @@ var _ = Describe("Podman stats", func() {
 	})
 
 	It("podman stats on all containers", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "-t", ALPINE, "sleep", "99"})
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stats", "--no-stream", "-a"})
@@ -68,7 +68,7 @@ var _ = Describe("Podman stats", func() {
 	})
 
 	It("podman stats only output cids", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "-t", ALPINE, "sleep", "99"})
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stats", "--no-stream", "--format", "\"{{.Container}}\""})
@@ -77,7 +77,7 @@ var _ = Describe("Podman stats", func() {
 	})
 
 	It("podman stats with json output", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "-t", ALPINE, "sleep", "99"})
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stats", "--no-stream", "--format", "json"})

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop container by id", func() {
-		session := podmanTest.RunSleepContainer("")
+		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -44,7 +44,7 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop container by name", func() {
-		session := podmanTest.RunSleepContainer("test1")
+		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stop", "test1"})
@@ -53,17 +53,17 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop all containers", func() {
-		session := podmanTest.RunSleepContainer("test1")
+		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid1 := session.OutputToString()
 
-		session = podmanTest.RunSleepContainer("test2")
+		session = podmanTest.RunTopContainer("test2")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid2 := session.OutputToString()
 
-		session = podmanTest.RunSleepContainer("test3")
+		session = podmanTest.RunTopContainer("test3")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid3 := session.OutputToString()
@@ -78,7 +78,7 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop latest containers", func() {
-		session := podmanTest.RunSleepContainer("test1")
+		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stop", "-l", "-t", "1"})

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -71,10 +71,10 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman top on container invalid options", func() {
-		sleep := podmanTest.RunSleepContainer("")
-		sleep.WaitWithDefaultTimeout()
-		Expect(sleep.ExitCode()).To(Equal(0))
-		cid := sleep.OutputToString()
+		top := podmanTest.RunTopContainer("")
+		top.WaitWithDefaultTimeout()
+		Expect(top.ExitCode()).To(Equal(0))
+		cid := top.OutputToString()
 
 		result := podmanTest.Podman([]string{"top", cid, "-o time"})
 		result.WaitWithDefaultTimeout()


### PR DESCRIPTION
As Matt pointed out, when running sleep in a container, the clean up was taking a
full ten seconds to stop container because sleep does not catch SIGTERM which is
the default podman stop signal and it had to wait for SIGKILL.  Changing sleep to
top should result in better test times.

Signed-off-by: baude <bbaude@redhat.com>