### PR TITLE
Generate container dependency graphs and use them to start pods

### DIFF
--- a/libpod/common_test.go
+++ b/libpod/common_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// nolint
 func getTestContainer(id, name, locksDir string) (*Container, error) {
 	ctr := &Container{
 		config: &ContainerConfig{
@@ -91,7 +91,6 @@ func getTestContainer(id, name, locksDir string) (*Container, error) {
 	return ctr, nil
 }
 
-// nolint
 func getTestPod(id, name, locksDir string) (*Pod, error) {
 	pod := &Pod{
 		config: &PodConfig{
@@ -112,9 +111,32 @@ func getTestPod(id, name, locksDir string) (*Pod, error) {
 	return pod, nil
 }
 
+func getTestCtrN(n, lockPath string) (*Container, error) {
+	return getTestContainer(strings.Repeat(n, 32), "test"+n, lockPath)
+}
+
+func getTestCtr1(lockPath string) (*Container, error) {
+	return getTestCtrN("1", lockPath)
+}
+
+func getTestCtr2(lockPath string) (*Container, error) {
+	return getTestCtrN("2", lockPath)
+}
+
+func getTestPodN(n, lockPath string) (*Pod, error) {
+	return getTestPod(strings.Repeat(n, 32), "test"+n, lockPath)
+}
+
+func getTestPod1(lockPath string) (*Pod, error) {
+	return getTestPodN("1", lockPath)
+}
+
+func getTestPod2(lockPath string) (*Pod, error) {
+	return getTestPodN("2", lockPath)
+}
+
 // This horrible hack tests if containers are equal in a way that should handle
 // empty arrays being dropped to nil pointers in the spec JSON
-// nolint
 func testContainersEqual(t *testing.T, a, b *Container) {
 	if a == nil && b == nil {
 		return

--- a/libpod/container_graph.go
+++ b/libpod/container_graph.go
@@ -1,0 +1,157 @@
+package libpod
+
+import (
+	"github.com/pkg/errors"
+)
+
+type containerNode struct {
+	id         string
+	container  *Container
+	dependsOn  []*containerNode
+	dependedOn []*containerNode
+}
+
+type containerGraph struct {
+	nodes              map[string]*containerNode
+	noDepNodes         []*containerNode
+	notDependedOnNodes []*containerNode
+}
+
+func buildContainerGraph(ctrs []*Container) (*containerGraph, error) {
+	graph := new(containerGraph)
+	graph.nodes = make(map[string]*containerNode)
+
+	// Start by building all nodes, with no edges
+	for _, ctr := range ctrs {
+		ctrNode := new(containerNode)
+		ctrNode.id = ctr.ID()
+		ctrNode.container = ctr
+
+		graph.nodes[ctr.ID()] = ctrNode
+	}
+
+	// Now add edges based on dependencies
+	for _, node := range graph.nodes {
+		deps := node.container.Dependencies()
+		for _, dep := range deps {
+			// Get the dep's node
+			depNode, ok := graph.nodes[dep]
+			if !ok {
+				return nil, errors.Wrapf(ErrNoSuchCtr, "container %s depends on container %s not found in input list", node.id, dep)
+			}
+
+			// Add the dependent node to the node's dependencies
+			// And add the node to the dependent node's dependedOn
+			node.dependsOn = append(node.dependsOn, depNode)
+			depNode.dependedOn = append(depNode.dependedOn, node)
+		}
+
+		// Maintain a list of nodes with no dependencies
+		// (no edges coming from them)
+		if len(deps) == 0 {
+			graph.noDepNodes = append(graph.noDepNodes, node)
+		}
+	}
+
+	// Need one more loop to get nodes that have nothing depending on them
+	// (no edges pointing to them)
+	for _, node := range graph.nodes {
+		if len(node.dependedOn) == 0 {
+			graph.notDependedOnNodes = append(graph.notDependedOnNodes, node)
+		}
+	}
+
+	// Need to do cycle detection
+	// We cannot start or stop if there are cyclic dependencies
+	cycle, err := detectCycles(graph)
+	if err != nil {
+		return nil, err
+	} else if cycle {
+		return nil, errors.Wrapf(ErrInternal, "cycle found in container dependency graph")
+	}
+
+	return graph, nil
+}
+
+// Detect cycles in a container graph
+// Return true if a cycle is found, false otherwise
+func detectCycles(graph *containerGraph) (bool, error) {
+	type nodeInfo struct {
+		index   int
+		lowLink int
+		onStack bool
+	}
+
+	index := 0
+
+	nodes := make(map[string]*nodeInfo)
+	stack := make([]*containerNode, 0, len(graph.nodes))
+
+	var strongConnect func(*containerNode) (bool, error)
+	strongConnect = func(node *containerNode) (bool, error) {
+		info := new(nodeInfo)
+		info.index = index
+		info.lowLink = index
+		index = index + 1
+
+		nodes[node.id] = info
+
+		stack = append(stack, node)
+
+		info.onStack = true
+
+		// Work through all nodes we point to
+		for _, successor := range node.dependsOn {
+			if _, ok := nodes[successor.id]; !ok {
+				cycle, err := strongConnect(successor)
+				if err != nil {
+					return false, err
+				} else if cycle {
+					return true, nil
+				}
+
+				successorInfo := nodes[successor.id]
+				if successorInfo.lowLink < info.lowLink {
+					info.lowLink = successorInfo.lowLink
+				}
+			} else {
+				successorInfo := nodes[successor.id]
+				if successorInfo.index < info.lowLink && successorInfo.onStack {
+					info.lowLink = successorInfo.index
+				}
+			}
+		}
+
+		if info.lowLink == info.index {
+			l := len(stack)
+			if l == 0 {
+				return false, errors.Wrapf(ErrInternal, "empty stack in detectCycles")
+			}
+
+			// Pop off the stack
+			topOfStack := stack[l-1]
+			stack = stack[:l-1]
+
+			// If the top of the stack is not us, we have found a
+			// cycle
+			if topOfStack.id != node.id {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	for id, node := range graph.nodes {
+		if _, ok := nodes[id]; !ok {
+			cycle, err := strongConnect(node)
+			if err != nil {
+				return false, err
+			} else if cycle {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/libpod/container_graph_test.go
+++ b/libpod/container_graph_test.go
@@ -35,7 +35,7 @@ func TestBuildContainerGraphOneCtr(t *testing.T) {
 	assert.Equal(t, ctr1.ID(), node.id)
 
 	assert.Equal(t, ctr1.ID(), graph.noDepNodes[0].id)
-	assert.Equal(t, ctr1.ID(), graph.notDependedOnNodes[0].id)
+	assert.Equal(t, ctr1.ID(), graph.notDependedOnNodes[ctr1.ID()].id)
 }
 
 func TestBuildContainerGraphTwoCtrNoEdge(t *testing.T) {
@@ -81,7 +81,7 @@ func TestBuildContainerGraphTwoCtrOneEdge(t *testing.T) {
 	assert.Equal(t, 1, len(graph.notDependedOnNodes))
 
 	assert.Equal(t, ctr1.ID(), graph.noDepNodes[0].id)
-	assert.Equal(t, ctr2.ID(), graph.notDependedOnNodes[0].id)
+	assert.Equal(t, ctr2.ID(), graph.notDependedOnNodes[ctr2.ID()].id)
 }
 
 func TestBuildContainerGraphTwoCtrCycle(t *testing.T) {
@@ -190,7 +190,7 @@ func TestBuildContainerGraphThreeContainersNoCycle(t *testing.T) {
 	assert.Equal(t, 1, len(graph.notDependedOnNodes))
 
 	assert.Equal(t, ctr3.ID(), graph.noDepNodes[0].id)
-	assert.Equal(t, ctr1.ID(), graph.notDependedOnNodes[0].id)
+	assert.Equal(t, ctr1.ID(), graph.notDependedOnNodes[ctr1.ID()].id)
 }
 
 func TestBuildContainerGraphFourContainersNoEdges(t *testing.T) {

--- a/libpod/container_graph_test.go
+++ b/libpod/container_graph_test.go
@@ -1,0 +1,293 @@
+package libpod
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildContainerGraphNoCtrsIsEmpty(t *testing.T) {
+	graph, err := buildContainerGraph([]*Container{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(graph.nodes))
+	assert.Equal(t, 0, len(graph.noDepNodes))
+	assert.Equal(t, 0, len(graph.notDependedOnNodes))
+}
+
+func TestBuildContainerGraphOneCtr(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+
+	graph, err := buildContainerGraph([]*Container{ctr1})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(graph.nodes))
+	assert.Equal(t, 1, len(graph.noDepNodes))
+	assert.Equal(t, 1, len(graph.notDependedOnNodes))
+
+	node, ok := graph.nodes[ctr1.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr1.ID(), node.id)
+
+	assert.Equal(t, ctr1.ID(), graph.noDepNodes[0].id)
+	assert.Equal(t, ctr1.ID(), graph.notDependedOnNodes[0].id)
+}
+
+func TestBuildContainerGraphTwoCtrNoEdge(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+
+	graph, err := buildContainerGraph([]*Container{ctr1, ctr2})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(graph.nodes))
+	assert.Equal(t, 2, len(graph.noDepNodes))
+	assert.Equal(t, 2, len(graph.notDependedOnNodes))
+
+	node1, ok := graph.nodes[ctr1.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr1.ID(), node1.id)
+
+	node2, ok := graph.nodes[ctr2.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr2.ID(), node2.id)
+}
+
+func TestBuildContainerGraphTwoCtrOneEdge(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr2.config.UserNsCtr = ctr1.config.ID
+
+	graph, err := buildContainerGraph([]*Container{ctr1, ctr2})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(graph.nodes))
+	assert.Equal(t, 1, len(graph.noDepNodes))
+	assert.Equal(t, 1, len(graph.notDependedOnNodes))
+
+	assert.Equal(t, ctr1.ID(), graph.noDepNodes[0].id)
+	assert.Equal(t, ctr2.ID(), graph.notDependedOnNodes[0].id)
+}
+
+func TestBuildContainerGraphTwoCtrCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr2.config.UserNsCtr = ctr1.config.ID
+	ctr1.config.NetNsCtr = ctr2.config.ID
+
+	_, err = buildContainerGraph([]*Container{ctr1, ctr2})
+	assert.Error(t, err)
+}
+
+func TestBuildContainerGraphThreeCtrNoEdges(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+
+	graph, err := buildContainerGraph([]*Container{ctr1, ctr2, ctr3})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(graph.nodes))
+	assert.Equal(t, 3, len(graph.noDepNodes))
+	assert.Equal(t, 3, len(graph.notDependedOnNodes))
+
+	node1, ok := graph.nodes[ctr1.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr1.ID(), node1.id)
+
+	node2, ok := graph.nodes[ctr2.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr2.ID(), node2.id)
+
+	node3, ok := graph.nodes[ctr3.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr3.ID(), node3.id)
+}
+
+func TestBuildContainerGraphThreeContainersTwoInCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr1.config.UserNsCtr = ctr2.config.ID
+	ctr2.config.IPCNsCtr = ctr1.config.ID
+
+	_, err = buildContainerGraph([]*Container{ctr1, ctr2, ctr3})
+	assert.Error(t, err)
+}
+
+func TestBuildContainerGraphThreeContainersCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr1.config.UserNsCtr = ctr2.config.ID
+	ctr2.config.IPCNsCtr = ctr3.config.ID
+	ctr3.config.NetNsCtr = ctr1.config.ID
+
+	_, err = buildContainerGraph([]*Container{ctr1, ctr2, ctr3})
+	assert.Error(t, err)
+}
+
+func TestBuildContainerGraphThreeContainersNoCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr1.config.UserNsCtr = ctr2.config.ID
+	ctr1.config.NetNsCtr = ctr3.config.ID
+	ctr2.config.IPCNsCtr = ctr3.config.ID
+
+	graph, err := buildContainerGraph([]*Container{ctr1, ctr2, ctr3})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(graph.nodes))
+	assert.Equal(t, 1, len(graph.noDepNodes))
+	assert.Equal(t, 1, len(graph.notDependedOnNodes))
+
+	assert.Equal(t, ctr3.ID(), graph.noDepNodes[0].id)
+	assert.Equal(t, ctr1.ID(), graph.notDependedOnNodes[0].id)
+}
+
+func TestBuildContainerGraphFourContainersNoEdges(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr4, err := getTestCtrN("4", tmpDir)
+
+	graph, err := buildContainerGraph([]*Container{ctr1, ctr2, ctr3, ctr4})
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(graph.nodes))
+	assert.Equal(t, 4, len(graph.noDepNodes))
+	assert.Equal(t, 4, len(graph.notDependedOnNodes))
+
+	node1, ok := graph.nodes[ctr1.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr1.ID(), node1.id)
+
+	node2, ok := graph.nodes[ctr2.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr2.ID(), node2.id)
+
+	node3, ok := graph.nodes[ctr3.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr3.ID(), node3.id)
+
+	node4, ok := graph.nodes[ctr4.ID()]
+	assert.True(t, ok)
+	assert.Equal(t, ctr4.ID(), node4.id)
+}
+
+func TestBuildContainerGraphFourContainersTwoInCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr4, err := getTestCtrN("4", tmpDir)
+	ctr1.config.IPCNsCtr = ctr2.config.ID
+	ctr2.config.UserNsCtr = ctr1.config.ID
+
+	_, err = buildContainerGraph([]*Container{ctr1, ctr2, ctr3, ctr4})
+	assert.Error(t, err)
+}
+
+func TestBuildContainerGraphFourContainersAllInCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr4, err := getTestCtrN("4", tmpDir)
+	ctr1.config.IPCNsCtr = ctr2.config.ID
+	ctr2.config.UserNsCtr = ctr3.config.ID
+	ctr3.config.NetNsCtr = ctr4.config.ID
+	ctr4.config.UTSNsCtr = ctr1.config.ID
+
+	_, err = buildContainerGraph([]*Container{ctr1, ctr2, ctr3, ctr4})
+	assert.Error(t, err)
+}
+
+func TestBuildContainerGraphFourContainersNoneInCycle(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ctr1, err := getTestCtr1(tmpDir)
+	assert.NoError(t, err)
+	ctr2, err := getTestCtr2(tmpDir)
+	assert.NoError(t, err)
+	ctr3, err := getTestCtrN("3", tmpDir)
+	assert.NoError(t, err)
+	ctr4, err := getTestCtrN("4", tmpDir)
+	ctr1.config.IPCNsCtr = ctr2.config.ID
+	ctr1.config.NetNsCtr = ctr3.config.ID
+	ctr2.config.UserNsCtr = ctr3.config.ID
+
+	graph, err := buildContainerGraph([]*Container{ctr1, ctr2, ctr3, ctr4})
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(graph.nodes))
+	assert.Equal(t, 2, len(graph.noDepNodes))
+	assert.Equal(t, 2, len(graph.notDependedOnNodes))
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -68,9 +68,6 @@ func newPod(lockDir string, runtime *Runtime) (*Pod, error) {
 	return pod, nil
 }
 
-// TODO: need function to produce a directed graph of containers
-// This would allow us to properly determine stop/start order
-
 // Start starts all containers within a pod
 // It combines the effects of Init() and Start() on a container
 // If a container has already been initialized it will be started,
@@ -98,11 +95,6 @@ func (p *Pod) Start() (map[string]error, error) {
 		return nil, err
 	}
 
-	// Maintain a map of containers still to start
-	ctrsToStart := make(map[string]*Container)
-	// Maintain a map of all containers so we can easily look up dependencies
-	allCtrsMap := make(map[string]*Container)
-
 	// We need to lock all the containers
 	for _, ctr := range allCtrs {
 		ctr.lock.Lock()
@@ -111,77 +103,83 @@ func (p *Pod) Start() (map[string]error, error) {
 		if err := ctr.syncContainer(); err != nil {
 			return nil, err
 		}
+	}
 
-		if ctr.state.State == ContainerStateConfigured ||
-			ctr.state.State == ContainerStateCreated ||
-			ctr.state.State == ContainerStateStopped {
-			ctrsToStart[ctr.ID()] = ctr
-		}
-		allCtrsMap[ctr.ID()] = ctr
+	// Build a dependency graph of containers in the pod
+	graph, err := buildContainerGraph(allCtrs)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error generating dependency graph for pod %s", p.ID())
 	}
 
 	ctrErrors := make(map[string]error)
+	ctrsVisited := make(map[string]bool)
 
-	// Loop at most 10 times, to prevent potential infinite loops in
-	// dependencies
-	loopCounter := 10
-
-	// Loop while we still have containers to start
-	for len(ctrsToStart) > 0 {
-		// Loop through all containers, attempting to start them
-		for id, ctr := range ctrsToStart {
-			// TODO should we only do a dependencies check if we are not ContainerStateCreated?
-			depsOK := true
-			var depErr error
-			// Check container dependencies
-			for _, depID := range ctr.Dependencies() {
-				depCtr := allCtrsMap[depID]
-				if depCtr.state.State != ContainerStateRunning &&
-					depCtr.state.State != ContainerStatePaused {
-					// We are definitely not OK to init, a dependency is not up
-					depsOK = false
-					// Check to see if the dependency errored
-					// If it did, error here too
-					if _, ok := ctrErrors[depID]; ok {
-						depErr = errors.Wrapf(ErrCtrStateInvalid, "dependency %s of container %s failed to start", depID, id)
-					}
-
-					break
-				}
-			}
-			if !depsOK {
-				// Only if one of the containers dependencies failed should we stop trying
-				// Otherwise, assume it's just yet to start, retry starting this container later
-				if depErr != nil {
-					ctrErrors[id] = depErr
-					delete(ctrsToStart, id)
-				}
-				continue
-			}
-
-			// Initialize and start the container
-			if err := ctr.initAndStart(); err != nil {
-				ctrErrors[id] = err
-			}
-			delete(ctrsToStart, id)
-		}
-
-		loopCounter = loopCounter - 1
-		if loopCounter == 0 {
-			// Loop through all remaining containers and add an error
-			for id := range ctrsToStart {
-				ctrErrors[id] = errors.Wrapf(ErrInternal, "exceeded maximum attempts trying to start container %s", id)
-			}
-
-			break
-		}
+	// If there are no containers without dependencies, we can't start
+	// Error out
+	if len(graph.noDepNodes) == 0 {
+		return nil, errors.Wrapf(ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
 	}
 
-	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error starting some containers")
+	// Traverse the graph beginning at nodes with no dependencies
+	for _, node := range graph.noDepNodes {
+		startNode(node, false, ctrErrors, ctrsVisited)
 	}
 
-	return nil, nil
+	return ctrErrors, nil
+}
+
+// Visit a node on a container graph and start the container, or set an error if
+// a dependency failed to start
+func startNode(node *containerNode, setError bool, ctrErrors map[string]error, ctrsVisited map[string]bool) {
+	// First, check if we have already visited the node
+	if ctrsVisited[node.id] {
+		return
+	}
+
+	// If setError is true, a dependency of us failed
+	// Mark us as failed and recurse
+	if setError {
+		// Mark us as visited, and set an error
+		ctrsVisited[node.id] = true
+		ctrErrors[node.id] = errors.Wrapf(ErrCtrStateInvalid, "a dependency of container %s failed to start", node.id)
+
+		// Hit anyone who depends on us, and set errors on them too
+		for _, successor := range node.dependedOn {
+			startNode(successor, true, ctrErrors, ctrsVisited)
+		}
+
+		return
+	}
+
+	// Have all our dependencies started?
+	// If not, don't visit the node yet
+	depsVisited := true
+	for _, dep := range node.dependsOn {
+		depsVisited = depsVisited && ctrsVisited[dep.id]
+	}
+	if !depsVisited {
+		// Don't visit us yet, all dependencies are not up
+		// We'll hit the dependencies eventually, and when we do it will
+		// recurse here
+		return
+	}
+
+	// Going to start the container, mark us as visited
+	ctrsVisited[node.id] = true
+
+	// Start the container
+	ctrErrored := false
+	if err := node.container.initAndStart(); err != nil {
+		ctrErrored = true
+		ctrErrors[node.id] = err
+	}
+
+	// Recurse to anyone who depends on us and start them
+	for _, successor := range node.dependedOn {
+		startNode(successor, ctrErrored, ctrErrors, ctrsVisited)
+	}
+
+	return
 }
 
 // Stop stops all containers within a pod that are not already stopped

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -167,11 +167,13 @@ func startNode(node *containerNode, setError bool, ctrErrors map[string]error, c
 	// Going to start the container, mark us as visited
 	ctrsVisited[node.id] = true
 
-	// Start the container
+	// Start the container (only if it is not running)
 	ctrErrored := false
-	if err := node.container.initAndStart(); err != nil {
-		ctrErrored = true
-		ctrErrors[node.id] = err
+	if node.container.state.State != ContainerStateRunning {
+		if err := node.container.initAndStart(); err != nil {
+			ctrErrored = true
+			ctrErrors[node.id] = err
+		}
 	}
 
 	// Recurse to anyone who depends on us and start them

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -96,30 +96,6 @@ func runForAllStates(t *testing.T, testFunc func(*testing.T, State, string)) {
 	}
 }
 
-func getTestCtrN(n, lockPath string) (*Container, error) {
-	return getTestContainer(strings.Repeat(n, 32), "test"+n, lockPath)
-}
-
-func getTestCtr1(lockPath string) (*Container, error) {
-	return getTestCtrN("1", lockPath)
-}
-
-func getTestCtr2(lockPath string) (*Container, error) {
-	return getTestCtrN("2", lockPath)
-}
-
-func getTestPodN(n, lockPath string) (*Pod, error) {
-	return getTestPod(strings.Repeat(n, 32), "test"+n, lockPath)
-}
-
-func getTestPod1(lockPath string) (*Pod, error) {
-	return getTestPodN("1", lockPath)
-}
-
-func getTestPod2(lockPath string) (*Pod, error) {
-	return getTestPodN("2", lockPath)
-}
-
 func TestAddAndGetContainer(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
 		testCtr, err := getTestCtr1(lockPath)


### PR DESCRIPTION
Add the ability to generate container dependency graphs.

Use these graphs to restructure pod start, so we no longer repeatedly loop over containers and instead follow the graph, starting containers once their dependencies are up.