### PR TITLE
Disable --sig-proxy tests due to race conditions

### DIFF
--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 	})
 
 	Specify("signals are forwarded to container using sig-proxy", func() {
+		Skip("Race condition issues on CI seem unfixable")
 		signal := syscall.SIGPOLL
 		session, pid := podmanTest.PodmanPID([]string{"run", "--name", "test1", fedoraMinimal, "bash", "-c", sigCatch})
 


### PR DESCRIPTION
@baude chased this for a day. It seems prohibitively difficult to test for a feature that I can't see many people actually using. Disable the failing test.