### PR TITLE
Check for duplicate names when generating new container and pod names.

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -706,7 +706,7 @@ func (s *BoltState) LookupPod(idOrName string) (*Pod, error) {
 			if err != nil {
 				return err
 			} else if !exists {
-				return errors.Wrapf(ErrNoSuchCtr, "no pod with name or ID %s found", idOrName)
+				return errors.Wrapf(ErrNoSuchPod, "no pod with name or ID %s found", idOrName)
 			}
 		}
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/docker/docker/pkg/stringid"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -150,7 +149,6 @@ func newContainer(rspec *spec.Spec, lockDir string) (*Container, error) {
 	ctr.state = new(containerState)
 
 	ctr.config.ID = stringid.GenerateNonCryptoID()
-	ctr.config.Name = namesgenerator.GetRandomName(0)
 
 	ctr.config.Spec = new(spec.Spec)
 	deepcopier.Copy(rspec).To(ctr.config.Spec)

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 
 	"github.com/containers/storage"
-	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -52,7 +51,6 @@ func newPod(lockDir string, runtime *Runtime) (*Pod, error) {
 	pod := new(Pod)
 	pod.config = new(PodConfig)
 	pod.config.ID = stringid.GenerateNonCryptoID()
-	pod.config.Name = namesgenerator.GetRandomName(0)
 	pod.config.Labels = make(map[string]string)
 	pod.runtime = runtime
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -61,7 +61,7 @@ func (r *Runtime) NewContainer(rSpec *spec.Spec, options ...CtrCreateOption) (c 
 
 	// Set up storage for the container
 	if err := ctr.setupStorage(); err != nil {
-		return nil, errors.Wrapf(err, "error configuring storage for container")
+		return nil, err
 	}
 	defer func() {
 		if err != nil {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -50,6 +50,15 @@ func (r *Runtime) NewContainer(rSpec *spec.Spec, options ...CtrCreateOption) (c 
 	ctr.state.State = ContainerStateConfigured
 	ctr.runtime = r
 
+	if ctr.config.Name == "" {
+		name, err := r.generateName()
+		if err != nil {
+			return nil, err
+		}
+
+		ctr.config.Name = name
+	}
+
 	// Set up storage for the container
 	if err := ctr.setupStorage(); err != nil {
 		return nil, errors.Wrapf(err, "error configuring storage for container")

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -35,6 +35,14 @@ func (r *Runtime) NewPod(options ...PodCreateOption) (*Pod, error) {
 		}
 	}
 
+	if pod.config.Name == "" {
+		name, err := r.generateName()
+		if err != nil {
+			return nil, err
+		}
+		pod.config.Name = name
+	}
+
 	pod.valid = true
 
 	if err := r.state.AddPod(pod); err != nil {


### PR DESCRIPTION
This fixes the situation where we fail to create a container when a name already exists.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>