### PR TITLE
Retrieve IP addresses for container from DB

### DIFF
--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -199,7 +199,7 @@ type NetworkSettings struct {
 	Gateway                string               `json:"Gateway"`
 	GlobalIPv6Addresses    []string             `json:"GlobalIPv6Addresses"`
 	GlobalIPv6PrefixLen    int                  `json:"GlobalIPv6PrefixLen"`
-	IPAddress              string               `json:"IPAddress"`
+	IPAddress              []string             `json:"IPAddress"`
 	IPPrefixLen            int                  `json:"IPPrefixLen"`
 	IPv6Gateway            string               `json:"IPv6Gateway"`
 	MacAddress             string               `json:"MacAddress"`


### PR DESCRIPTION
Instead of execing out to the host's IP, use the IP address we got back from CNI to populate Inspect's IP address information.

Fixes #679 

This does introduce an incompatability with Docker in that Inspect's IP field is now an array, as our containers can (potentially) have multiple addresses.