### PR TITLE
Makefile: Fix typo podmon -> podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ help:
 	@echo "Usage: make <target>"
 	@echo
 	@echo " * 'install' - Install binaries to system locations"
-	@echo " * 'binaries' - Build podmon"
+	@echo " * 'binaries' - Build podman"
 	@echo " * 'integration' - Execute integration tests"
 	@echo " * 'clean' - Clean artifacts"
 	@echo " * 'lint' - Execute the source code linter"


### PR DESCRIPTION
This typo was introduced in 3aa63b2b

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>