### PR TITLE
Allow the use of -i/-a on any container

### DIFF
--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod"
@@ -91,20 +90,7 @@ func startCmd(c *cli.Context) error {
 			continue
 		}
 
-		// We can only be interactive if both the config and the command-line say so
-		if c.Bool("interactive") && !ctr.Config().Stdin {
-			return errors.Errorf("the container was not created with the interactive option")
-		}
-
-		tty, err := strconv.ParseBool(ctr.Spec().Annotations["io.kubernetes.cri-o.TTY"])
-		if err != nil {
-			return errors.Wrapf(err, "unable to parse annotations in %s", ctr.ID())
-		}
-
-		// Handle start --attach
-		// We only get a terminal session if both a tty was specified in the spec and
-		// -a on the command-line was given.
-		if attach && tty {
+		if attach {
 			inputStream := os.Stdin
 			if !c.Bool("interactive") {
 				inputStream = nil

--- a/test/e2e/run_restart_test.go
+++ b/test/e2e/run_restart_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Podman run restart containers", func() {
 		killSession.WaitWithDefaultTimeout()
 		Expect(killSession.ExitCode()).To(Equal(0))
 
-		session2 := podmanTest.Podman([]string{"start", "--attach", "test1"})
+		session2 := podmanTest.Podman([]string{"start", "test1"})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
 	})


### PR DESCRIPTION
We used to not allow the use of -a/-i on containers that were not
started with -i or a tty.  Given the improvements in our terminal
handling, this should work now.

This also fixes a systemic problem with the autotests.

Signed-off-by: baude <bbaude@redhat.com>