### PR TITLE
do not commit default volumes from container

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -120,7 +121,17 @@ func commitCmd(c *cli.Context) error {
 		Changes:       c.StringSlice("change"),
 		Author:        c.String("author"),
 	}
-	newImage, err := ctr.Commit(getContext(), reference, options)
+	var createArtifact createConfig
+	artifact, err := ctr.GetArtifact("create-config")
+	if err == nil {
+		if err := json.Unmarshal(artifact, &createArtifact); err != nil {
+			return err
+		}
+	}
+	mounts := getMounts(createArtifact.Volumes, true)
+	command := createArtifact.Command
+	entryPoint := createArtifact.Entrypoint
+	newImage, err := ctr.Commit(getContext(), reference, options, strings.Split(mounts, ","), command, entryPoint)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -110,4 +110,26 @@ var _ = Describe("Podman commit", func() {
 		check.WaitWithDefaultTimeout()
 		Expect(check.ExitCode()).To(Equal(0))
 	})
+
+	It("podman commit with volume mounts", func() {
+		s := podmanTest.Podman([]string{"run", "--name", "test1", "-v", "/tmp:/foo", "alpine", "date"})
+		s.WaitWithDefaultTimeout()
+		Expect(s.ExitCode()).To(Equal(0))
+
+		c := podmanTest.Podman([]string{"commit", "test1", "newimage"})
+		c.WaitWithDefaultTimeout()
+		Expect(c.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "newimage"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(Equal(0))
+		image := inspect.InspectImageJSON()
+		_, ok := image[0].ContainerConfig.Volumes["/tmp"]
+		Expect(ok).To(BeTrue())
+
+		r := podmanTest.Podman([]string{"run", "newimage"})
+		r.WaitWithDefaultTimeout()
+		Expect(r.ExitCode()).To(Equal(0))
+	})
+
 })


### PR DESCRIPTION
when performing a container commit, we should not add the default list of volumes
for a container to the resulting image.  it will cause the resulting image to crash
when run subsequently.

Signed-off-by: baude <bbaude@redhat.com>