### PR TITLE
Do not print unnecessary Buildah details during commit

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -2,7 +2,6 @@ package libpod
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	is "github.com/containers/image/storage"
@@ -143,6 +142,5 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	if err = importBuilder.Commit(ctx, imageRef, commitOptions); err != nil {
 		return nil, err
 	}
-	fmt.Println(importBuilder.Comment())
 	return c.runtime.imageRuntime.NewFromLocal(imageRef.DockerReference().String())
 }


### PR DESCRIPTION
Noticed this while investigating #705 

We should never print straight to stdout in libpod. We need to either accept a writer for reports, or not print at all. The latter seems easiest, and this comment doesn't seem particularly valuable.