### PR TITLE
generateHosts fixes

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -901,8 +901,8 @@ func (c *Container) generateHosts() (string, error) {
 	if len(c.config.HostAdd) > 0 {
 		for _, host := range c.config.HostAdd {
 			// the host format has already been verified at this point
-			fields := strings.Split(host, ":")
-			hosts += fmt.Sprintf("%s %s\n", fields[0], fields[1])
+			fields := strings.SplitN(host, ":", 2)
+			hosts += fmt.Sprintf("%s %s\n", fields[1], fields[0])
 		}
 	}
 	return c.writeStringToRundir("hosts", hosts)

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -62,11 +62,11 @@ var _ = Describe("Podman run dns", func() {
 	})
 
 	It("podman run add host", func() {
-		session := podmanTest.Podman([]string{"run", "--add-host=foobar:1.1.1.1", "--add-host=foobaz:dead:beef:cafe", ALPINE, "cat", "/etc/hosts"})
+		session := podmanTest.Podman([]string{"run", "--add-host=foobar:1.1.1.1", "--add-host=foobaz:2001:db8::68", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session.LineInOuputStartsWith("1.1.1.1 foobar")
-		session.LineInOuputStartsWith("dead:beef:cafe foobaz")
+		session.LineInOuputStartsWith("2001:db8::68 foobaz")
 	})
 
 	It("podman run add hostname", func() {

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -62,10 +62,11 @@ var _ = Describe("Podman run dns", func() {
 	})
 
 	It("podman run add host", func() {
-		session := podmanTest.Podman([]string{"run", "--add-host=foobar:1.1.1.1", ALPINE, "cat", "/etc/hosts"})
+		session := podmanTest.Podman([]string{"run", "--add-host=foobar:1.1.1.1", "--add-host=foobaz:dead:beef:cafe", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session.LineInOuputStartsWith("foobar 1.1.1.1")
+		session.LineInOuputStartsWith("1.1.1.1 foobar")
+		session.LineInOuputStartsWith("dead:beef:cafe foobaz")
 	})
 
 	It("podman run add hostname", func() {


### PR DESCRIPTION
- the input format for `--add-host` (`host:ip`) is the reverse of `/etc/hosts`, so we need to reverse the field order when we append to `/etc/hosts`
- the input accepts IPv6 in the validator, but split was resulting in truncated IPv6 addresses

Signed-off-by: Nathan Williams <nath.e.will@gmail.com>