### PR TITLE
Containers transitioning to stop should not break stats

### DIFF
--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -140,7 +140,7 @@ func statsCmd(c *cli.Context) error {
 				containerStats[id] = initialStats
 			}
 			stats, err := ctr.GetContainerStats(containerStats[id])
-			if err != nil {
+			if err != nil && errors.Cause(err) != libpod.ErrNoSuchCtr {
 				return err
 			}
 			// replace the previous measurement with the current one

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -37,7 +37,7 @@ func (c *Container) GetContainerStats(previousStats *ContainerStats) (*Container
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if err := c.syncContainer(); err != nil {
-		return stats, errors.Wrapf(err, "error updating container %s state", c.ID())
+		return stats, err
 	}
 	if c.state.State != ContainerStateRunning {
 		return stats, nil


### PR DESCRIPTION
When a container is transitioning from running to stopped and stats is runnings,
we should not break stats if we are unable to get stats for that container.

Resolves: #598

Signed-off-by: baude <bbaude@redhat.com>