### PR TITLE
Add .containerenv file

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -672,6 +672,16 @@ func (c *Container) makeBindMounts() error {
 		c.state.BindMounts["/etc/hostname"] = hostnamePath
 	}
 
+	// Make .containerenv
+	if _, ok := c.state.BindMounts["/.containerenv"]; !ok {
+		// Empty string for now, but we may consider populating this later
+		containerenvPath, err := c.writeStringToRundir(".containerenv", "")
+		if err != nil {
+			return errors.Wrapf(err, "error creating containerenv file for container %s", c.ID())
+		}
+		c.state.BindMounts["/.containerenv"] = containerenvPath
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This will allow programs to easily identify they are running in a container

There was some discussion about putting it in /run, but I opted for just / to match Docker convention. Then again, we did rename the file...