### PR TITLE
Sleep for 5 seconds before pushing to registry in tests

### DIFF
--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -62,6 +63,9 @@ var _ = Describe("Podman push", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "-p", "5000:5000", "docker.io/library/registry:2", "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+
+		// Give the registry 5 seconds to warm up before pushing
+		time.Sleep(5 * time.Second)
 
 		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
 		push.WaitWithDefaultTimeout()


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

We've some kind of timing issue going on with the push to a local repository test.  Adding a 5 second wait to see if the issue is cleared by that.