### PR TITLE
Modify diff and inspect docs

### DIFF
--- a/docs/podman-diff.1.md
+++ b/docs/podman-diff.1.md
@@ -20,13 +20,16 @@ Alter the output into a different format.  The only valid format for diff is `js
 
 ## EXAMPLE
 
-podman diff redis:alpine
+```
+# podman diff redis:alpine
 C /usr
 C /usr/local
 C /usr/local/bin
 A /usr/local/bin/docker-entrypoint.sh
+```
 
-podman diff --format json redis:alpine
+```
+# podman diff --format json redis:alpine
 {
   "changed": [
     "/usr",
@@ -37,6 +40,7 @@ podman diff --format json redis:alpine
     "/usr/local/bin/docker-entrypoint.sh"
   ]
 }
+```
 
 ## SEE ALSO
 podman(1)

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -17,11 +17,12 @@ unspecified type. If a format is specified, the given template will be executed 
 
 **--type, t="TYPE"**
 
-Return data on items of the specified type.  Type can be 'container', 'image' or 'all' (default: all)
+Return JSON for the specified type.  Type can be 'container', 'image' or 'all' (default: all)
 
 **--format, -f="FORMAT"**
 
-Format the output using the given Go template
+Format the output using the given Go template.
+The keys of the returned JSON can be used as the values for the --format flag (see examples below).
 
 **--latest, -l**
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
@@ -87,8 +88,13 @@ fedora
 ```
 
 ```
-$ sudo podman inspect a04 --format "{{.GraphDriver.Name}}"
+# podman inspect a04 --format "{{.GraphDriver.Name}}"
 overlay
+```
+
+```
+# podman inspect --format "size: {{.Size}}" alpine
+size:   4405240
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
Format the examples in podman-diff.md better.
The description for --type in the inspect docs was slightly different
from that in the inline help.
Also stated what values to use in the Go template for the --format flag.

Signed-off-by: umohnani8 <umohnani@redhat.com>