### PR TITLE
Modify --user flag for podman create and run

### DIFF
--- a/pkg/chrootuser/user_linux.go
+++ b/pkg/chrootuser/user_linux.go
@@ -4,6 +4,7 @@ package chrootuser
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -78,6 +79,9 @@ func openChrootedFile(rootdir, filename string) (*exec.Cmd, io.ReadCloser, error
 
 var (
 	lookupUser, lookupGroup sync.Mutex
+	// ErrNoSuchUser indicates that the user provided by the caller does not
+	// exist in /etc/passws
+	ErrNoSuchUser = errors.New("user does not exist in /etc/passwd")
 )
 
 type lookupPasswdEntry struct {
@@ -207,7 +211,7 @@ func lookupGroupForUIDInContainer(rootdir string, userid uint64) (username strin
 		return pwd.name, pwd.gid, nil
 	}
 
-	return "", 0, user.UnknownUserError(fmt.Sprintf("error looking up user with UID %d", userid))
+	return "", 0, ErrNoSuchUser
 }
 
 func lookupAdditionalGroupsForUIDInContainer(rootdir string, userid uint64) (gid []uint32, err error) {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -316,6 +316,27 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(Equal("uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),18(audio),20(dialout),26(tape),27(video),777,65533(nogroup)"))
 	})
 
+	It("podman run with user (default)", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "id"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)"))
+	})
+
+	It("podman run with user (integer)", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--user=1234", ALPINE, "id"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("uid=1234 gid=1234"))
+	})
+
+	It("podman run with user (username)", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--user=mail", ALPINE, "id"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=12(mail) groups=12(mail)"))
+	})
+
 	It("podman run with attach stdin outputs container ID", func() {
 		session := podmanTest.Podman([]string{"run", "--attach", "stdin", ALPINE, "printenv"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
If an integer is passed into the --user flag, i.e --user=1234
don't look up the user in /etc/passwd, just assign the integer as the uid.

Fixes https://github.com/projectatomic/libpod/issues/631

Signed-off-by: umohnani8 <umohnani@redhat.com>