### PR TITLE
Vendor in latest containers/image

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -10,7 +10,7 @@ github.com/containerd/cgroups 7a5fdd8330119dc70d850260db8f3594d89d6943
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.4.0
 github.com/containernetworking/plugins master
-github.com/containers/image e51d350816912bbd09a91f690cd394b6225c043d
+github.com/containers/image 88423e35d5f11939b0db4fb8f2939fc04adf2463
 github.com/containers/storage ce923c1ed9e51c8fe58e41a86abc05be7b824f62
 github.com/coreos/go-systemd v14
 github.com/cri-o/ocicni master
@@ -89,6 +89,6 @@ k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kuberne
 github.com/mrunalp/fileutils master
 github.com/varlink/go master https://github.com/varlink/go
 github.com/projectatomic/buildah master https://github.com/projectatomic/buildah
-vendor/github.com/Nvveen/Gotty master
+github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master


### PR DESCRIPTION
Fixes podman pull to pull a public image even if $XDG_RUNTIME_DIR
does not exist for authentication. Public images don't require credentials
to access.

Fixes https://github.com/projectatomic/libpod/issues/659

Signed-off-by: umohnani8 <umohnani@redhat.com>