### PR TITLE
Remove ability to specify mount label when mounting

### DIFF
--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -79,7 +79,7 @@ func mountCmd(c *cli.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "error looking up container %q", args[0])
 		}
-		mountPoint, err := ctr.Mount(ctr.MountLabel())
+		mountPoint, err := ctr.Mount()
 		if err != nil {
 			return errors.Wrapf(err, "error mounting container %q", ctr.ID())
 		}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1000,7 +1000,6 @@ _podman_mount() {
  "
 
     local options_with_args="
-    --label
     --format
  "
 


### PR DESCRIPTION
Followup to #502

Remove the ability to specify a custom mount label via API. This allows us to convert ctr.Mount() to use the standard mount logic.

Also add an additional check in the unmount logic to make sure we don't try to unmount containers with active exec sessions.