### PR TITLE
Prevent containers not in pods from depending on containers in pods

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -413,6 +413,10 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 				if depCtrPod == nil {
 					return errors.Wrapf(ErrInvalidArg, "container %s depends on container %s which is not in pod %s", ctr.ID(), dependsCtr, pod.ID())
 				}
+
+				if string(depCtrPod) != pod.ID() {
+					return errors.Wrapf(ErrInvalidArg, "container %s depends on container %s which is in a different pod (%s)", ctr.ID(), dependsCtr, string(depCtrPod))
+				}
 			} else {
 				// If we're not part of a pod, we cannot depend on containets in a pod
 				if depCtrPod != nil {

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -126,9 +126,12 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 	// But in-memory state is intended purely for testing and not production
 	// use, so this should be fine.
 	depCtrs := ctr.Dependencies()
-	for _, depCtr := range depCtrs {
-		if _, ok := s.containers[depCtr]; !ok {
-			return errors.Wrapf(ErrNoSuchCtr, "cannot depend on nonexistent container %s", depCtr)
+	for _, depID := range depCtrs {
+		depCtr, ok := s.containers[depID]
+		if !ok {
+			return errors.Wrapf(ErrNoSuchCtr, "cannot depend on nonexistent container %s", depID)
+		} else if depCtr.config.Pod != "" {
+			return errors.Wrapf(ErrInvalidArg, "cannot depend on container in a pod if not part of same pod")
 		}
 	}
 


### PR DESCRIPTION
Containers in pods cannot depend on containers outside of the same pod. Make the reverse true as well - containers not in pods cannot depend on containers in pods. This greatly simplifies our dependency handling, as we can guarantee that removing a pod will not encounter dependency issues.