### PR TITLE
Removing tagged images change in behavior

### DIFF
--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -75,14 +75,14 @@ func rmiCmd(c *cli.Context) error {
 		return errors.Errorf("no valid images to delete")
 	}
 	for _, img := range imagesToDelete {
-		err := runtime.RemoveImage(img, c.Bool("force"))
+		msg, err := runtime.RemoveImage(img, c.Bool("force"))
 		if err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}
 			lastError = err
 		} else {
-			fmt.Println(img.ID())
+			fmt.Println(msg)
 		}
 	}
 	return lastError

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -35,20 +35,16 @@ var _ = Describe("Podman push", func() {
 
 		session = podmanTest.Podman([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session.ExitCode()).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"rmi", "busybox:test"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
-
-		session = podmanTest.Podman([]string{"rmi", "-f", "busybox:test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	// push to oci-archive, docker-archive, and dir are tested in pull_test.go
 
-	It("podman push to containers/storage", func() {
+	It("podman push to dir", func() {
 		session := podmanTest.Podman([]string{"push", "--remove-signatures", ALPINE, "dir:/tmp/busybox"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -67,4 +67,40 @@ var _ = Describe("Podman rmi", func() {
 
 	})
 
+	It("podman rmi tagged image", func() {
+		setup := podmanTest.Podman([]string{"images", "-q", ALPINE})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"tag", "alpine", "foo:bar", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"images", "-q", "foo"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		Expect(result.LineInOuputContains(setup.OutputToString())).To(BeTrue())
+	})
+
+	It("podman rmi image with tags by ID cannot be done without force", func() {
+		setup := podmanTest.Podman([]string{"images", "-q", ALPINE})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		alpineId := setup.OutputToString()
+
+		session := podmanTest.Podman([]string{"tag", "alpine", "foo:bar", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// Trying without --force should fail
+		result := podmanTest.Podman([]string{"rmi", alpineId})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).ToNot(Equal(0))
+
+		// With --force it should work
+		resultForce := podmanTest.Podman([]string{"rmi", "-f", alpineId})
+		resultForce.WaitWithDefaultTimeout()
+		Expect(resultForce.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
An image name is really just a tag.  When an image has multiple tags, we should be
able to "delete" the one of its tags without harm. In this case, the "delete' is
really a form of Untag (removing the tag from the image).

If an image has multiple tags and the user tries to delete by ID without force, this
should be denied because when you delete by ID there is no distinguishing it like
image tags.

Signed-off-by: baude <bbaude@redhat.com>