### PR TITLE
We should not have a default workdir

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -390,6 +390,5 @@ var createFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "workdir, w",
 		Usage: "Working `directory inside the container",
-		Value: "/",
 	},
 }

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -566,8 +566,10 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 	}
 
 	// WORKING DIRECTORY
-	workDir := c.String("workdir")
-	if workDir == "" {
+	workDir := "/"
+	if c.IsSet("workdir") {
+		workDir = c.String("workdir")
+	} else if data.ContainerConfig.WorkingDir != "" {
 		workDir = data.ContainerConfig.WorkingDir
 	}
 


### PR DESCRIPTION
Having a default workdir is causing us not to use the
container images workdir.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>