### PR TITLE
Unescape characters in inspect JSON format output

### DIFF
--- a/cmd/podman/formats/formats_test.go
+++ b/cmd/podman/formats/formats_test.go
@@ -1,0 +1,42 @@
+package formats
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/projectatomic/libpod/pkg/inspect"
+)
+
+func TestSetJSONFormatEncoder(t *testing.T) {
+	tt := []struct {
+		name       string
+		imageData  *inspect.ImageData
+		expected   string
+		isTerminal bool
+	}{
+		{
+			name:       "HTML tags are not escaped",
+			imageData:  &inspect.ImageData{Author: "dave <dave@corp.io>"},
+			expected:   `"Author": "dave <dave@corp.io>"`,
+			isTerminal: true,
+		},
+		{
+			name:       "HTML tags are escaped",
+			imageData:  &inspect.ImageData{Author: "dave <dave@corp.io>"},
+			expected:   `"Author": "dave \u003cdave@corp.io\u003e"`,
+			isTerminal: false,
+		},
+	}
+
+	for _, tc := range tt {
+		buf := bytes.NewBuffer(nil)
+		enc := setJSONFormatEncoder(tc.isTerminal, buf)
+		if err := enc.Encode(tc.imageData); err != nil {
+			t.Errorf("test %#v failed encoding: %s", tc.name, err)
+		}
+		if !strings.Contains(buf.String(), tc.expected) {
+			t.Errorf("test %#v expected output to contain %#v. Output:\n%v\n", tc.name, tc.expected, buf.String())
+		}
+	}
+}


### PR DESCRIPTION
This patch changes the way the `inspect command` output is displayed on the screen when the format is set to JSON.

Note: if the output is redirected to a file the output is *not* escaped.

For example, before this commit if you run:
```shell
$ sudo podman inspect --format "json" daveimg
[
   {
   ...
      "Author": "Dave \u003cdave@corp.io\u003e",
   }
   ...
]
```

with this patch the output will be:
```shell
[
   {
   ...
      "Author": "Dave <dave@corp.io>",
   }
   ...
]
```

This is a follow-up to https://github.com/projectatomic/buildah/pull/421