### PR TITLE
podman pull should always try to pull

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -181,7 +181,7 @@ func createCmd(c *cli.Context) error {
 
 	rtc := runtime.GetConfig()
 
-	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{})
+	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -99,17 +99,17 @@ func loadCmd(c *cli.Context) error {
 	}
 
 	src := libpod.DockerArchive + ":" + input
-	newImage, err := runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{})
+	newImage, err := runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false)
 	if err != nil {
 		// generate full src name with specified image:tag
 		fullSrc := libpod.OCIArchive + ":" + input
 		if image != "" {
 			fullSrc = fullSrc + ":" + image
 		}
-		newImage, err = runtime.ImageRuntime().New(fullSrc, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{})
+		newImage, err = runtime.ImageRuntime().New(fullSrc, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false)
 		if err != nil {
 			src = libpod.DirTransport + ":" + input
-			newImage, err = runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{})
+			newImage, err = runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false)
 			if err != nil {
 				return errors.Wrapf(err, "error pulling %q", src)
 			}

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -99,7 +99,7 @@ func pullCmd(c *cli.Context) error {
 		DockerInsecureSkipTLSVerify: !c.BoolT("tls-verify"),
 	}
 
-	newImage, err := runtime.ImageRuntime().New(image, c.String("signature-policy"), c.String("authfile"), writer, &dockerRegistryOptions, image2.SigningOptions{})
+	newImage, err := runtime.ImageRuntime().New(image, c.String("signature-policy"), c.String("authfile"), writer, &dockerRegistryOptions, image2.SigningOptions{}, true)
 	if err != nil {
 		return errors.Wrapf(err, "error pulling image %q", image)
 	}

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -56,7 +56,7 @@ func runCmd(c *cli.Context) error {
 	}
 
 	rtc := runtime.GetConfig()
-	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{})
+	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false)
 	if err != nil {
 		return errors.Wrapf(err, "unable to find image")
 	}

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -117,18 +117,20 @@ func (ir *Runtime) NewFromLocal(name string) (*Image, error) {
 
 // New creates a new image object where the image could be local
 // or remote
-func (ir *Runtime) New(name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *DockerRegistryOptions, signingoptions SigningOptions) (*Image, error) {
+func (ir *Runtime) New(name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *DockerRegistryOptions, signingoptions SigningOptions, forcePull bool) (*Image, error) {
 	// We don't know if the image is local or not ... check local first
 	newImage := Image{
 		InputName:    name,
 		Local:        false,
 		imageruntime: ir,
 	}
-	localImage, err := newImage.getLocalImage()
-	if err == nil {
-		newImage.Local = true
-		newImage.image = localImage
-		return &newImage, nil
+	if !forcePull {
+		localImage, err := newImage.getLocalImage()
+		if err == nil {
+			newImage.Local = true
+			newImage.image = localImage
+			return &newImage, nil
+		}
 	}
 
 	// The image is not local

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -81,9 +81,9 @@ func TestImage_NewFromLocal(t *testing.T) {
 	// Need images to be present for this test
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	bb, err := ir.New("docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{})
+	bb, err := ir.New("docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, false)
 	assert.NoError(t, err)
-	bbglibc, err := ir.New("docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{})
+	bbglibc, err := ir.New("docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{}, false)
 	assert.NoError(t, err)
 
 	tm, err := makeLocalMatrix(bb, bbglibc)
@@ -126,7 +126,7 @@ func TestImage_New(t *testing.T) {
 	// Iterate over the names and delete the image
 	// after the pull
 	for _, img := range names {
-		newImage, err := ir.New(img, "", "", writer, nil, SigningOptions{})
+		newImage, err := ir.New(img, "", "", writer, nil, SigningOptions{}, false)
 		assert.NoError(t, err)
 		assert.NotEqual(t, newImage.ID(), "")
 		err = newImage.Remove(false)
@@ -150,7 +150,7 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	newImage, err := ir.New("busybox", "", "", os.Stdout, nil, SigningOptions{})
+	newImage, err := ir.New("busybox", "", "", os.Stdout, nil, SigningOptions{}, false)
 	assert.NoError(t, err)
 	err = newImage.TagImage("foo:latest")
 	assert.NoError(t, err)


### PR DESCRIPTION
In the case where you have an image local, if the the user runs
podman pull, we should always attempt to pull an updated image.

Added a forceRemote bool to New (image) so we can differentiate
between "pull" or run because the actions differ.  Run does not
need to pull the latest -- only run.

Signed-off-by: baude <bbaude@redhat.com>