### PR TITLE
Modify secrets pkg

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -194,7 +194,10 @@ func WithDefaultMountsFile(mountsFile string) RuntimeOption {
 			return ErrRuntimeFinalized
 		}
 
-		rt.config.DefaultMountsFile = []string{mountsFile}
+		if mountsFile == "" {
+			return ErrInvalidArg
+		}
+		rt.config.DefaultMountsFile = mountsFile
 		return nil
 	}
 }

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -132,7 +132,7 @@ type RuntimeConfig struct {
 	// HooksDir Path to the directory containing hooks configuration files
 	HooksDir string `toml:"hooks_dir"`
 	// DefaultMountsFile is the path to the default mounts file for testing purposes only
-	DefaultMountsFile []string `toml:"-"`
+	DefaultMountsFile string `toml:"-"`
 }
 
 var (

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -127,15 +127,20 @@ func getMountsMap(path string) (string, string, error) {
 }
 
 // SecretMounts copies, adds, and mounts the secrets to the container root filesystem
-func SecretMounts(mountLabel, containerWorkingDir string, mountFile []string) []rspec.Mount {
-	var secretMounts []rspec.Mount
+func SecretMounts(mountLabel, containerWorkingDir string, mountFile string) []rspec.Mount {
+	var (
+		secretMounts []rspec.Mount
+		mountFiles   []string
+	)
 	// Add secrets from paths given in the mounts.conf files
 	// mountFile will have a value if the hidden --default-mounts-file flag is set
 	// Note for testing purposes only
-	if len(mountFile) == 0 {
-		mountFile = append(mountFile, []string{OverrideMountsFile, DefaultMountsFile}...)
+	if mountFile == "" {
+		mountFiles = append(mountFiles, []string{OverrideMountsFile, DefaultMountsFile}...)
+	} else {
+		mountFiles = append(mountFiles, mountFile)
 	}
-	for _, file := range mountFile {
+	for _, file := range mountFiles {
 		mounts, err := addSecretsFromMountsFile(file, mountLabel, containerWorkingDir)
 		if err != nil {
 			logrus.Warnf("error mounting secrets, skipping: %v", err)


### PR DESCRIPTION
Made a mistake in my earlier patch. I though that if you add an empty string
to an array, the length of the array would still be 0...
Realised this when vendoring the secrets pkg into cri-o.

Signed-off-by: umohnani8 <umohnani@redhat.com>