### PR TITLE
cmd/podman/run.go: Error nicely when no image found

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -56,6 +56,9 @@ func runCmd(c *cli.Context) error {
 
 	rtc := runtime.GetConfig()
 	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "unable to find image")
+	}
 
 	data, err := newImage.Inspect()
 	if err != nil {

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -465,6 +465,9 @@ func (i *Image) ToImageRef() (types.Image, error) {
 
 // toImageRef returns an Image Reference type from an image
 func (i *Image) toImageRef() (types.Image, error) {
+	if i == nil {
+		return nil, errors.Errorf("cannot convert nil image to image reference")
+	}
 	if i.imgRef == nil {
 		ref, err := is.Transport.ParseStoreReference(i.imageruntime.store, "@"+i.ID())
 		if err != nil {


### PR DESCRIPTION
When no image is found, display a useful error message. Also, in imageToRef
protect against a nil image being passed.

Resolves: #553

Signed-off-by: baude <bbaude@redhat.com>