### PR TITLE
Do not fail on missing c/storage container

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -223,6 +223,15 @@ func (c *Container) teardownStorage() error {
 	}
 
 	if err := c.runtime.storageService.DeleteContainer(c.ID()); err != nil {
+		// If the container has already been removed, warn but do not
+		// error - we wanted it gone, it is already gone.
+		// Potentially another tool using containers/storage already
+		// removed it?
+		if err == storage.ErrNotAContainer {
+			logrus.Errorf("Storage for container %s already removed", c.ID())
+			return nil
+		}
+
 		return errors.Wrapf(err, "error removing container %s root filesystem", c.ID())
 	}
 

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -7,7 +7,6 @@ import (
 	istorage "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
-	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -29,7 +28,6 @@ func getStorageService(store storage.Store) (*storageService, error) {
 type ContainerInfo struct {
 	Dir    string
 	RunDir string
-	Config *v1.Image
 }
 
 // RuntimeContainerMetadata is the structure that we encode as JSON and store
@@ -81,11 +79,6 @@ func (r *storageService) CreateContainerStorage(systemContext *types.SystemConte
 		return ContainerInfo{}, err
 	}
 	defer image.Close()
-
-	imageConfig, err := image.OCIConfig()
-	if err != nil {
-		return ContainerInfo{}, err
-	}
 
 	// Update the image name and ID.
 	if imageName == "" && len(img.Names) > 0 {
@@ -159,7 +152,6 @@ func (r *storageService) CreateContainerStorage(systemContext *types.SystemConte
 	return ContainerInfo{
 		Dir:    containerDir,
 		RunDir: containerRunDir,
-		Config: imageConfig,
 	}, nil
 }
 


### PR DESCRIPTION
We share our container storage with other users of the containers/storage library. These other users can, and occasionally will, delete our containers without telling us first. Right now, libpod will get very angry and refuse to even remove such containers, which is very much not good. This PR begins to remedy this by only warning, and not erroring, when we go to delete storage and storage has already been removed.

Note that this does not handle the case where libpod thinks the container is mounted, but it in fact is not and has been deleted. This will still cause errors that leave you unable to even delete the container, but is harder to fix because c/storage does not distinguish between mounting layers, containers, and images, which makes it harder to determine what is going on when an error comes back. I'll look into that later.