### PR TITLE
Add --default-mounts-file hidden flag

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -125,6 +125,11 @@ func main() {
 			Usage: "path for the cpu profiling results",
 		},
 		cli.StringFlag{
+			Name:   "default-mounts-file",
+			Usage:  "path to default mounts file",
+			Hidden: true,
+		},
+		cli.StringFlag{
 			Name:   "hooks-dir-path",
 			Usage:  "set the OCI hooks directory path",
 			Value:  hooks.DefaultHooksDir,

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -58,6 +58,9 @@ func getRuntime(c *cli.Context) (*libpod.Runtime, error) {
 	if c.GlobalIsSet("cni-config-dir") {
 		options = append(options, libpod.WithCNIConfigDir(c.GlobalString("cni-config-dir")))
 	}
+	if c.GlobalIsSet("default-mounts-file") {
+		options = append(options, libpod.WithDefaultMountsFile(c.GlobalString("default-mounts-file")))
+	}
 	options = append(options, libpod.WithHooksDir(c.GlobalString("hooks-dir-path")))
 
 	// TODO flag to set CNI plugins dir?

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -753,7 +753,7 @@ func (c *Container) makeBindMounts() error {
 	}
 
 	// Add Secret Mounts
-	secretMounts := secrets.SecretMounts(c.config.MountLabel, c.state.RunDir)
+	secretMounts := secrets.SecretMounts(c.config.MountLabel, c.state.RunDir, c.runtime.config.DefaultMountsFile)
 	for _, mount := range secretMounts {
 		if _, ok := c.state.BindMounts[mount.Destination]; !ok {
 			c.state.BindMounts[mount.Destination] = mount.Source

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -186,6 +186,19 @@ func WithHooksDir(hooksDir string) RuntimeOption {
 	}
 }
 
+// WithDefaultMountsFile sets the file to look at for default mounts (mainly secrets)
+// Note we are not saving this in the database as it is for testing purposes only
+func WithDefaultMountsFile(mountsFile string) RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return ErrRuntimeFinalized
+		}
+
+		rt.config.DefaultMountsFile = []string{mountsFile}
+		return nil
+	}
+}
+
 // WithTmpDir sets the directory that temporary runtime files which are not
 // expected to survive across reboots will be stored
 // This should be located on a tmpfs mount (/tmp or /var/run for example)

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -131,6 +131,8 @@ type RuntimeConfig struct {
 	CNIPluginDir []string `toml:"cni_plugin_dir"`
 	// HooksDir Path to the directory containing hooks configuration files
 	HooksDir string `toml:"hooks_dir"`
+	// DefaultMountsFile is the path to the default mounts file for testing purposes only
+	DefaultMountsFile []string `toml:"-"`
 }
 
 var (

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -127,10 +127,15 @@ func getMountsMap(path string) (string, string, error) {
 }
 
 // SecretMounts copies, adds, and mounts the secrets to the container root filesystem
-func SecretMounts(mountLabel, containerWorkingDir string) []rspec.Mount {
+func SecretMounts(mountLabel, containerWorkingDir string, mountFile []string) []rspec.Mount {
 	var secretMounts []rspec.Mount
 	// Add secrets from paths given in the mounts.conf files
-	for _, file := range []string{OverrideMountsFile, DefaultMountsFile} {
+	// mountFile will have a value if the hidden --default-mounts-file flag is set
+	// Note for testing purposes only
+	if len(mountFile) == 0 {
+		mountFile = append(mountFile, []string{OverrideMountsFile, DefaultMountsFile}...)
+	}
+	for _, file := range mountFile {
 		mounts, err := addSecretsFromMountsFile(file, mountLabel, containerWorkingDir)
 		if err != nil {
 			logrus.Warnf("error mounting secrets, skipping: %v", err)

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run with secrets", func() {
-		containersDir := "/usr/share/containers"
+		containersDir := filepath.Join(podmanTest.TempDir, "containers")
 		err := os.MkdirAll(containersDir, 0755)
 		Expect(err).To(BeNil())
 
@@ -288,18 +288,15 @@ var _ = Describe("Podman run", func() {
 		execSession.WaitWithDefaultTimeout()
 		Expect(execSession.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "cat", "/run/secrets/test.txt"})
+		session := podmanTest.Podman([]string{"--default-mounts-file=" + mountsFile, "run", "--rm", ALPINE, "cat", "/run/secrets/test.txt"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal(secretsString))
 
-		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "ls", "/run/secrets/mysymlink"})
+		session = podmanTest.Podman([]string{"--default-mounts-file=" + mountsFile, "run", "--rm", ALPINE, "ls", "/run/secrets/mysymlink"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("key.pem"))
-
-		err = os.RemoveAll(containersDir)
-		Expect(err).To(BeNil())
 	})
 
 	It("podman run with FIPS mode secrets", func() {


### PR DESCRIPTION
The hidden flag is used to override the path of the default mounts file
for testing purposes.
Also modified the secrets pkg to allow for this override to happen.

Signed-off-by: umohnani8 <umohnani@redhat.com>