### PR TITLE
Add FIPS mode secret

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -302,6 +302,20 @@ var _ = Describe("Podman run", func() {
 		Expect(err).To(BeNil())
 	})
 
+	It("podman run with FIPS mode secrets", func() {
+		fipsFile := "/etc/system-fips"
+		err = ioutil.WriteFile(fipsFile, []byte{}, 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "ls", "/run/secrets"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("system-fips"))
+
+		err = os.Remove(fipsFile)
+		Expect(err).To(BeNil())
+	})
+
 	It("podman run without group-add", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
If the host is in FIPS mode and /etc/system-fips exists
/run/secrets/system-fips is created in the container so that
the container can run in FIPS mode as well.

Moving the changes of https://github.com/projectatomic/buildah/pull/603 here. The secrets pkg will be vendored into buildah and cri-o to reduce code duplication.

Signed-off-by: umohnani8 <umohnani@redhat.com>