### PR TITLE
podman_tutorial: Add latest tag in sample code

### DIFF
--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -89,7 +89,7 @@ page.
 $ sudo podman run -dt -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
                     -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
                     -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-                    registry.fedoraproject.org/f26/httpd /usr/bin/run-httpd
+                    registry.fedoraproject.org/f26/httpd:latest /usr/bin/run-httpd
 ```
 Because the container is being run in detached mode, represented by the *-d* in the podman run command, podman
 will print the container ID after it has run.


### PR DESCRIPTION
Without this tag, podman returns:
Trying to pull registry.fedoraproject.org/f26/httpd...Failed
unable to find image: unable to pull registry.fedoraproject.org/f26/httpd

After adding the tag ":latest", podman managed to download and run the
container.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>