### PR TITLE
Restart test Improve

### DIFF
--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -36,10 +36,15 @@ var _ = Describe("Podman restart", func() {
 	It("Podman restart stopped container by name", func() {
 		_, exitCode, _ := podmanTest.RunLsContainer("test1")
 		Expect(exitCode).To(Equal(0))
+		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
+		startTime.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"restart", "test1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
+		restartTime.WaitWithDefaultTimeout()
+		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
 	})
 
 	It("Podman restart stopped container by ID", func() {
@@ -47,6 +52,8 @@ var _ = Describe("Podman restart", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
+		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", cid})
+		startTime.WaitWithDefaultTimeout()
 
 		startSession := podmanTest.Podman([]string{"start", cid})
 		startSession.WaitWithDefaultTimeout()
@@ -55,16 +62,24 @@ var _ = Describe("Podman restart", func() {
 		session2 := podmanTest.Podman([]string{"restart", cid})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
+		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", cid})
+		restartTime.WaitWithDefaultTimeout()
+		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
 	})
 
 	It("Podman restart running container", func() {
 		_ = podmanTest.RunTopContainer("test1")
 		ok := WaitForContainer(&podmanTest)
 		Expect(ok).To(BeTrue())
+		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
+		startTime.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"restart", "--latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
+		restartTime.WaitWithDefaultTimeout()
+		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
 	})
 
 	It("Podman restart multiple containers", func() {
@@ -73,9 +88,15 @@ var _ = Describe("Podman restart", func() {
 
 		_, exitCode, _ = podmanTest.RunLsContainer("test2")
 		Expect(exitCode).To(Equal(0))
+		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
+		startTime.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"restart", "test1", "test2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
+		restartTime.WaitWithDefaultTimeout()
+		Expect(restartTime.OutputToStringArray()[0]).To(Not(Equal(startTime.OutputToStringArray()[0])))
+		Expect(restartTime.OutputToStringArray()[1]).To(Not(Equal(startTime.OutputToStringArray()[1])))
 	})
 })

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Podman restart", func() {
 		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
 		startTime.WaitWithDefaultTimeout()
 
-		session := podmanTest.Podman([]string{"restart", "--latest"})
+		session := podmanTest.Podman([]string{"restart", "test1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
@@ -97,6 +97,25 @@ var _ = Describe("Podman restart", func() {
 		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
 		restartTime.WaitWithDefaultTimeout()
 		Expect(restartTime.OutputToStringArray()[0]).To(Not(Equal(startTime.OutputToStringArray()[0])))
+		Expect(restartTime.OutputToStringArray()[1]).To(Not(Equal(startTime.OutputToStringArray()[1])))
+	})
+
+	It("Podman restart the latest container", func() {
+		_, exitCode, _ := podmanTest.RunLsContainer("test1")
+		Expect(exitCode).To(Equal(0))
+
+		_, exitCode, _ = podmanTest.RunLsContainer("test2")
+		Expect(exitCode).To(Equal(0))
+
+		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
+		startTime.WaitWithDefaultTimeout()
+
+		session := podmanTest.Podman([]string{"restart", "-l"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		restartTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1", "test2"})
+		restartTime.WaitWithDefaultTimeout()
+		Expect(restartTime.OutputToStringArray()[0]).To(Equal(startTime.OutputToStringArray()[0]))
 		Expect(restartTime.OutputToStringArray()[1]).To(Not(Equal(startTime.OutputToStringArray()[1])))
 	})
 })


### PR DESCRIPTION
Some improvement for restart tests:
1. Add start time check for each test
2. Separated the --latest flag test from restart running container test
3. Add a test for --timeout