### PR TITLE
Refactor unittest for varlink component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /test/checkseccomp/checkseccomp
 /test/copyimg/copyimg
 /build/
+.nfs*
+.ropeproject
+__pycache__

--- a/test/varlink/podman_testcase.py
+++ b/test/varlink/podman_testcase.py
@@ -1,0 +1,28 @@
+"""Custom TestCase for varlink/podman."""
+import os
+import unittest
+
+import varlink
+
+
+class PodmanTestCase(unittest.TestCase):
+    """Provides varlink setup for podman."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize class by calling parent."""
+        super(PodmanTestCase, self).__init__(*args, **kwargs)
+        self.address = os.environ.get(
+            'PODMAN_HOST',
+            'unix:/run/podman/io.projectatomic.podman')
+
+    def setUp(self):
+        """Set up the varlink/podman fixture before each test."""
+        super(PodmanTestCase, self).setUp()
+        self.client = varlink.Client(
+            address=self.address)
+        self.podman = self.client.open('io.projectatomic.podman')
+
+    def tearDown(self):
+        """Deconstruct the varlink/podman fixture after each test."""
+        super(PodmanTestCase, self).tearDown()
+        self.podman.close()

--- a/test/varlink/run_varlink_tests.sh
+++ b/test/varlink/run_varlink_tests.sh
@@ -23,12 +23,11 @@ export PODMAN_HOST="unix:${TMPSTORAGE}/podman/io.projectatomic.podman"
 # Need a location to store the podman socket
 mkdir -p ${TMPSTORAGE}/podman
 
-systemd-cat -t podman -p notice bin/podman --version
+bin/podman --version
 
 set -x
 # Run podman in background without systemd for test purposes
-systemd-cat -t podman -p notice \
-  bin/podman --storage-driver=vfs --root=${TMPSTORAGE}/crio \
+bin/podman --storage-driver=vfs --root=${TMPSTORAGE}/crio \
   --runroot=${TMPSTORAGE}/crio-run varlink ${PODMAN_HOST} &
 
 ${PYTHON} -m unittest discover -s test/varlink/ $@

--- a/test/varlink/run_varlink_tests.sh
+++ b/test/varlink/run_varlink_tests.sh
@@ -1,37 +1,35 @@
 #!/bin/bash
 
-set -x
 if [ ! -n "${PYTHON+ }" ]; then
-    if hash python3 > /dev/null 2>&1 /dev/null; then
-        PYTHON=$(hash -t python3)
-    elif type python3 > /dev/null 2>&1; then
-        PYTHON=$(type python3 | awk '{print $3}')
-    elif hash python2 > /dev/null 2>&1; then
-        PYTHON=$(hash -t python2)
-    elif type python2 > /dev/null 2>&1; then
-        PYTHON=$(type python2 | awk '{print $3}')
-    else
-        PYTHON='/usr/bin/python'
-    fi
+  if hash python3 > /dev/null 2>&1; then
+    PYTHON=$(hash -t python3)
+  elif type python3 > /dev/null 2>&1; then
+    PYTHON=$(type python3 | awk '{print $3}')
+  elif hash python2 > /dev/null 2>&1; then
+    PYTHON=$(hash -t python2)
+  elif type python2 > /dev/null 2>&1; then
+    PYTHON=$(type python2 | awk '{print $3}')
+  else
+    PYTHON='/usr/bin/python'
+  fi
 fi
 
 # Create temporary directory for storage
-TMPSTORAGE=`mktemp -d`
+TMPSTORAGE=`mktemp -d /tmp/podman.XXXXXXXXXX`
+trap 'rm -fr ${TMPSTORAGE}' EXIT
+
+export PODMAN_HOST="unix:${TMPSTORAGE}/podman/io.projectatomic.podman"
 
 # Need a location to store the podman socket
-mkdir /run/podman
+mkdir -p ${TMPSTORAGE}/podman
 
+systemd-cat -t podman -p notice bin/podman --version
+
+set -x
 # Run podman in background without systemd for test purposes
-bin/podman --storage-driver=vfs --root=${TMPSTORAGE}/crio --runroot=${TMPSTORAGE}/crio-run varlink unix:/run/podman/io.projectatomic.podman&
+systemd-cat -t podman -p notice \
+  bin/podman --storage-driver=vfs --root=${TMPSTORAGE}/crio \
+  --runroot=${TMPSTORAGE}/crio-run varlink ${PODMAN_HOST} &
 
-# Record podman's pid to be killed later
-PODMAN_PID=`echo $!`
-
-# Run tests
-${PYTHON} -m unittest discover -s test/varlink/
-
-# Kill podman
-kill -9 ${PODMAN_PID}
-
-# Clean up
-rm -fr ${TMPSTORAGE}
+${PYTHON} -m unittest discover -s test/varlink/ $@
+pkill podman

--- a/test/varlink/test_containers.py
+++ b/test/varlink/test_containers.py
@@ -1,99 +1,89 @@
 import unittest
-from varlink import (Client, VarlinkError)
+
+from varlink import VarlinkError
+
+from podman_testcase import PodmanTestCase
+
+MethodNotImplemented = 'org.varlink.service.MethodNotImplemented'
 
 
-address = "unix:/run/podman/io.projectatomic.podman"
-client = Client(address=address)
-
-
-def runErrorTest(tfunc):
-    try:
-        tfunc()
-    except VarlinkError as e:
-        return e.error() == "org.varlink.service.MethodNotImplemented"
-    return False
-
-
-class ContainersAPI(unittest.TestCase):
+class TestContainersAPI(PodmanTestCase):
     def test_ListContainers(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ListContainers))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ListContainers()
 
     def test_CreateContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.CreateContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.CreateContainer()
 
     def test_InspecContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.InspectContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.InspectContainer()
 
     def test_ListContainerProcesses(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ListContainerProcesses))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ListContainerProcesses()
 
     def test_GetContainerLogs(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.GetContainerLogs))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.GetContainerLogs()
 
     def test_ListContainerChanges(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ListContainerChanges))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ListContainerChanges()
 
     def test_ExportContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ExportContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ExportContainer()
 
     def test_GetContainerStats(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.GetContainerStats))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.GetContainerStats()
 
     def test_ResizeContainerTty(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ResizeContainerTty))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ResizeContainerTty()
 
     def test_StartContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.StartContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.StartContainer()
 
     def test_RestartContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.RestartContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.RestartContainer()
 
     def test_KillContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.KillContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.KillContainer()
 
     def test_UpdateContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.UpdateContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.UpdateContainer()
 
     def test_RenameContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.RenameContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.RenameContainer()
 
     def test_PauseContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.PauseContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.PauseContainer()
 
     def test_UnpauseContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.UnpauseContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.UnpauseContainer()
 
     def test_AttachToContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.AttachToContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.AttachToContainer()
 
     def test_WaitContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.WaitContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.WaitContainer()
 
     def test_RemoveContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.RemoveContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.RemoveContainer()
 
-    def test_DeleteContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.DeleteContainer))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/varlink/test_images.py
+++ b/test/varlink/test_images.py
@@ -1,71 +1,65 @@
 import unittest
-from varlink import (Client, VarlinkError)
+
+from varlink import VarlinkError
+
+from podman_testcase import PodmanTestCase
+
+MethodNotImplemented = 'org.varlink.service.MethodNotImplemented'
 
 
-address = "unix:/run/podman/io.projectatomic.podman"
-client = Client(address=address)
-
-
-def runErrorTest(tfunc):
-    try:
-        tfunc()
-    except VarlinkError as e:
-        return e.error() == "org.varlink.service.MethodNotImplemented"
-    return False
-
-
-class ImagesAPI(unittest.TestCase):
+class TestImagesAPI(PodmanTestCase):
     def test_ListImages(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ListImages))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ListImages()
 
     def test_BuildImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.BuildImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.BuildImage()
 
     def test_CreateImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.CreateImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.CreateImage()
 
     def test_InspectImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.InspectImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.InspectImage()
 
     def test_HistoryImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.HistoryImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.HistoryImage()
 
     def test_PushImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.PushImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.PushImage()
 
     def test_TagImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.TagImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.TagImage()
 
     def test_RemoveImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.TagImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.TagImage()
 
     def test_SearchImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.SearchImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.SearchImage()
 
     def test_DeleteUnusedImages(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.DeleteUnusedImages))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.DeleteUnusedImages()
 
     def test_CreateFromContainer(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.CreateFromContainer))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.CreateFromContainer()
 
     def test_ImportImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ImportImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ImportImage()
 
     def test_ExportImage(self):
-        podman = client.open("io.projectatomic.podman")
-        self.assertTrue(runErrorTest(podman.ExportImage))
+        with self.assertRaisesRegex(VarlinkError, MethodNotImplemented):
+            self.podman.ExportImage()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/varlink/test_system.py
+++ b/test/varlink/test_system.py
@@ -1,21 +1,19 @@
 import unittest
-from varlink import (Client, VarlinkError)
+
+from podman_testcase import PodmanTestCase
 
 
-address = "unix:/run/podman/io.projectatomic.podman"
-client = Client(address=address)
-
-class SystemAPI(unittest.TestCase):
+class TestSystemAPI(PodmanTestCase):
     def test_ping(self):
-        podman = client.open("io.projectatomic.podman")
-        response = podman.Ping()
-        self.assertEqual("OK", response["ping"]["message"])
+        response = self.podman.Ping()
+        self.assertEqual('OK', response['ping']['message'])
 
     def test_GetVersion(self):
-        podman = client.open("io.projectatomic.podman")
-        response = podman.GetVersion()
-        for k in ["version", "go_version", "built", "os_arch"]:
-            self.assertTrue(k in response["version"].keys())
+        response = self.podman.GetVersion()
+        self.assertTrue(set(
+            ['version', 'go_version', 'built', 'os_arch']
+        ).issubset(response['version'].keys()))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Allow unittest's to run as normal user
- Refactor tests to use unittest features
- Refactor tests to use fixtures to track resources
- Update test runner script to clean up on failure

Signed-off-by: Jhon Honce <jhonce@redhat.com>