### PR TITLE
test/e2e/run_signal_test.go Racey signal test

### DIFF
--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 	})
 
 	Specify("signals are forwarded to container using sig-proxy", func() {
+		Skip("Test has beome racey.  Skip for now")
 		signal := syscall.SIGPOLL
 		session, pid := podmanTest.PodmanPID([]string{"run", "--name", "test1", fedoraMinimal, "bash", "-c", sigCatch})
 


### PR DESCRIPTION
One of the signal tests has become very racey recently and is causing
PRs to pile up.  Decision was made to skip/disable it for now while
we work on making it more stable.

Signed-off-by: baude <bbaude@redhat.com>