### PR TITLE
Add image fields to libpod database

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -121,17 +120,7 @@ func commitCmd(c *cli.Context) error {
 		Changes:       c.StringSlice("change"),
 		Author:        c.String("author"),
 	}
-	var createArtifact createConfig
-	artifact, err := ctr.GetArtifact("create-config")
-	if err == nil {
-		if err := json.Unmarshal(artifact, &createArtifact); err != nil {
-			return err
-		}
-	}
-	mounts := getMounts(createArtifact.Volumes, true)
-	command := createArtifact.Command
-	entryPoint := createArtifact.Entrypoint
-	newImage, err := ctr.Commit(getContext(), reference, options, strings.Split(mounts, ","), command, entryPoint)
+	newImage, err := ctr.Commit(getContext(), reference, options)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -658,8 +658,7 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 		// others, if they are included
 		volumes := make([]string, 0, len(c.Volumes))
 		for _, vol := range c.Volumes {
-			splitVol := strings.Split(vol, ":")
-			volumes = append(volumes, splitVol[0])
+			volumes = append(volumes, strings.SplitN(vol, ":", 2)[0])
 		}
 
 		options = append(options, libpod.WithUserVolumes(volumes))

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -653,8 +653,17 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 	}
 
 	if len(c.Volumes) != 0 {
-		options = append(options, libpod.WithUserVolumes())
+		options = append(options, libpod.WithUserVolumes(c.Volumes))
 	}
+
+	if len(c.Command) != 0 {
+		options = append(options, libpod.WithCommand(c.Command))
+	}
+
+	// Add entrypoint unconditionally
+	// If it's empty it's because it was explicitly set to "" or the image
+	// does not have one
+	options = append(options, libpod.WithEntrypoint(c.Entrypoint))
 
 	if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -652,6 +652,10 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 		}
 	}
 
+	if len(c.Volumes) != 0 {
+		options = append(options, libpod.WithUserVolumes())
+	}
+
 	if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())
 		if err != nil {

--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -653,7 +653,16 @@ func (c *createConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 	}
 
 	if len(c.Volumes) != 0 {
-		options = append(options, libpod.WithUserVolumes(c.Volumes))
+		// Volumes consist of multiple, comma-delineated fields
+		// The image spec only includes one part of that, so drop the
+		// others, if they are included
+		volumes := make([]string, 0, len(c.Volumes))
+		for _, vol := range c.Volumes {
+			splitVol := strings.Split(vol, ":")
+			volumes = append(volumes, splitVol[0])
+		}
+
+		options = append(options, libpod.WithUserVolumes(volumes))
 	}
 
 	if len(c.Command) != 0 {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -190,6 +190,10 @@ type ContainerConfig struct {
 	// These include the SHM mount
 	// These must be unmounted before the container's rootfs is unmounted
 	Mounts []string `json:"mounts,omitempty"`
+	// UserVolumes indicates that the container has user-added volume mounts
+	// It is used to trigger OCI hooks that rely on the presence of user
+	// volumes
+	UserVolumes bool `json:"userVolumes, omitempty"`
 
 	// Security Config
 	// Whether the container is privileged

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -473,6 +473,40 @@ func (c *Container) HostsAdd() []string {
 	return c.config.HostAdd
 }
 
+// UserVolumes returns user-added volume mounts in the container.
+// These are not added to the spec, but are used during image commit and to
+// trigger some OCI hooks.
+func (c *Container) UserVolumes() []string {
+	volumes := make([]string, 0, len(c.config.UserVolumes))
+	for _, vol := range c.config.UserVolumes {
+		volumes = append(volumes, vol)
+	}
+
+	return volumes
+}
+
+// Entrypoint is the container's entrypoint.
+// This is not added to the spec, but is instead used during image commit.
+func (c *Container) Entrypoint() []string {
+	entrypoint := make([]string, 0, len(c.config.Entrypoint))
+	for _, str := range c.config.Entrypoint {
+		entrypoint = append(entrypoint, str)
+	}
+
+	return entrypoint
+}
+
+// Command is the container's command
+// This is not added to the spec, but is instead used during image commit
+func (c *Container) Command() []string {
+	command := make([]string, 0, len(c.config.Command))
+	for _, str := range c.config.Command {
+		command = append(command, str)
+	}
+
+	return command
+}
+
 // Stdin returns whether STDIN on the container will be kept open
 func (c *Container) Stdin() bool {
 	return c.config.Stdin

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -174,28 +174,26 @@ type ContainerConfig struct {
 	// TODO consider breaking these subsections up into smaller structs
 
 	// Storage Config
-	// Information on the image used for the root filesystem
+
+	// Information on the image used for the root filesystem/
 	RootfsImageID   string `json:"rootfsImageID,omitempty"`
 	RootfsImageName string `json:"rootfsImageName,omitempty"`
-	// Whether to mount volumes specified in the image
+	// Whether to mount volumes specified in the image.
 	ImageVolumes bool `json:"imageVolumes"`
-	// Src path to be mounted on /dev/shm in container
+	// Src path to be mounted on /dev/shm in container.
 	ShmDir string `json:"ShmDir,omitempty"`
-	// Size of the container's SHM
+	// Size of the container's SHM.
 	ShmSize int64 `json:"shmSize"`
 	// Static directory for container content that will persist across
-	// reboot
+	// reboot.
 	StaticDir string `json:"staticDir"`
-	// Mounts list contains all additional mounts into the container rootfs
-	// These include the SHM mount
-	// These must be unmounted before the container's rootfs is unmounted
+	// Mounts list contains all additional mounts into the container rootfs.
+	// These include the SHM mount.
+	// These must be unmounted before the container's rootfs is unmounted.
 	Mounts []string `json:"mounts,omitempty"`
-	// UserVolumes indicates that the container has user-added volume mounts
-	// It is used to trigger OCI hooks that rely on the presence of user
-	// volumes
-	UserVolumes bool `json:"userVolumes, omitempty"`
 
 	// Security Config
+
 	// Whether the container is privileged
 	Privileged bool `json:"privileged"`
 	// SELinux process label for container
@@ -221,11 +219,12 @@ type ContainerConfig struct {
 	UTSNsCtr    string `json:"utsNsCtr,omitempty"`
 	CgroupNsCtr string `json:"cgroupNsCtr,omitempty"`
 
-	// IDs of dependency containers
-	// These containers must be started before this container is started
+	// IDs of dependency containers.
+	// These containers must be started before this container is started.
 	Dependencies []string
 
 	// Network Config
+
 	// CreateNetNS indicates that libpod should create and configure a new
 	// network namespace for the container
 	// This cannot be set if NetNsCtr is also set
@@ -247,7 +246,26 @@ type ContainerConfig struct {
 	// Will be appended to host's host file
 	HostAdd []string `json:"hostsAdd,omitempty"`
 
+	// Image Config
+
+	// UserVolumes contains user-added volume mounts in the container.
+	// These will not be added to the container's spec, as it is assumed
+	// they are already present in the spec given to Libpod. Instead, it is
+	// used when committing containers to generate the VOLUMES field of the
+	// image that is created, and for triggering some OCI hooks which do not
+	// fire unless user-added volume mounts are present.
+	UserVolumes []string `json:"userVolumes,omitempty"`
+	// Entrypoint is the container's entrypoint.
+	// It is not used in spec generation, but will be used when the
+	// container is committed to populate the entrypoint of the new image.
+	Entrypoint []string `json:"entrypoint,omitempty"`
+	// Command is the container's command.
+	// It is not used in spec generation, but will be used when the
+	// container is committed to populate the command of the new image.
+	Command []string `json:"command,omitempty"`
+
 	// Misc Options
+
 	// Whether to keep container STDIN open
 	Stdin bool `json:"stdin,omitempty"`
 	// Labels is a set of key-value pairs providing additional information

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -26,7 +26,7 @@ type ContainerCommitOptions struct {
 
 // Commit commits the changes between a container and its image, creating a new
 // image
-func (c *Container) Commit(ctx context.Context, destImage string, options ContainerCommitOptions, mounts, command, entryPoint []string) (*image.Image, error) {
+func (c *Container) Commit(ctx context.Context, destImage string, options ContainerCommitOptions) (*image.Image, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -74,14 +74,10 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	// add it to the resulting image.
 
 	// Entrypoint - always set this first or cmd will get wiped out
-	if len(entryPoint) > 0 {
-		importBuilder.SetEntrypoint(entryPoint)
-	}
+	importBuilder.SetEntrypoint(c.config.Entrypoint)
 
 	// Cmd
-	if len(command) > 0 {
-		importBuilder.SetCmd(command)
-	}
+	importBuilder.SetCmd(c.config.Command)
 
 	// Env
 	for _, e := range c.config.Spec.Process.Env {
@@ -100,7 +96,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	// User
 	importBuilder.SetUser(c.User())
 	// Volumes
-	for _, v := range mounts {
+	for _, v := range c.config.UserVolumes {
 		if v != "" {
 			importBuilder.AddVolume(v)
 		}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -198,6 +198,10 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	c.config.StaticDir = containerInfo.Dir
 	c.state.RunDir = containerInfo.RunDir
 
+	// Set the default Entrypoint and Command
+	c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
+	c.config.Command = containerInfo.Config.Config.Cmd
+
 	artifacts := filepath.Join(c.config.StaticDir, artifactsDir)
 	if err := os.MkdirAll(artifacts, 0755); err != nil {
 		return errors.Wrapf(err, "error creating artifacts directory %q", artifacts)
@@ -1144,7 +1148,7 @@ func (c *Container) setupOCIHooks(g *generate.Generator) error {
 	}
 	for _, hook := range ocihooks {
 		logrus.Debugf("SetupOCIHooks", hook)
-		if hook.HasBindMounts && c.config.UserVolumes {
+		if hook.HasBindMounts && len(c.config.UserVolumes) > 0 {
 			if err := addHook(hook); err != nil {
 				return err
 			}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1125,6 +1125,7 @@ func (c *Container) saveSpec(spec *spec.Spec) error {
 	return nil
 }
 
+// Add OCI hooks to a container's spec
 func (c *Container) setupOCIHooks(g *generate.Generator) error {
 	addedHooks := map[string]struct{}{}
 	ocihooks, err := hooks.SetupHooks(c.runtime.config.HooksDir)
@@ -1143,7 +1144,7 @@ func (c *Container) setupOCIHooks(g *generate.Generator) error {
 	}
 	for _, hook := range ocihooks {
 		logrus.Debugf("SetupOCIHooks", hook)
-		if hook.HasBindMounts && len(c.config.Spec.Mounts) > 0 {
+		if hook.HasBindMounts && c.config.UserVolumes {
 			if err := addHook(hook); err != nil {
 				return err
 			}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -741,42 +741,6 @@ func WithCgroupParent(parent string) CtrCreateOption {
 	}
 }
 
-// Pod Creation Options
-
-// WithPodName sets the name of the pod
-func WithPodName(name string) PodCreateOption {
-	return func(pod *Pod) error {
-		if pod.valid {
-			return ErrPodFinalized
-		}
-
-		// Check the name against a regex
-		if !nameRegex.MatchString(name) {
-			return errors.Wrapf(ErrInvalidArg, "name must match regex [a-zA-Z0-9_-]+")
-		}
-
-		pod.config.Name = name
-
-		return nil
-	}
-}
-
-// WithPodLabels sets the labels of a pod
-func WithPodLabels(labels map[string]string) PodCreateOption {
-	return func(pod *Pod) error {
-		if pod.valid {
-			return ErrPodFinalized
-		}
-
-		pod.config.Labels = make(map[string]string)
-		for key, value := range labels {
-			pod.config.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
 // WithDNSSearch sets the additional search domains of a container
 func WithDNSSearch(searchDomains []string) CtrCreateOption {
 	return func(ctr *Container) error {
@@ -847,6 +811,55 @@ func WithGroups(groups []string) CtrCreateOption {
 			return ErrCtrFinalized
 		}
 		ctr.config.Groups = groups
+		return nil
+	}
+}
+
+// WithUserVolumes informs libpod that the container has user-added volumes
+// It is used to for triggering hooks that check for the presence of volume
+// mounts
+func WithUserVolumes() CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+		ctr.config.UserVolumes = true
+		return nil
+	}
+}
+
+// Pod Creation Options
+
+// WithPodName sets the name of the pod
+func WithPodName(name string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+
+		// Check the name against a regex
+		if !nameRegex.MatchString(name) {
+			return errors.Wrapf(ErrInvalidArg, "name must match regex [a-zA-Z0-9_-]+")
+		}
+
+		pod.config.Name = name
+
+		return nil
+	}
+}
+
+// WithPodLabels sets the labels of a pod
+func WithPodLabels(labels map[string]string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+
+		pod.config.Labels = make(map[string]string)
+		for key, value := range labels {
+			pod.config.Labels[key] = value
+		}
+
 		return nil
 	}
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -18,7 +18,7 @@ var (
 
 // Runtime Creation Options
 
-// WithStorageConfig uses the given configuration to set up container storage
+// WithStorageConfig uses the given configuration to set up container storage.
 // If this is not specified, the system default configuration will be used
 // instead.
 func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
@@ -74,8 +74,8 @@ func WithSignaturePolicy(path string) RuntimeOption {
 	}
 }
 
-// WithStateType sets the backing state implementation for libpod
-// Please note that information is not portable between backing states
+// WithStateType sets the backing state implementation for libpod.
+// Please note that information is not portable between backing states.
 // As such, if this differs between two libpods running on the same system,
 // they will not share containers, and unspecified behavior may occur.
 func WithStateType(storeType RuntimeStateStore) RuntimeOption {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -20,7 +20,7 @@ var (
 
 // WithStorageConfig uses the given configuration to set up container storage
 // If this is not specified, the system default configuration will be used
-// instead
+// instead.
 func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -45,7 +45,7 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 	}
 }
 
-// WithDefaultTransport sets the default transport for retrieving images
+// WithDefaultTransport sets the default transport for retrieving images.
 func WithDefaultTransport(defaultTransport string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -61,7 +61,7 @@ func WithDefaultTransport(defaultTransport string) RuntimeOption {
 // WithSignaturePolicy specifies the path of a file which decides how trust is
 // managed for images we've pulled.
 // If this is not specified, the system default configuration will be used
-// instead
+// instead.
 func WithSignaturePolicy(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -77,7 +77,7 @@ func WithSignaturePolicy(path string) RuntimeOption {
 // WithStateType sets the backing state implementation for libpod
 // Please note that information is not portable between backing states
 // As such, if this differs between two libpods running on the same system,
-// they will not share containers, and unspecified behavior may occur
+// they will not share containers, and unspecified behavior may occur.
 func WithStateType(storeType RuntimeStateStore) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -94,7 +94,7 @@ func WithStateType(storeType RuntimeStateStore) RuntimeOption {
 	}
 }
 
-// WithOCIRuntime specifies an OCI runtime to use for running containers
+// WithOCIRuntime specifies an OCI runtime to use for running containers.
 func WithOCIRuntime(runtimePath string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -112,7 +112,7 @@ func WithOCIRuntime(runtimePath string) RuntimeOption {
 }
 
 // WithConmonPath specifies the path to the conmon binary which manages the
-// runtime
+// runtime.
 func WithConmonPath(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -129,7 +129,7 @@ func WithConmonPath(path string) RuntimeOption {
 	}
 }
 
-// WithConmonEnv specifies the environment variable list for the conmon process
+// WithConmonEnv specifies the environment variable list for the conmon process.
 func WithConmonEnv(environment []string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -144,8 +144,8 @@ func WithConmonEnv(environment []string) RuntimeOption {
 }
 
 // WithCgroupManager specifies the manager implementation name which is used to
-// handle cgroups for containers
-// Current valid values are "cgroupfs" and "systemd"
+// handle cgroups for containers.
+// Current valid values are "cgroupfs" and "systemd".
 func WithCgroupManager(manager string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -159,7 +159,7 @@ func WithCgroupManager(manager string) RuntimeOption {
 }
 
 // WithStaticDir sets the directory that static runtime files which persist
-// across reboots will be stored
+// across reboots will be stored.
 func WithStaticDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -172,9 +172,9 @@ func WithStaticDir(dir string) RuntimeOption {
 	}
 }
 
-// WithHooksDir sets the directory to look for OCI runtime hooks config
+// WithHooksDir sets the directory to look for OCI runtime hooks config.
 // Note we are not saving this in database, since this is really just for used
-// for testing
+// for testing.
 func WithHooksDir(hooksDir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -186,8 +186,10 @@ func WithHooksDir(hooksDir string) RuntimeOption {
 	}
 }
 
-// WithDefaultMountsFile sets the file to look at for default mounts (mainly secrets)
-// Note we are not saving this in the database as it is for testing purposes only
+// WithDefaultMountsFile sets the file to look at for default mounts (mainly
+// secrets).
+// Note we are not saving this in the database as it is for testing purposes
+// only.
 func WithDefaultMountsFile(mountsFile string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -203,8 +205,8 @@ func WithDefaultMountsFile(mountsFile string) RuntimeOption {
 }
 
 // WithTmpDir sets the directory that temporary runtime files which are not
-// expected to survive across reboots will be stored
-// This should be located on a tmpfs mount (/tmp or /var/run for example)
+// expected to survive across reboots will be stored.
+// This should be located on a tmpfs mount (/tmp or /var/run for example).
 func WithTmpDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -217,8 +219,8 @@ func WithTmpDir(dir string) RuntimeOption {
 	}
 }
 
-// WithMaxLogSize sets the maximum size of container logs
-// Positive sizes are limits in bytes, -1 is unlimited
+// WithMaxLogSize sets the maximum size of container logs.
+// Positive sizes are limits in bytes, -1 is unlimited.
 func WithMaxLogSize(limit int64) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -232,7 +234,7 @@ func WithMaxLogSize(limit int64) RuntimeOption {
 }
 
 // WithNoPivotRoot sets the runtime to use MS_MOVE instead of PIVOT_ROOT when
-// starting containers
+// starting containers.
 func WithNoPivotRoot(noPivot bool) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -245,7 +247,7 @@ func WithNoPivotRoot(noPivot bool) RuntimeOption {
 	}
 }
 
-// WithCNIConfigDir sets the CNI configuration directory
+// WithCNIConfigDir sets the CNI configuration directory.
 func WithCNIConfigDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -258,7 +260,7 @@ func WithCNIConfigDir(dir string) RuntimeOption {
 	}
 }
 
-// WithCNIPluginDir sets the CNI plugins directory
+// WithCNIPluginDir sets the CNI plugins directory.
 func WithCNIPluginDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
@@ -273,7 +275,7 @@ func WithCNIPluginDir(dir string) RuntimeOption {
 
 // Container Creation Options
 
-// WithShmDir sets the directory that should be mounted on /dev/shm
+// WithShmDir sets the directory that should be mounted on /dev/shm.
 func WithShmDir(dir string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -285,7 +287,7 @@ func WithShmDir(dir string) CtrCreateOption {
 	}
 }
 
-// WithShmSize sets the size of /dev/shm tmpfs mount
+// WithShmSize sets the size of /dev/shm tmpfs mount.
 func WithShmSize(size int64) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -297,7 +299,7 @@ func WithShmSize(size int64) CtrCreateOption {
 	}
 }
 
-// WithPrivileged sets the privileged flag in the container runtime
+// WithPrivileged sets the privileged flag in the container runtime.
 func WithPrivileged(privileged bool) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -309,7 +311,7 @@ func WithPrivileged(privileged bool) CtrCreateOption {
 	}
 }
 
-// WithSELinuxLabels sets the mount label for SELinux
+// WithSELinuxLabels sets the mount label for SELinux.
 func WithSELinuxLabels(processLabel, mountLabel string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -322,8 +324,8 @@ func WithSELinuxLabels(processLabel, mountLabel string) CtrCreateOption {
 	}
 }
 
-// WithUser sets the user identity field in configutation
-// Valid uses [user | user:group | uid | uid:gid | user:gid | uid:group ]
+// WithUser sets the user identity field in configutation.
+// Valid uses [user | user:group | uid | uid:gid | user:gid | uid:group ].
 func WithUser(user string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -335,10 +337,11 @@ func WithUser(user string) CtrCreateOption {
 	}
 }
 
-// WithRootFSFromImage sets up a fresh root filesystem using the given image
+// WithRootFSFromImage sets up a fresh root filesystem using the given image.
 // If useImageConfig is specified, image volumes, environment variables, and
-// other configuration from the image will be added to the config
-// TODO: Replace image name and ID with a libpod.Image struct when that is finished
+// other configuration from the image will be added to the config.
+// TODO: Replace image name and ID with a libpod.Image struct when that is
+// finished.
 func WithRootFSFromImage(imageID string, imageName string, useImageVolumes bool) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -357,7 +360,7 @@ func WithRootFSFromImage(imageID string, imageName string, useImageVolumes bool)
 	}
 }
 
-// WithStdin keeps stdin on the container open to allow interaction
+// WithStdin keeps stdin on the container open to allow interaction.
 func WithStdin() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -370,9 +373,9 @@ func WithStdin() CtrCreateOption {
 	}
 }
 
-// WithPod adds the container to a pod
+// WithPod adds the container to a pod.
 // Containers which join a pod can only join the namespaces of other containers
-// in the same pod
+// in the same pod.
 func (r *Runtime) WithPod(pod *Pod) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -389,7 +392,7 @@ func (r *Runtime) WithPod(pod *Pod) CtrCreateOption {
 	}
 }
 
-// WithLabels adds labels to the container
+// WithLabels adds labels to the container.
 func WithLabels(labels map[string]string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -405,7 +408,7 @@ func WithLabels(labels map[string]string) CtrCreateOption {
 	}
 }
 
-// WithName sets the container's name
+// WithName sets the container's name.
 func WithName(name string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -423,7 +426,7 @@ func WithName(name string) CtrCreateOption {
 	}
 }
 
-// WithStopSignal sets the signal that will be sent to stop the container
+// WithStopSignal sets the signal that will be sent to stop the container.
 func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -442,7 +445,8 @@ func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 	}
 }
 
-// WithStopTimeout sets the time to after initial stop signal is sent to container, before sending the kill signal
+// WithStopTimeout sets the time to after initial stop signal is sent to the
+// container, before sending the kill signal.
 func WithStopTimeout(timeout uint) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -456,9 +460,9 @@ func WithStopTimeout(timeout uint) CtrCreateOption {
 }
 
 // WithIPCNSFrom indicates the the container should join the IPC namespace of
-// the given container
+// the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithIPCNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -484,9 +488,9 @@ func WithIPCNSFrom(nsCtr *Container) CtrCreateOption {
 }
 
 // WithMountNSFrom indicates the the container should join the mount namespace
-// of the given container
+// of the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithMountNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -512,9 +516,9 @@ func WithMountNSFrom(nsCtr *Container) CtrCreateOption {
 }
 
 // WithNetNSFrom indicates the the container should join the network namespace
-// of the given container
+// of the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithNetNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -544,9 +548,9 @@ func WithNetNSFrom(nsCtr *Container) CtrCreateOption {
 }
 
 // WithPIDNSFrom indicates the the container should join the PID namespace of
-// the given container
+// the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithPIDNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -572,9 +576,9 @@ func WithPIDNSFrom(nsCtr *Container) CtrCreateOption {
 }
 
 // WithUserNSFrom indicates the the container should join the user namespace of
-// the given container
+// the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -600,9 +604,9 @@ func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 }
 
 // WithUTSNSFrom indicates the the container should join the UTS namespace of
-// the given container
+// the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithUTSNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -628,9 +632,9 @@ func WithUTSNSFrom(nsCtr *Container) CtrCreateOption {
 }
 
 // WithCgroupNSFrom indicates the the container should join the CGroup namespace
-// of the given container
+// of the given container.
 // If the container has joined a pod, it can only join the namespaces of
-// containers in the same pod
+// containers in the same pod.
 func WithCgroupNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -655,8 +659,8 @@ func WithCgroupNSFrom(nsCtr *Container) CtrCreateOption {
 	}
 }
 
-// WithDependencyCtrs sets dependency containers of the given container
-// Dependency containers must be running before this container is started
+// WithDependencyCtrs sets dependency containers of the given container.
+// Dependency containers must be running before this container is started.
 func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -688,9 +692,9 @@ func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 }
 
 // WithNetNS indicates that the container should be given a new network
-// namespace with a minimal configuration
-// An optional array of port mappings can be provided
-// Conflicts with WithNetNSFrom()
+// namespace with a minimal configuration.
+// An optional array of port mappings can be provided.
+// Conflicts with WithNetNSFrom().
 func WithNetNS(portMappings []ocicni.PortMapping) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -708,7 +712,7 @@ func WithNetNS(portMappings []ocicni.PortMapping) CtrCreateOption {
 	}
 }
 
-// WithLogPath sets the path to the log file
+// WithLogPath sets the path to the log file.
 func WithLogPath(path string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -724,7 +728,7 @@ func WithLogPath(path string) CtrCreateOption {
 	}
 }
 
-// WithCgroupParent sets the Cgroup Parent of the new container
+// WithCgroupParent sets the Cgroup Parent of the new container.
 func WithCgroupParent(parent string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -741,7 +745,7 @@ func WithCgroupParent(parent string) CtrCreateOption {
 	}
 }
 
-// WithDNSSearch sets the additional search domains of a container
+// WithDNSSearch sets the additional search domains of a container.
 func WithDNSSearch(searchDomains []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -752,7 +756,7 @@ func WithDNSSearch(searchDomains []string) CtrCreateOption {
 	}
 }
 
-// WithDNS sets additional name servers for the container
+// WithDNS sets additional name servers for the container.
 func WithDNS(dnsServers []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -771,7 +775,7 @@ func WithDNS(dnsServers []string) CtrCreateOption {
 	}
 }
 
-// WithDNSOption sets addition dns options for the container
+// WithDNSOption sets addition dns options for the container.
 func WithDNSOption(dnsOptions []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -782,7 +786,7 @@ func WithDNSOption(dnsOptions []string) CtrCreateOption {
 	}
 }
 
-// WithHosts sets additional host:IP for the hosts file
+// WithHosts sets additional host:IP for the hosts file.
 func WithHosts(hosts []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -793,7 +797,8 @@ func WithHosts(hosts []string) CtrCreateOption {
 	}
 }
 
-// WithConmonPidFile specifies the path to the file that receives the pid of conmon
+// WithConmonPidFile specifies the path to the file that receives the pid of
+// conmon.
 func WithConmonPidFile(path string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -804,7 +809,8 @@ func WithConmonPidFile(path string) CtrCreateOption {
 	}
 }
 
-// WithGroups sets additional groups for the container, which are defined by the user
+// WithGroups sets additional groups for the container, which are defined by
+// the user.
 func WithGroups(groups []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -815,9 +821,9 @@ func WithGroups(groups []string) CtrCreateOption {
 	}
 }
 
-// WithUserVolumes informs libpod that the container has user-added volumes
+// WithUserVolumes informs libpod that the container has user-added volumes.
 // It is used to for triggering hooks that check for the presence of volume
-// mounts
+// mounts.
 func WithUserVolumes() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
@@ -830,7 +836,7 @@ func WithUserVolumes() CtrCreateOption {
 
 // Pod Creation Options
 
-// WithPodName sets the name of the pod
+// WithPodName sets the name of the pod.
 func WithPodName(name string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
@@ -848,7 +854,7 @@ func WithPodName(name string) PodCreateOption {
 	}
 }
 
-// WithPodLabels sets the labels of a pod
+// WithPodLabels sets the labels of a pod.
 func WithPodLabels(labels map[string]string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {


### PR DESCRIPTION
This allows us to accurately trigger OCI hooks that trigger on the presence of volume mounts.
