### PR TITLE
If cidfile exists, do not proceed

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -159,6 +159,9 @@ func createCmd(c *cli.Context) error {
 	}
 
 	if c.String("cidfile") != "" {
+		if _, err := os.Stat(c.String("cidfile")); err == nil {
+			return errors.Errorf("container id file exists. ensure another container is not using it or delete %s", c.String("cidfile"))
+		}
 		if err := libpod.WriteFile("", c.String("cidfile")); err != nil {
 			return errors.Wrapf(err, "unable to write cidfile %s", c.String("cidfile"))
 		}

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -37,6 +37,9 @@ func runCmd(c *cli.Context) error {
 	}
 
 	if c.String("cidfile") != "" {
+		if _, err := os.Stat(c.String("cidfile")); err == nil {
+			return errors.Errorf("container id file exists. ensure another container is not using it or delete %s", c.String("cidfile"))
+		}
 		if err := libpod.WriteFile("", c.String("cidfile")); err != nil {
 			return errors.Wrapf(err, "unable to write cidfile %s", c.String("cidfile"))
 		}


### PR DESCRIPTION
Both podman run and create have an option to write the container ID to a file. The option
is called cidfile.  If the cidfile exists, we should not create or run a container but rather
output a sensical error message.

Resolves: #530

Signed-off-by: baude <bbaude@redhat.com>