### PR TITLE
regression: tls verify should be set on registries.conf if insecure

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -181,7 +181,7 @@ func createCmd(c *cli.Context) error {
 
 	rtc := runtime.GetConfig()
 
-	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false)
+	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -99,17 +99,17 @@ func loadCmd(c *cli.Context) error {
 	}
 
 	src := libpod.DockerArchive + ":" + input
-	newImage, err := runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false)
+	newImage, err := runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false, false)
 	if err != nil {
 		// generate full src name with specified image:tag
 		fullSrc := libpod.OCIArchive + ":" + input
 		if image != "" {
 			fullSrc = fullSrc + ":" + image
 		}
-		newImage, err = runtime.ImageRuntime().New(fullSrc, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false)
+		newImage, err = runtime.ImageRuntime().New(fullSrc, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false, false)
 		if err != nil {
 			src = libpod.DirTransport + ":" + input
-			newImage, err = runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false)
+			newImage, err = runtime.ImageRuntime().New(src, c.String("signature-policy"), "", writer, &libpodImage.DockerRegistryOptions{}, libpodImage.SigningOptions{}, false, false)
 			if err != nil {
 				return errors.Wrapf(err, "error pulling %q", src)
 			}

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -58,6 +58,7 @@ var (
 // pullCmd gets the data from the command line and calls pullImage
 // to copy an image from a registry to a local machine
 func pullCmd(c *cli.Context) error {
+	forceSecure := true
 	runtime, err := getRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
@@ -98,8 +99,11 @@ func pullCmd(c *cli.Context) error {
 		DockerCertPath:              c.String("cert-dir"),
 		DockerInsecureSkipTLSVerify: !c.BoolT("tls-verify"),
 	}
+	if !c.IsSet("tls-verify") {
+		forceSecure = false
+	}
 
-	newImage, err := runtime.ImageRuntime().New(image, c.String("signature-policy"), c.String("authfile"), writer, &dockerRegistryOptions, image2.SigningOptions{}, true)
+	newImage, err := runtime.ImageRuntime().New(image, c.String("signature-policy"), c.String("authfile"), writer, &dockerRegistryOptions, image2.SigningOptions{}, true, forceSecure)
 	if err != nil {
 		return errors.Wrapf(err, "error pulling image %q", image)
 	}

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -56,7 +56,7 @@ func runCmd(c *cli.Context) error {
 	}
 
 	rtc := runtime.GetConfig()
-	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false)
+	newImage, err := runtime.ImageRuntime().New(c.Args()[0], rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false, false)
 	if err != nil {
 		return errors.Wrapf(err, "unable to find image")
 	}

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -9,8 +9,8 @@ import (
 	"github.com/containers/image/docker"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/formats"
-	"github.com/projectatomic/libpod/libpod"
 	"github.com/projectatomic/libpod/libpod/common"
+	sysreg "github.com/projectatomic/libpod/pkg/registries"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -110,7 +110,7 @@ func searchCmd(c *cli.Context) error {
 	if len(c.StringSlice("registry")) > 0 {
 		registries = c.StringSlice("registry")
 	} else {
-		registries, err = libpod.GetRegistries()
+		registries, err = sysreg.GetRegistries()
 		if err != nil {
 			return errors.Wrapf(err, "error getting registries to search")
 		}

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -83,7 +83,9 @@ option be used, as the default behavior of using the system-wide default policy
 
 **--tls-verify**
 
-Require HTTPS and verify certificates when contacting registries (default: true)
+Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
+then tls verification will be used, If set to false then tls verification will not be used. If not specified
+tls verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
 ## EXAMPLES
 

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -117,7 +117,7 @@ func (ir *Runtime) NewFromLocal(name string) (*Image, error) {
 
 // New creates a new image object where the image could be local
 // or remote
-func (ir *Runtime) New(name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *DockerRegistryOptions, signingoptions SigningOptions, forcePull bool) (*Image, error) {
+func (ir *Runtime) New(name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *DockerRegistryOptions, signingoptions SigningOptions, forcePull, forceSecure bool) (*Image, error) {
 	// We don't know if the image is local or not ... check local first
 	newImage := Image{
 		InputName:    name,
@@ -137,7 +137,7 @@ func (ir *Runtime) New(name, signaturePolicyPath, authfile string, writer io.Wri
 	if signaturePolicyPath == "" {
 		signaturePolicyPath = ir.SignaturePolicyPath
 	}
-	imageName, err := newImage.pullImage(writer, authfile, signaturePolicyPath, signingoptions, dockeroptions)
+	imageName, err := newImage.pullImage(writer, authfile, signaturePolicyPath, signingoptions, dockeroptions, forceSecure)
 	if err != nil {
 		return nil, errors.Errorf("unable to pull %s", name)
 	}

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -81,9 +81,9 @@ func TestImage_NewFromLocal(t *testing.T) {
 	// Need images to be present for this test
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	bb, err := ir.New("docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, false)
+	bb, err := ir.New("docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, false, false)
 	assert.NoError(t, err)
-	bbglibc, err := ir.New("docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{}, false)
+	bbglibc, err := ir.New("docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{}, false, false)
 	assert.NoError(t, err)
 
 	tm, err := makeLocalMatrix(bb, bbglibc)
@@ -126,7 +126,7 @@ func TestImage_New(t *testing.T) {
 	// Iterate over the names and delete the image
 	// after the pull
 	for _, img := range names {
-		newImage, err := ir.New(img, "", "", writer, nil, SigningOptions{}, false)
+		newImage, err := ir.New(img, "", "", writer, nil, SigningOptions{}, false, false)
 		assert.NoError(t, err)
 		assert.NotEqual(t, newImage.ID(), "")
 		err = newImage.Remove(false)
@@ -150,7 +150,7 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	newImage, err := ir.New("busybox", "", "", os.Stdout, nil, SigningOptions{}, false)
+	newImage, err := ir.New("busybox", "", "", os.Stdout, nil, SigningOptions{}, false, false)
 	assert.NoError(t, err)
 	err = newImage.TagImage("foo:latest")
 	assert.NoError(t, err)

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/libpod/image"
 	"github.com/projectatomic/libpod/pkg/hooks"
+	sysreg "github.com/projectatomic/libpod/pkg/registries"
 	"github.com/sirupsen/logrus"
 	"github.com/ulule/deepcopier"
 )
@@ -549,7 +550,7 @@ func (r *Runtime) Info() ([]InfoData, error) {
 	}
 	info = append(info, InfoData{Type: "store", Data: storeInfo})
 
-	reg, err := GetRegistries()
+	reg, err := sysreg.GetRegistries()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting registries")
 	}
@@ -557,7 +558,7 @@ func (r *Runtime) Info() ([]InfoData, error) {
 	registries["registries"] = reg
 	info = append(info, InfoData{Type: "registries", Data: registries})
 
-	i, err := GetInsecureRegistries()
+	i, err := sysreg.GetInsecureRegistries()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting registries")
 	}

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -3,15 +3,12 @@ package libpod
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/containers/image/directory"
 	"github.com/containers/image/docker"
 	dockerarchive "github.com/containers/image/docker/archive"
 	ociarchive "github.com/containers/image/oci/archive"
-	"github.com/containers/image/pkg/sysregistries"
 	"github.com/containers/image/tarball"
-	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -179,32 +176,4 @@ func removeStorageContainers(ctrIDs []string, store storage.Store) error {
 		}
 	}
 	return nil
-}
-
-// GetRegistries gets the searchable registries from the global registration file.
-func GetRegistries() ([]string, error) {
-	registryConfigPath := ""
-	envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")
-	if len(envOverride) > 0 {
-		registryConfigPath = envOverride
-	}
-	searchRegistries, err := sysregistries.GetRegistries(&types.SystemContext{SystemRegistriesConfPath: registryConfigPath})
-	if err != nil {
-		return nil, errors.Errorf("unable to parse the registries.conf file")
-	}
-	return searchRegistries, nil
-}
-
-// GetInsecureRegistries obtains the list of inseure registries from the global registration file.
-func GetInsecureRegistries() ([]string, error) {
-	registryConfigPath := ""
-	envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")
-	if len(envOverride) > 0 {
-		registryConfigPath = envOverride
-	}
-	registries, err := sysregistries.GetInsecureRegistries(&types.SystemContext{SystemRegistriesConfPath: registryConfigPath})
-	if err != nil {
-		return nil, errors.Errorf("unable to parse the registries.conf file")
-	}
-	return registries, nil
 }

--- a/libpod/runtime_img_test.go
+++ b/libpod/runtime_img_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	sysreg "github.com/projectatomic/libpod/pkg/registries"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +39,7 @@ func TestGetRegistries(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(registryPath)
 	os.Setenv("REGISTRIES_CONFIG_PATH", registryPath)
-	registries, err := GetRegistries()
+	registries, err := sysreg.GetRegistries()
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(registries, []string{"one"}))
 }
@@ -48,7 +49,7 @@ func TestGetInsecureRegistries(t *testing.T) {
 	assert.NoError(t, err)
 	os.Setenv("REGISTRIES_CONFIG_PATH", registryPath)
 	defer os.Remove(registryPath)
-	registries, err := GetInsecureRegistries()
+	registries, err := sysreg.GetInsecureRegistries()
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(registries, []string{"two"}))
 }

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -1,0 +1,37 @@
+package registries
+
+import (
+	"os"
+
+	"github.com/containers/image/pkg/sysregistries"
+	"github.com/containers/image/types"
+	"github.com/pkg/errors"
+)
+
+// GetRegistries obtains the list of registries defined in the global registries file.
+func GetRegistries() ([]string, error) {
+	registryConfigPath := ""
+	envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")
+	if len(envOverride) > 0 {
+		registryConfigPath = envOverride
+	}
+	searchRegistries, err := sysregistries.GetRegistries(&types.SystemContext{SystemRegistriesConfPath: registryConfigPath})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse the registries.conf file")
+	}
+	return searchRegistries, nil
+}
+
+// GetInsecureRegistries obtains the list of inseure registries from the global registration file.
+func GetInsecureRegistries() ([]string, error) {
+	registryConfigPath := ""
+	envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")
+	if len(envOverride) > 0 {
+		registryConfigPath = envOverride
+	}
+	registries, err := sysregistries.GetInsecureRegistries(&types.SystemContext{SystemRegistriesConfPath: registryConfigPath})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse the registries.conf file")
+	}
+	return registries, nil
+}


### PR DESCRIPTION
In the case where podman needs to pull an image, if that registry that the image
resides on is known to be insesure (as defined in /etc/containers/registries.conf),
tls-verify should be altered on the fly.

Signed-off-by: baude <bbaude@redhat.com>