### PR TITLE
We should not allow a user to mount a container with a different label

### DIFF
--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -24,10 +24,6 @@ var (
 			Usage: "do not truncate output",
 		},
 		cli.StringFlag{
-			Name:  "label",
-			Usage: "SELinux label for the mount point",
-		},
-		cli.StringFlag{
 			Name:  "format",
 			Usage: "Change the output format to Go template",
 		},
@@ -83,7 +79,7 @@ func mountCmd(c *cli.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "error looking up container %q", args[0])
 		}
-		mountPoint, err := ctr.Mount(c.String("label"))
+		mountPoint, err := ctr.Mount(ctr.MountLabel())
 		if err != nil {
 			return errors.Wrapf(err, "error mounting container %q", ctr.ID())
 		}

--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -30,10 +30,6 @@ returned.
 
 Do not truncate IDs in output.
 
-**--label**
-
-SELinux label for the mount point
-
 ## EXAMPLE
 
 podman mount c831414b10a3


### PR DESCRIPTION
We need to get the label from the container and mount with it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>