### PR TITLE
Add conmon-pidfile flag to bash completions and manpages

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1051,6 +1051,7 @@ _podman_container_run() {
 		--cap-drop
 		--cgroup-parent
 		--cidfile
+		--conmon-pidfile
 		--cpu-period
 		--cpu-quota
 		--cpu-rt-period

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -52,6 +52,9 @@ each of stdin, stdout, and stderr.
 **--cidfile**=""
    Write the container ID to the file
 
+**--conmon-pidfile**=""
+   Write the pid of the `conmon` process to a file. `conmon` daemonizes separate from Podman, so this is necessary when using systemd to restart Podman containers.
+
 **--cpu-count**=*0*
     Limit the number of CPUs available for execution by the container.
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -64,6 +64,9 @@ each of stdin, stdout, and stderr.
 **--cidfile**=""
    Write the container ID to the file
 
+**--conmon-pidfile**=""
+   Write the pid of the `conmon` process to a file. `conmon` daemonizes separate from Podman, so this is necessary when using systemd to restart Podman containers.
+
 **--cpu-period**=*0*
     Limit the CPU CFS (Completely Fair Scheduler) period
 


### PR DESCRIPTION
Missed this when it was first added