### PR TITLE
Run images with no names

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -32,6 +32,7 @@ var runCommand = cli.Command{
 }
 
 func runCmd(c *cli.Context) error {
+	var imageName string
 	if err := validateFlags(c, createFlags); err != nil {
 		return err
 	}
@@ -64,8 +65,12 @@ func runCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-
-	createConfig, err := parseCreateOpts(c, runtime, newImage.Names()[0], data)
+	if len(newImage.Names()) < 1 {
+		imageName = newImage.ID()
+	} else {
+		imageName = newImage.Names()[0]
+	}
+	createConfig, err := parseCreateOpts(c, runtime, imageName, data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When an image name has no reponames, you should still be able to run it
by ID.  When doing so, imageName needs to be set to "" so we don't hit an index
out of range error

Resolves: #587

Signed-off-by: baude <bbaude@redhat.com>