### PR TITLE
Allow sha256: prefix for input

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -102,7 +102,6 @@ func (ir *Runtime) newFromStorage(img *storage.Image) *Image {
 // to only deal with local images already in the store (or
 // its aliases)
 func (ir *Runtime) NewFromLocal(name string) (*Image, error) {
-
 	image := Image{
 		InputName:    name,
 		Local:        true,
@@ -166,6 +165,14 @@ func (i *Image) reloadImage() error {
 	return nil
 }
 
+// stringSha256 strips sha256 from user input
+func stripSha256(name string) string {
+	if strings.HasPrefix(name, "sha256:") && len(name) > 7 {
+		return name[7:]
+	}
+	return name
+}
+
 // getLocalImage resolves an unknown input describing an image and
 // returns a storage.Image or an error. It is used by NewFromLocal.
 func (i *Image) getLocalImage() (*storage.Image, error) {
@@ -174,7 +181,7 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 		return nil, errors.Errorf("input name is blank")
 	}
 	var taggedName string
-	img, err := i.imageruntime.getImage(i.InputName)
+	img, err := i.imageruntime.getImage(stripSha256(i.InputName))
 	if err == nil {
 		return img.image, err
 	}

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -165,6 +165,7 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	}
 
 	// Test against tagged images of busybox
+
 	// foo should resolve to foo:latest
 	repoTag, err := newImage.MatchRepoTag("foo")
 	assert.NoError(t, err)
@@ -184,4 +185,15 @@ func Test_splitString(t *testing.T) {
 	assert.Equal(t, splitString("foo/bar"), "bar")
 	assert.Equal(t, splitString("a/foo/bar"), "bar")
 	assert.Equal(t, splitString("bar"), "bar")
+}
+
+// Test_stripSha256 tests test the stripSha256 function which removes
+// the prefix "sha256:" from a string if it is present
+func Test_stripSha256(t *testing.T) {
+	assert.Equal(t, stripSha256(""), "")
+	assert.Equal(t, stripSha256("test1"), "test1")
+	assert.Equal(t, stripSha256("sha256:9110ae7f579f35ee0c3938696f23fe0f5fbe641738ea52eb83c2df7e9995fa17"), "9110ae7f579f35ee0c3938696f23fe0f5fbe641738ea52eb83c2df7e9995fa17")
+	assert.Equal(t, stripSha256("sha256:9110ae7f"), "9110ae7f")
+	assert.Equal(t, stripSha256("sha256:"), "sha256:")
+	assert.Equal(t, stripSha256("sha256:a"), "a")
 }

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -129,4 +130,17 @@ var _ = Describe("Podman images", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(1))
 	})
+
+	It("podman check for image with sha256: prefix", func() {
+		session := podmanTest.Podman([]string{"inspect", "--format=json", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.IsJSONOutputValid()).To(BeTrue())
+		imageData := session.InspectImageJSON()
+
+		result := podmanTest.Podman([]string{"images", fmt.Sprintf("sha256:%s", imageData[0].ID)})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+	})
+
 })


### PR DESCRIPTION
We should allow users to pass in image ids with the sha256: prefix
for local images.

Resolves: #493

Signed-off-by: baude <bbaude@redhat.com>