### PR TITLE
Strip transport from image name when looking for local image

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -182,6 +182,12 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 	if i.InputName == "" {
 		return nil, errors.Errorf("input name is blank")
 	}
+	// Check if the input name has a transport and if so strip it
+	dest, err := alltransports.ParseImageName(i.InputName)
+	if err == nil && dest.DockerReference() != nil {
+		i.InputName = dest.DockerReference().String()
+	}
+
 	var taggedName string
 	img, err := i.imageruntime.getImage(stripSha256(i.InputName))
 	if err == nil {


### PR DESCRIPTION
When a user pulls an image using a transport, like docker-daemon, we try to lookup
the new image in storage by the input name after the pull.  Because the input name
has a transport (different than local storage), that lookup would fail.

Signed-off-by: baude <bbaude@redhat.com>