### PR TITLE
Add iidfile param to build and commit man pages

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -137,6 +137,10 @@ Control the format for the built image's manifest and configuration data.
 Recognized formats include *oci* (OCI image-spec v1.0, the default) and
 *docker* (version 2, using schema format 2 for the manifest).
 
+**--iidfile** *ImageIDfile*
+
+Write the image ID to the file.
+
 **--isolation** [Not Supported]
 
 Buildah is not currently supported on Windows, and does not have a daemon.

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -27,6 +27,10 @@ Apply the following possible instructions to the created image:
 **CMD** | **ENTRYPOINT** | **ENV** | **EXPOSE** | **LABEL** | **STOPSIGNAL** | **USER** | **VOLUME** | **WORKDIR**
 Can be set multiple times
 
+**--iidfile** *ImageIDfile*
+
+Write the image ID to the file.
+
 **--message, -m**
 Set commit message for committed image
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

iidfile was recently added as a parameter to 'bulidah bud' and ' buildah commit', adding here to as I think @baude's commit/build work will pick them up.  That PR was https://github.com/projectatomic/buildah/pull/636