### PR TITLE
change handling of ports when running containers

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -77,4 +77,18 @@ var _ = Describe("Podman rmi", func() {
 		Expect(results.ExitCode()).To(Equal(0))
 		Expect(results.OutputToString()).To(ContainSubstring(": 80,"))
 	})
+
+	It("podman run network expose duplicate host port results in error", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "-p", "80", ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "-l"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(Equal(0))
+
+		containerConfig := inspect.InspectContainerToJSON()
+		Expect(containerConfig[0].NetworkSettings.Ports[0].HostPort).ToNot(Equal("80"))
+	})
+
 })


### PR DESCRIPTION
the atomic team has reported two bugs when running containers.  In the case where
a user does:

* podman run -p 80 .... podman should assign a random port to the host and expose the container port 80 to it
* podman should detect if the user attempts to use the same host port more than once.

Signed-off-by: baude <bbaude@redhat.com>