### PR TITLE
podman: new option --conmon-pidfile=

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -101,6 +101,10 @@ var createFlags = []cli.Flag{
 		Name:  "cidfile",
 		Usage: "Write the container ID to the file",
 	},
+	cli.StringFlag{
+		Name:  "conmon-pidfile",
+		Usage: "path to the file that will receive the PID of conmon",
+	},
 	cli.Uint64Flag{
 		Name:  "cpu-period",
 		Usage: "Limit the CPU CFS (Completely Fair Scheduler) period",

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -74,6 +74,7 @@ type createConfig struct {
 	CapAdd             []string // cap-add
 	CapDrop            []string // cap-drop
 	CidFile            string
+	ConmonPidFile      string
 	CgroupParent       string // cgroup-parent
 	Command            []string
 	Detach             bool              // detach
@@ -201,6 +202,7 @@ func createCmd(c *cli.Context) error {
 	// Gather up the options for NewContainer which consist of With... funcs
 	options = append(options, libpod.WithRootFSFromImage(createConfig.ImageID, createConfig.Image, useImageVolumes))
 	options = append(options, libpod.WithSELinuxLabels(createConfig.ProcessLabel, createConfig.MountLabel))
+	options = append(options, libpod.WithConmonPidFile(createConfig.ConmonPidFile))
 	options = append(options, libpod.WithLabels(createConfig.Labels))
 	options = append(options, libpod.WithUser(createConfig.User))
 	options = append(options, libpod.WithShmDir(createConfig.ShmDir))
@@ -611,6 +613,7 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 	config := &createConfig{
 		Runtime:           runtime,
 		BuiltinImgVolumes: ImageVolumes,
+		ConmonPidFile:     c.String("conmon-pidfile"),
 		ImageVolumeType:   c.String("image-volume"),
 		CapAdd:            c.StringSlice("cap-add"),
 		CapDrop:           c.StringSlice("cap-drop"),

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -81,6 +81,7 @@ func runCmd(c *cli.Context) error {
 	// Gather up the options for NewContainer which consist of With... funcs
 	options = append(options, libpod.WithRootFSFromImage(createConfig.ImageID, createConfig.Image, useImageVolumes))
 	options = append(options, libpod.WithSELinuxLabels(createConfig.ProcessLabel, createConfig.MountLabel))
+	options = append(options, libpod.WithConmonPidFile(createConfig.ConmonPidFile))
 	options = append(options, libpod.WithLabels(createConfig.Labels))
 	options = append(options, libpod.WithUser(createConfig.User))
 	options = append(options, libpod.WithShmDir(createConfig.ShmDir))

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -251,6 +251,8 @@ type ContainerConfig struct {
 	CgroupParent string `json:"cgroupParent"`
 	// LogPath log location
 	LogPath string `json:"logPath"`
+	// File containing the conmon PID
+	ConmonPidFile string `json:"conmonPidFile,omitempty"`
 	// TODO log options for log drivers
 }
 

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -212,6 +212,9 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string) (err e
 	args = append(args, "-p", filepath.Join(ctr.state.RunDir, "pidfile"))
 	args = append(args, "-l", ctr.LogPath())
 	args = append(args, "--exit-dir", r.exitsDir)
+	if ctr.config.ConmonPidFile != "" {
+		args = append(args, "--conmon-pidfile", ctr.config.ConmonPidFile)
+	}
 	args = append(args, "--socket-dir-path", r.socketsDir)
 	if ctr.config.Spec.Process.Terminal {
 		args = append(args, "-t")

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -766,3 +766,14 @@ func WithHosts(hosts []string) CtrCreateOption {
 		return nil
 	}
 }
+
+// WithConmonPidFile specifies the path to the file that receives the pid of conmon
+func WithConmonPidFile(path string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		ctr.config.ConmonPidFile = path
+		return nil
+	}
+}


### PR DESCRIPTION
so that it is possible to use systemd to automatically restart the
container:

[Service]
Type=forking
PIDFile=/run/awesome-service.pid
ExecStart=/usr/bin/podman --conmon-pidfile=/run/awesome-service.pid run --name awesome -d IMAGE /usr/bin/do-something
ExecStopPost=/usr/bin/podman rm awesome
Restart=always

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>