### PR TITLE
Add generic dependencies

### DIFF
--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -91,10 +91,6 @@ func startCmd(c *cli.Context) error {
 			continue
 		}
 
-		if err := ctr.Init(); err != nil && errors.Cause(err) != libpod.ErrCtrExists {
-			return err
-		}
-
 		// We can only be interactive if both the config and the command-line say so
 		if c.Bool("interactive") && !ctr.Config().Stdin {
 			return errors.Errorf("the container was not created with the interactive option")

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -77,6 +77,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		ExecIDs:         execIDs,
 		GraphDriver:     driverData,
 		Mounts:          spec.Mounts,
+		Dependencies:    c.Dependencies(),
 		NetworkSettings: &inspect.NetworkSettings{
 			Bridge:                 "",    // TODO
 			SandboxID:              "",    // TODO - is this even relevant?

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -625,7 +625,7 @@ func WithCgroupNSFrom(nsCtr *Container) CtrCreateOption {
 	}
 }
 
-// WithDependencies sets dependency containers of the given container
+// WithDependencyCtrs sets dependency containers of the given container
 // Dependency containers must be running before this container is started
 func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -165,6 +165,11 @@ func startNode(node *containerNode, setError bool, ctrErrors map[string]error, c
 	// Going to start the container, mark us as visited
 	ctrsVisited[node.id] = true
 
+	// TODO: Maybe have a checkDependenciesRunningLocked here?
+	// Graph traversal should ensure our deps have been started, but some
+	// might have stopped since?
+	// Potentially will hurt our perf, though
+
 	// Start the container (only if it is not running)
 	ctrErrored := false
 	if node.container.state.State != ContainerStateRunning {

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -149,8 +149,8 @@ type ContainerInspectData struct {
 	ImageID         string                 `json:"Image"`
 	ImageName       string                 `json:"ImageName"`
 	ResolvConfPath  string                 `json:"ResolvConfPath"`
-	HostnamePath    string                 `json:"HostnamePath"` //TODO
-	HostsPath       string                 `json:"HostsPath"`    //TODO
+	HostnamePath    string                 `json:"HostnamePath"`
+	HostsPath       string                 `json:"HostsPath"`
 	StaticDir       string                 `json:"StaticDir"`
 	LogPath         string                 `json:"LogPath"`
 	Name            string                 `json:"Name"`
@@ -159,11 +159,12 @@ type ContainerInspectData struct {
 	MountLabel      string                 `json:"MountLabel"`
 	ProcessLabel    string                 `json:"ProcessLabel"`
 	AppArmorProfile string                 `json:"AppArmorProfile"`
-	ExecIDs         []string               `json:"ExecIDs"` //TODO
+	ExecIDs         []string               `json:"ExecIDs"`
 	GraphDriver     *Data                  `json:"GraphDriver"`
 	SizeRw          int64                  `json:"SizeRw,omitempty"`
 	SizeRootFs      int64                  `json:"SizeRootFs,omitempty"`
 	Mounts          []specs.Mount          `json:"Mounts"`
+	Dependencies    []string               `json:"Dependencies"`
 	NetworkSettings *NetworkSettings       `json:"NetworkSettings"` //TODO
 }
 


### PR DESCRIPTION
Right now, libpod has a notion of dependencies between containers - if container A uses container B's network namespace, container B must be running before container A can start so we can join that namespace. These patches extend this notion of dependencies to be generic - we can now make a container depend on other containers, only starting when these other containers are started. This allows enforced ordering of container start.

I'm working on patches to add a `--recursive` flag to `start` and `remove` to take advantage of this, starting a container and all dependencies that are not running, and removing a container and all its dependencies. Those will come in a separate PR so as to not clutter things.