### PR TITLE
Remove image via Buildah if a buildah container is associated

### DIFF
--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
+	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/urfave/cli"
@@ -67,6 +69,20 @@ func rmiCmd(c *cli.Context) error {
 		image := runtime.NewImage(arg)
 		iid, err := image.Remove(c.Bool("force"))
 		if err != nil {
+			if errors.Cause(err) == storage.ErrImageUsedByContainer {
+				buildahImage, err2 := runtime.GetImage(image.LocalName)
+				if err2 == nil {
+					errBuildah := rmiBuildahCmd(c, buildahImage.ID)
+					if errBuildah == nil {
+						err = nil
+					} else {
+						fmt.Printf("A container created with Buildah may be associated with this image.\n")
+						fmt.Printf("Remove the container with Buildah or retry using the --force option.\n")
+					}
+				} else {
+					fmt.Printf("Unable to find image %s\n", image.LocalName)
+				}
+			}
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}
@@ -76,4 +92,42 @@ func rmiCmd(c *cli.Context) error {
 		}
 	}
 	return lastError
+}
+
+func rmiBuildahCmd(c *cli.Context, imageID string) error {
+	rmiCmdArgs := []string{}
+
+	// Handle Global Options
+	logLevel := c.GlobalString("log-level")
+	if logLevel == "debug" {
+		rmiCmdArgs = append(rmiCmdArgs, "--debug")
+	}
+
+	rmiCmdArgs = append(rmiCmdArgs, "rmi")
+
+	if c.Bool("force") {
+		rmiCmdArgs = append(rmiCmdArgs, "--force")
+	}
+
+	rmiCmdArgs = append(rmiCmdArgs, imageID)
+	buildah := "buildah"
+
+	if _, err := exec.LookPath(buildah); err != nil {
+		return errors.Wrapf(err, "buildah not found in PATH")
+	}
+	if _, err := exec.Command(buildah).Output(); err != nil {
+		return errors.Wrapf(err, "buildah is not operational on this server")
+	}
+
+	cmd := exec.Command(buildah, rmiCmdArgs...)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "error running the buildah rmi command")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

If we receive a storage.ErrImageUsedByContainer error, it's likely that the image has a container associated with it via Buildah doing a 'buildah from image' and the user will see 'image is in use by a container'.  Yet if the do a 'podman ps --all' no containers will be seen.

This change is probably a short term fix until we can get a snazzier solution together via the container/storage.  This calls 'buildah rmi" to do the dirty work.  The one hiccup with this is if you do a 'podman rmi -a' and there's a buildah container associated with the image, you'll get a double error message, one from Buildah, the other from Podman.
```
# podman rmi -a
Could not remove image "3fd9065eaf02feaf94d68376da52541925650b81698c53c6824d92ff63f98353" (must force) - container "c39c25ebd002e534b7419ac1a812747955d380848d257fc2a7975908a65a4946" is using its reference image: image is in use by a container
A container created with Buildah may be associated with this image.
Remove the container with Buildah or retry using the --force option.
Image used by c39c25ebd002e534b7419ac1a812747955d380848d257fc2a7975908a65a4946: image is in use by a container

podman rmi -a --force
3fd9065eaf02feaf94d68376da52541925650b81698c53c6824d92ff63f98353

```
Addresses #174 at least temporarily.