### PR TITLE
Changes to attach to enable per-stream attaching

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -69,16 +69,12 @@ func attachCmd(c *cli.Context) error {
 		return errors.Errorf("you can only attach to running containers")
 	}
 
-	if c.BoolT("sig-proxy") {
-		ProxySignals(ctr)
-	}
-
 	inputStream := os.Stdin
 	if c.Bool("no-stdin") {
 		inputStream = nil
 	}
 
-	if err := attachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys")); err != nil {
+	if err := attachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys"), c.BoolT("sig-proxy")); err != nil {
 		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 	}
 

--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/urfave/cli"
@@ -71,7 +73,12 @@ func attachCmd(c *cli.Context) error {
 		ProxySignals(ctr)
 	}
 
-	if err := ctr.Attach(c.Bool("no-stdin"), c.String("detach-keys")); err != nil {
+	inputStream := os.Stdin
+	if c.Bool("no-stdin") {
+		inputStream = nil
+	}
+
+	if err := attachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys")); err != nil {
 		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 	}
 

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -179,24 +179,13 @@ func runCmd(c *cli.Context) error {
 		}
 	}
 
-	attachChan, err := startAttachCtr(ctr, outputStream, errorStream, inputStream, c.String("detach-keys"))
-	if err != nil {
+	if err := startAttachCtr(ctr, outputStream, errorStream, inputStream, c.String("detach-keys"), c.BoolT("sig-proxy")); err != nil {
 		// This means the command did not exist
 		exitCode = 127
 		if strings.Index(err.Error(), "permission denied") > -1 {
 			exitCode = 126
 		}
 		return err
-	}
-
-	if c.BoolT("sig-proxy") {
-		ProxySignals(ctr)
-	}
-
-	// Wait for attach to complete
-	err = <-attachChan
-	if err != nil {
-		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 	}
 
 	if ecode, err := ctr.ExitCode(); err != nil {

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -110,19 +110,8 @@ func startCmd(c *cli.Context) error {
 				inputStream = nil
 			}
 
-			attachChan, err := startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys"))
-			if err != nil {
+			if err := startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys"), c.Bool("sig-proxy")); err != nil {
 				return errors.Wrapf(err, "unable to start container %s", ctr.ID())
-			}
-
-			if c.Bool("sig-proxy") {
-				ProxySignals(ctr)
-			}
-
-			// Wait for attach to complete
-			err = <-attachChan
-			if err != nil {
-				return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 			}
 
 			if ecode, err := ctr.ExitCode(); err != nil {

--- a/libpod/container_attach.go
+++ b/libpod/container_attach.go
@@ -49,12 +49,6 @@ func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan re
 		return errors.Wrapf(ErrInvalidArg, "must provide at least one stream to attach to")
 	}
 
-	// Do not allow stdin on containers without Stdin set
-	// Conmon was not configured properly
-	if streams.AttachInput && !c.config.Stdin {
-		return errors.Wrapf(ErrInvalidArg, "this container was not created as interactive, cannot attach stdin")
-	}
-
 	// Check the validity of the provided keys first
 	var err error
 	detachKeys := []byte{}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -310,7 +310,6 @@ var _ = Describe("Podman run", func() {
 	It("podman run with attach stdout does not print stderr", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--attach", "stdout", ALPINE, "ls", "/doesnotexist"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal(""))
 	})
 


### PR DESCRIPTION
This allows us to attach to attach to just stdout or stderr or stdin, or any combination of these.

This needs tests, and is having terminal issues, but the code should be complete.