### PR TITLE
Modify man pages so they compile correctly in mandb

### DIFF
--- a/docs/podman-attach.1.md
+++ b/docs/podman-attach.1.md
@@ -3,7 +3,7 @@
 # podman-attach "1" "December 2017" "podman"
 
 ## NAME
-podman attach - Attach to a running container
+podman\-attach - Attach to a running container
 
 ## SYNOPSIS
 **podman attach [OPTIONS] CONTAINER**

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -3,7 +3,7 @@
 # podman-commit "1" "December 2017" "podman"
 
 ## NAME
-podman commit - Create new image based on the changed container
+podman\-commit - Create new image based on the changed container
 
 ## SYNOPSIS
 **podman commit** [*options* [...]] CONTAINER IMAGE

--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -3,7 +3,7 @@
 # podman-cp "1" "August 2017" "podman"
 
 ## NAME
-podman cp - Copy files/folders between a container and the local filesystem
+podman\-cp - Copy files/folders between a container and the local filesystem
 
 ## Description
 We chose not to implement the `cp` feature in `podman` even though the upstream Docker

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -2,7 +2,7 @@
 % Dan Walsh
 
 ## NAME
-podman create - Create a new container
+podman\-create - Create a new container
 
 ## SYNOPSIS
 **podman create** [*options* [...]] IMAGE [COMMAND] [ARG...]

--- a/docs/podman-diff.1.md
+++ b/docs/podman-diff.1.md
@@ -3,7 +3,7 @@
 # podman-diff "1" "August 2017" "podman"
 
 ## NAME
-podman diff - Inspect changes on a container or image's filesystem
+podman\-diff - Inspect changes on a container or image's filesystem
 
 ## SYNOPSIS
 **podman** **diff** [*options* [...]] NAME

--- a/docs/podman-exec.1.md
+++ b/docs/podman-exec.1.md
@@ -3,7 +3,7 @@
 # podman-exec "1" "December 2017" "podman"
 
 ## NAME
-podman exec - Execute a command in a running container
+podman\-exec - Execute a command in a running container
 
 ## SYNOPSIS
 **podman exec**

--- a/docs/podman-history.1.md
+++ b/docs/podman-history.1.md
@@ -3,7 +3,7 @@
 % podman-history "1" "JULY 2017" "podman"
 
 ## NAME
-podman history - Shows the history of an image
+podman\-history - Shows the history of an image
 
 ## SYNOPSIS
 **podman history**

--- a/docs/podman-images.1.md
+++ b/docs/podman-images.1.md
@@ -3,7 +3,7 @@
 # podman-images "1" "March 2017" "podman"
 
 ## NAME
-podman images - List images in local storage
+podman\-images - List images in local storage
 
 ## SYNOPSIS
 **podman** **images** [*options* [...]]

--- a/docs/podman-import.1.md
+++ b/docs/podman-import.1.md
@@ -3,7 +3,7 @@
 # podman-import "1" "November 2017" "podman"
 
 ## NAME
-podman import - Import a tarball and save it as a filesystem image
+podman\-import - Import a tarball and save it as a filesystem image
 
 ## SYNOPSIS
 **podman import**

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -3,7 +3,7 @@
 % podman-version "1" "JULY 2017" "podman"
 
 ## NAME
-podman info - Display system information
+podman\-info - Display system information
 
 
 ## SYNOPSIS

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -3,7 +3,7 @@
 # podman-inspect "1" "July 2017" "podman"
 
 ## NAME
-podman inspect - Display a container or image's configuration
+podman\-inspect - Display a container or image's configuration
 
 ## SYNOPSIS
 **podman** **inspect** [*options* [...]] name [...]

--- a/docs/podman-kill.1.md
+++ b/docs/podman-kill.1.md
@@ -3,7 +3,7 @@
 # podman-kill"1" "September 2017" "podman"
 
 ## NAME
-podman kill - Kills one or more containers with a signal
+podman\-kill - Kills one or more containers with a signal
 
 ## SYNOPSIS
 **podman kill [OPTIONS] CONTAINER [...]**

--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -3,7 +3,7 @@
 # podman-load "1" "July 2017" "podman"
 
 ## NAME
-podman load - Load an image from docker archive
+podman\-load - Load an image from docker archive
 
 ## SYNOPSIS
 **podman load**

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -3,7 +3,7 @@
 # podman-login "1" "August 2017" "podman"
 
 ## NAME
-podman login - Login to a container registry
+podman\-login - Login to a container registry
 
 ## SYNOPSIS
 **podman login**

--- a/docs/podman-logout.1.md
+++ b/docs/podman-logout.1.md
@@ -3,7 +3,7 @@
 # podman-logout "1" "August 2017" "podman"
 
 ## NAME
-podman logout - Logout of a container registry
+podman\-logout - Logout of a container registry
 
 ## SYNOPSIS
 **podman logout**

--- a/docs/podman-logs.1.md
+++ b/docs/podman-logs.1.md
@@ -3,7 +3,7 @@
 # podman-logs "1" "March 2017" "podman"
 
 ## NAME
-podman logs - Fetch the logs of a container
+podman\-logs - Fetch the logs of a container
 
 ## SYNOPSIS
 **podman** **logs** [*options* [...]] container

--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -3,7 +3,7 @@
 # podman-mount "1" "July 2017" "podman"
 
 ## NAME
-podman mount - Mount a working container's root filesystem
+podman\-mount - Mount a working container's root filesystem
 
 ## SYNOPSIS
 **podman** **mount**

--- a/docs/podman-pause.1.md
+++ b/docs/podman-pause.1.md
@@ -3,7 +3,7 @@
 # podman-pause "1" "September 2017" "podman"
 
 ## NAME
-podman pause - Pause one or more containers
+podman\-pause - Pause one or more containers
 
 ## SYNOPSIS
 **podman pause [OPTIONS] CONTAINER [...]**

--- a/docs/podman-port.1.md
+++ b/docs/podman-port.1.md
@@ -3,7 +3,7 @@
 # podman-port "1" "January 2018" "podman"
 
 ## NAME
-podman port - List port mappings for a container
+podman\-port - List port mappings for a container
 
 ## SYNOPSIS
 **podman port [OPTIONS] CONTAINER [PRIVATE_PORT[/PROTO]]**

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -3,7 +3,7 @@
 % podman-ps "1" "AUGUST 2017" "podman"
 
 ## NAME
-podman ps - Prints out information about containers
+podman\-ps - Prints out information about containers
 
 ## SYNOPSIS
 **podman ps**

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -3,7 +3,7 @@
 # podman-pull "1" "July 2017" "podman"
 
 ## NAME
-podman pull - Pull an image from a registry
+podman\-pull - Pull an image from a registry
 
 ## SYNOPSIS
 **podman pull**

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -3,7 +3,7 @@
 # podman-push "1" "June 2017" "podman"
 
 ## NAME
-podman push - Push an image from local storage to elsewhere
+podman\-push - Push an image from local storage to elsewhere
 
 ## SYNOPSIS
 **podman** **push** [*options* [...]] **imageID** [**destination**]

--- a/docs/podman-restart.1.md
+++ b/docs/podman-restart.1.md
@@ -3,7 +3,7 @@
 # podman-restart "1" "March 2017" "podman"
 
 ## NAME
-podman restart - Restart a container
+podman\-restart - Restart a container
 
 ## SYNOPSIS
 **podman attach [OPTIONS] CONTAINER [CONTAINER...]**

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -3,7 +3,7 @@
 # podman-rm "1" "August 2017" "podman"
 
 ## NAME
-podman rm - Remove one or more containers
+podman\-rm - Remove one or more containers
 
 ## SYNOPSIS
 **podman** **rm** [*options* [...]] container

--- a/docs/podman-rmi.1.md
+++ b/docs/podman-rmi.1.md
@@ -3,7 +3,7 @@
 # podman-rmi "1" "March 2017" "podman"
 
 ## NAME
-podman rmi - Removes one or more images
+podman\-rmi - Removes one or more images
 
 ## SYNOPSIS
 **podman** **rmi** **imageID [...]**

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -2,7 +2,7 @@
 % Dan Walsh
 
 ## NAME
-podman run - Run a command in a new container
+podman\-run - Run a command in a new container
 
 ## SYNOPSIS
 **podman run** [*options* [...]] IMAGE [COMMAND] [ARG...]

--- a/docs/podman-save.1.md
+++ b/docs/podman-save.1.md
@@ -3,7 +3,7 @@
 # podman-save "1" "July 2017" "podman"
 
 ## NAME
-podman save - Save an image to docker-archive or oci-archive
+podman\-save - Save an image to docker-archive or oci-archive
 
 ## SYNOPSIS
 **podman save**

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -3,7 +3,7 @@
 # podman-search "1" "January 2018" "podman"
 
 ## NAME
-podman search - Search a registry for an image
+podman\-search - Search a registry for an image
 
 ## SYNOPSIS
 **podman search**

--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -3,7 +3,7 @@
 # podman-start "1" "November 2017" "podman"
 
 ## NAME
-podman start - Start one or more containers
+podman\-start - Start one or more containers
 
 ## SYNOPSIS
 **podman start [OPTIONS] CONTAINER [...]**

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -3,7 +3,7 @@
 # podman-stats "1" "July 2017" "podman"
 
 ## NAME
-podman stats - Display a live stream of 1 or more containers' resource usage statistics
+podman\-stats - Display a live stream of 1 or more containers' resource usage statistics
 
 ## SYNOPSIS
 **podman** **stats** [*options* [...]] [container]

--- a/docs/podman-stop.1.md
+++ b/docs/podman-stop.1.md
@@ -3,7 +3,7 @@
 # podman-stop "1" "September 2017" "podman"
 
 ## NAME
-podman stop - Stop one or more containers
+podman\-stop - Stop one or more containers
 
 ## SYNOPSIS
 **podman stop [OPTIONS] CONTAINER [...]**

--- a/docs/podman-tag.1.md
+++ b/docs/podman-tag.1.md
@@ -3,7 +3,7 @@
 # podman-tag "1" "July 2017" "podman"
 
 ## NAME
-podman tag - Add an additional name to a local image
+podman\-tag - Add an additional name to a local image
 
 ## SYNOPSIS
 **podman [GLOBAL OPTIONS] tag IMAGE[:TAG] TARGET_NAME[:TAG]**

--- a/docs/podman-top.1.md
+++ b/docs/podman-top.1.md
@@ -2,7 +2,7 @@
 % Brent Baude
 
 ## NAME
-podman top - Display the running processes of a container
+podman\-top - Display the running processes of a container
 
 ## SYNOPSIS
 **podman top**

--- a/docs/podman-umount.1.md
+++ b/docs/podman-umount.1.md
@@ -3,7 +3,7 @@
 # podman-umount "1" "July 2017" "podman"
 
 ## NAME
-podman umount - Unmount a working container's root file system
+podman\-umount - Unmount a working container's root file system
 
 ## SYNOPSIS
 **podman** **umount** **containerID**

--- a/docs/podman-unpause.1.md
+++ b/docs/podman-unpause.1.md
@@ -3,7 +3,7 @@
 # podman-unpause "1" "September 2017" "podman"
 
 ## NAME
-podman unpause - Unpause one or more containers
+podman\-unpause - Unpause one or more containers
 
 ## SYNOPSIS
 **podman unpause [OPTIONS] CONTAINER [...]**

--- a/docs/podman-varlink.1.md
+++ b/docs/podman-varlink.1.md
@@ -3,7 +3,7 @@
 # podman-varlink "1" "April 2018" "podman"
 
 ## NAME
-podman varlink - Runs the varlink backend interface
+podman\-varlink - Runs the varlink backend interface
 
 ## SYNOPSIS
 **podman varlink**

--- a/docs/podman-version.1.md
+++ b/docs/podman-version.1.md
@@ -3,7 +3,7 @@
 # podman-version "1" "July 2017" "podman"
 
 ## NAME
-podman version - Display the PODMAN Version Information
+podman\-version - Display the PODMAN Version Information
 
 ## SYNOPSIS
 **podman version**

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -3,7 +3,7 @@
 # podman-wait "1" "September 2017" "podman"
 
 ## NAME
-podman wait - Waits on one or more containers to stop and prints exit code
+podman\-wait - Waits on one or more containers to stop and prints exit code
 
 ## SYNOPSIS
 **podman wait**


### PR DESCRIPTION
This fixes an issue where if you did
man -k podman-run

podman-run (1)    - (unknown subject)

Now you will see

man -k podman-run
podman-run (1)       - Run a command in a new container

More importantly

man -k containers | grep podman
podman (1)           - Simple management tool for containers and images
podman-kill (1)      - Kills one or more containers with a signal
podman-pause (1)     - Pause one or more containers
podman-ps (1)        - Prints out information about containers
podman-rm (1)        - Remove one or more containers
podman-start (1)     - Start one or more containers
podman-stats (1)     - Display a live stream of 1 or more containers' resource usage statistics
podman-stop (1)      - Stop one or more containers
podman-unpause (1)   - Unpause one or more containers
podman-wait (1)      - Waits on one or more containers to stop and prints exit code

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>