### PR TITLE
Add seconds after epoch to copr rpms to tie break versioning

### DIFF
--- a/.copr/prepare.sh
+++ b/.copr/prepare.sh
@@ -10,7 +10,7 @@ git fetch --unshallow || :
 COMMIT=$(git rev-parse HEAD)
 COMMIT_SHORT=$(git rev-parse --short HEAD)
 COMMIT_NUM=$(git rev-list HEAD --count)
-COMMIT_DATE=$(date --date="@$(git show -s --format=%ct HEAD)" +%Y%m%d)
+COMMIT_DATE=$(date +%s)
 
 sed "s,#COMMIT#,${COMMIT},;
      s,#SHORTCOMMIT#,${COMMIT_SHORT},;

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -44,7 +44,7 @@
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           podman
-Version:        0.4.4
+Version:        0.4.4.#COMMITDATE#
 Release:        git%{shortcommit}%{?dist}
 Summary:        Manage Pods, Containers and Container Images
 License:        ASL 2.0


### PR DESCRIPTION
Signed-off-by: baude <bbaude@redhat.com>