### PR TITLE
libpod.conf: Podman's conmon path on openSUSE

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -20,6 +20,7 @@ conmon_path = [
 	    "/usr/local/libexec/crio/conmon",
 	    "/usr/bin/conmon",
 	    "/usr/sbin/conmon",
+	    "/usr/lib/podman/bin/conmon",
 	    "/usr/lib/crio/bin/conmon"
 ]
 


### PR DESCRIPTION
Add the path to Podman's conmon for openSUSE and SLE.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>