### PR TITLE
Make container environment variable conditional, and add a more specific one in podman

### DIFF
--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -195,6 +195,7 @@ func createConfigToOCISpec(config *createConfig) (*spec.Spec, error) {
 	for sysctlKey, sysctlVal := range config.Sysctl {
 		g.AddLinuxSysctl(sysctlKey, sysctlVal)
 	}
+	g.AddProcessEnv("container", "podman")
 
 	// RESOURCES - MEMORY
 	if config.Resources.Memory != 0 {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -909,7 +909,18 @@ func (c *Container) generateSpec() (*spec.Spec, error) {
 
 	g.SetHostname(c.Hostname())
 	g.AddProcessEnv("HOSTNAME", g.Spec().Hostname)
-	g.AddProcessEnv("container", "libpod")
+
+	// Only add container environment variable if not already present
+	foundContainerEnv := false
+	for _, env := range g.Spec().Process.Env {
+		if strings.HasPrefix(env, "container=") {
+			foundContainerEnv = true
+			break
+		}
+	}
+	if !foundContainerEnv {
+		g.AddProcessEnv("container", "libpod")
+	}
 
 	return g.Spec(), nil
 }


### PR DESCRIPTION
@rhatdan wanted containers to have a more specific `container` environment variable - `podman` for Podman-started containers, `buildah` for buildah-started containers, etc

This makes adding the environment variable in `libpod` conditional on it not already being present, and adds a more specific one in Podman to override it.