### PR TITLE
README: Link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,9 +115,8 @@ commit automatically with `git commit -s`.
 
 ## Communications
 
-For general questions, or discussions, please use the
-IRC group on `irc.freenode.net` called `cri-o`
-that has been setup.
+For general questions and discussion, please use the
+IRC `#podman` channel on `irc.freenode.net`.
 
 For discussions around issues/bugs and features, you can use the github
 [issues](https://github.com/projectatomic/libpod/issues)

--- a/README.md
+++ b/README.md
@@ -50,11 +50,8 @@ includes tables showing Docker commands and their Podman equivalent commands.
 **[Tutorials](docs/tutorials)**
 Tutorials on the Podman utility.
 
-## Communication with Fellow Developers
-
-For async communication and long running discussions please use issues and pull requests on the github repo. This will be the best place to discuss design and implementation.
-
-For sync communication we have an IRC channel #PODMAN, on chat.freenode.net, that everyone is welcome to join and chat about development.
+**[Contributing](CONTRIBUTING.md)**
+Information about contributing to this project.
 
 ### Current Roadmap
 


### PR DESCRIPTION
Make that information more easily discoverable.  And since `CONTRIBUTING.md` already mentions IRC, we can drop the IRC reference from the `README.md` to DRY things up.

Also update `CONTRIBUTING.md` to replace the stale #cri-o reference left over from the initial libpod/podman fork.  While I was touching this line, I also shuffled some of the wording around to tighten that sentence up.