### PR TITLE
Functionality changes to the following flags

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -86,7 +86,7 @@ type createConfig struct {
 	Entrypoint         []string          //entrypoint
 	Env                map[string]string //env
 	ExposedPorts       map[nat.Port]struct{}
-	GroupAdd           []uint32 // group-add
+	GroupAdd           []string // group-add
 	HostAdd            []string //add-host
 	Hostname           string   //hostname
 	Image              string
@@ -208,6 +208,7 @@ func createCmd(c *cli.Context) error {
 	options = append(options, libpod.WithUser(createConfig.User))
 	options = append(options, libpod.WithShmDir(createConfig.ShmDir))
 	options = append(options, libpod.WithShmSize(createConfig.Resources.ShmSize))
+	options = append(options, libpod.WithGroups(createConfig.GroupAdd))
 	ctr, err := runtime.NewContainer(runtimeSpec, options...)
 	if err != nil {
 		return err
@@ -404,11 +405,6 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 	sysctl, err := validateSysctl(c.StringSlice("sysctl"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid value for sysctl")
-	}
-
-	groupAdd, err := stringSlicetoUint32Slice(c.StringSlice("group-add"))
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid value for groups provided")
 	}
 
 	if c.String("memory") != "" {
@@ -625,7 +621,7 @@ func parseCreateOpts(c *cli.Context, runtime *libpod.Runtime, imageName string, 
 		Entrypoint:        entrypoint,
 		Env:               env,
 		//ExposedPorts:   ports,
-		GroupAdd:       groupAdd,
+		GroupAdd:       c.StringSlice("group-add"),
 		Hostname:       c.String("hostname"),
 		HostAdd:        c.StringSlice("add-host"),
 		Image:          imageName,

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,7 +11,6 @@ import (
 	"github.com/projectatomic/libpod/libpod/image"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-	"os"
 )
 
 var runDescription = "Runs a command in a new container from the given image"
@@ -94,6 +94,7 @@ func runCmd(c *cli.Context) error {
 	options = append(options, libpod.WithUser(createConfig.User))
 	options = append(options, libpod.WithShmDir(createConfig.ShmDir))
 	options = append(options, libpod.WithShmSize(createConfig.Resources.ShmSize))
+	options = append(options, libpod.WithGroups(createConfig.GroupAdd))
 
 	// Default used if not overridden on command line
 

--- a/cmd/podman/run_test.go
+++ b/cmd/podman/run_test.go
@@ -101,7 +101,7 @@ func TestPIDsLimit(t *testing.T) {
 // TestBLKIOWeightDevice verifies the inputed blkio weigh device is correctly defined in the spec
 func TestBLKIOWeightDevice(t *testing.T) {
 	a := createCLI()
-	args := []string{"--blkio-weight-device", "/dev/sda:100"}
+	args := []string{"--blkio-weight-device", "/dev/zero:100"}
 	a.Run(append(cmd, args...))
 	runtimeSpec, err := getRuntimeSpec(CLI)
 	if err != nil {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -201,6 +201,8 @@ type ContainerConfig struct {
 	// User and group to use in the container
 	// Can be specified by name or UID/GID
 	User string `json:"user,omitempty"`
+	// Additional groups to add
+	Groups []string `json:"groups, omitempty"`
 
 	// Namespace Config
 	// IDs of container to share namespaces with

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -823,3 +823,14 @@ func WithConmonPidFile(path string) CtrCreateOption {
 		return nil
 	}
 }
+
+// WithGroups sets additional groups for the container, which are defined by the user
+func WithGroups(groups []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		ctr.config.Groups = groups
+		return nil
+	}
+}

--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -69,3 +69,8 @@ func GetUser(rootdir, userspec string) (uint32, uint32, error) {
 	}
 	return 0, 0, err
 }
+
+// GetAdditionalGroupsForUser returns a list of gids that userid is associated with
+func GetAdditionalGroupsForUser(rootdir string, userid uint64) ([]uint32, error) {
+	return lookupAdditionalGroupsForUIDInContainer(rootdir, userid)
+}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -185,6 +185,34 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("15"))
 	})
 
+	It("podman run device-read-bps test", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--device-read-bps=/dev/zero:1mb", ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("1048576"))
+	})
+
+	It("podman run device-write-bps test", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--device-write-bps=/dev/zero:1mb", ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("1048576"))
+	})
+
+	It("podman run device-read-iops test", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--device-read-iops=/dev/zero:100", ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.throttle.read_iops_device"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("100"))
+	})
+
+	It("podman run device-write-iops test", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--device-write-iops=/dev/zero:100", ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.throttle.write_iops_device"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("100"))
+	})
+
 	It("podman run notify_socket", func() {
 		sock := "/run/sock"
 		os.Setenv("NOTIFY_SOCKET", sock)
@@ -256,6 +284,20 @@ var _ = Describe("Podman run", func() {
 
 		err = os.RemoveAll(containersDir)
 		Expect(err).To(BeNil())
+	})
+
+	It("podman run without group-add", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "id"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)"))
+	})
+
+	It("podman run with group-add", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--group-add=audio", "--group-add=nogroup", "--group-add=777", ALPINE, "id"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),18(audio),20(dialout),26(tape),27(video),777,65533(nogroup)"))
 	})
 
 })


### PR DESCRIPTION
	--group-add
	--blkio-weight-device
	--device-read-bps
	--device-write-bps
	--device-read-iops
	--device-write-iops

--group-add now supports group names as well as the gid associated with them.
All the --device flags work now with moderate changes to the code to support both
bps and iops.
Added tests for all the flags.

Signed-off-by: umohnani8 <umohnani@redhat.com>