### PR TITLE
Force host UID/GID mapping when creating containers

### DIFF
--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -102,7 +102,13 @@ func (r *storageService) CreateContainerStorage(systemContext *types.SystemConte
 	// Build the container.
 	names := []string{containerName}
 
-	container, err := r.store.CreateContainer(containerID, names, img.ID, "", string(mdata), nil)
+	options := storage.ContainerOptions{
+		IDMappingOptions: storage.IDMappingOptions{
+			HostUIDMapping: true,
+			HostGIDMapping: true,
+		},
+	}
+	container, err := r.store.CreateContainer(containerID, names, img.ID, "", string(mdata), &options)
 	if err != nil {
 		logrus.Debugf("failed to create container %s(%s): %v", metadata.ContainerName, containerID, err)
 


### PR DESCRIPTION
Until we can handle running containers which use UID/GID mappings (via #597 or something similar), make sure that we always create containers that use the host mappings.