### PR TITLE
varlink containers

### DIFF
--- a/cmd/podman/batchcontainer/container.go
+++ b/cmd/podman/batchcontainer/container.go
@@ -1,0 +1,159 @@
+package batchcontainer
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/libpod"
+	"github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PsOptions describes the struct being formed for ps
+type PsOptions struct {
+	All       bool
+	Filter    string
+	Format    string
+	Last      int
+	Latest    bool
+	NoTrunc   bool
+	Quiet     bool
+	Size      bool
+	Label     string
+	Namespace bool
+}
+
+// BatchContainerStruct is the return obkect from BatchContainer and contains
+// container related information
+type BatchContainerStruct struct {
+	ConConfig          *libpod.ContainerConfig
+	ConState           libpod.ContainerStatus
+	ExitCode           int32
+	Pid                int
+	RootFsSize, RwSize int64
+	StartedTime        time.Time
+}
+
+// Namespace describes output for ps namespace
+type Namespace struct {
+	PID    string `json:"pid,omitempty"`
+	Cgroup string `json:"cgroup,omitempty"`
+	IPC    string `json:"ipc,omitempty"`
+	MNT    string `json:"mnt,omitempty"`
+	NET    string `json:"net,omitempty"`
+	PIDNS  string `json:"pidns,omitempty"`
+	User   string `json:"user,omitempty"`
+	UTS    string `json:"uts,omitempty"`
+}
+
+// BatchContainer is used in ps to reduce performance hits by "batching"
+// locks.
+func BatchContainerOp(ctr *libpod.Container, opts PsOptions) (BatchContainerStruct, error) {
+	var (
+		conConfig          *libpod.ContainerConfig
+		conState           libpod.ContainerStatus
+		err                error
+		exitCode           int32
+		pid                int
+		rootFsSize, rwSize int64
+		startedTime        time.Time
+	)
+
+	batchErr := ctr.Batch(func(c *libpod.Container) error {
+		conConfig = c.Config()
+		conState, err = c.State()
+		if err != nil {
+			return errors.Wrapf(err, "unable to obtain container state")
+		}
+
+		exitCode, err = c.ExitCode()
+		if err != nil {
+			return errors.Wrapf(err, "unable to obtain container exit code")
+		}
+		startedTime, err = c.StartedTime()
+		if err != nil {
+			logrus.Errorf("error getting started time for %q: %v", c.ID(), err)
+		}
+
+		if !opts.Size && !opts.Namespace {
+			return nil
+		}
+
+		if opts.Namespace {
+			pid, err = c.PID()
+			if err != nil {
+				return errors.Wrapf(err, "unable to obtain container pid")
+			}
+		}
+		if opts.Size {
+			rootFsSize, err = c.RootFsSize()
+			if err != nil {
+				logrus.Errorf("error getting root fs size for %q: %v", c.ID(), err)
+			}
+
+			rwSize, err = c.RWSize()
+			if err != nil {
+				logrus.Errorf("error getting rw size for %q: %v", c.ID(), err)
+			}
+
+		}
+		return nil
+	})
+	if batchErr != nil {
+		return BatchContainerStruct{}, batchErr
+	}
+	return BatchContainerStruct{
+		ConConfig:   conConfig,
+		ConState:    conState,
+		ExitCode:    exitCode,
+		Pid:         pid,
+		RootFsSize:  rootFsSize,
+		RwSize:      rwSize,
+		StartedTime: startedTime,
+	}, nil
+}
+
+// GetNamespaces returns a populated namespace struct
+func GetNamespaces(pid int) *Namespace {
+	ctrPID := strconv.Itoa(pid)
+	cgroup, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "cgroup"))
+	ipc, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "ipc"))
+	mnt, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "mnt"))
+	net, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "net"))
+	pidns, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "pid"))
+	user, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "user"))
+	uts, _ := getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "uts"))
+
+	return &Namespace{
+		PID:    ctrPID,
+		Cgroup: cgroup,
+		IPC:    ipc,
+		MNT:    mnt,
+		NET:    net,
+		PIDNS:  pidns,
+		User:   user,
+		UTS:    uts,
+	}
+}
+
+func getNamespaceInfo(path string) (string, error) {
+	val, err := os.Readlink(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting info from %q", path)
+	}
+	return getStrFromSquareBrackets(val), nil
+}
+
+// getStrFromSquareBrackets gets the string inside [] from a string
+func getStrFromSquareBrackets(cmd string) string {
+	reg, err := regexp.Compile(".*\\[|\\].*")
+	if err != nil {
+		return ""
+	}
+	arr := strings.Split(reg.ReplaceAllLiteralString(cmd, ""), ",")
+	return strings.Join(arr, ",")
+}

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -64,7 +65,7 @@ func restartCmd(c *cli.Context) error {
 				ctrTimeout = timeout
 			}
 
-			lastError = restartCtr(ctrTimeout, lastCtr)
+			lastError = lastCtr.RestartWithTimeout(context.TODO(), ctrTimeout)
 		}
 	}
 
@@ -83,7 +84,7 @@ func restartCmd(c *cli.Context) error {
 			ctrTimeout = timeout
 		}
 
-		if err := restartCtr(ctrTimeout, ctr); err != nil {
+		if err := ctr.RestartWithTimeout(context.TODO(), ctrTimeout); err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}
@@ -92,25 +93,4 @@ func restartCmd(c *cli.Context) error {
 	}
 
 	return lastError
-}
-
-// Restart a single container
-func restartCtr(timeout uint, ctr *libpod.Container) error {
-	state, err := ctr.State()
-	if err != nil {
-		return err
-	}
-	if state == libpod.ContainerStateRunning {
-		if err := ctr.StopWithTimeout(timeout); err != nil {
-			return err
-		}
-	}
-
-	if err := ctr.Start(getContext()); err != nil {
-		return err
-	}
-
-	fmt.Printf("%s\n", ctr.ID())
-
-	return nil
 }

--- a/cmd/podman/varlink/io.projectatomic.podman.varlink
+++ b/cmd/podman/varlink/io.projectatomic.podman.varlink
@@ -53,32 +53,100 @@ type ImageSearch (
     star_count: int
 )
 
+# ListContainer is the returned struct for an individual container
+type ListContainerData (
+    id: string,
+    image: string,
+    imageid: string,
+    command: []string,
+    createdat: string,
+    runningfor: string,
+    status: string,
+    ports: []ContainerPortMappings,
+    rootfssize: int,
+    rwsize: int,
+    names: string,
+    labels: [string]string,
+    mounts: []ContainerMount,
+    containerrunning: bool,
+    namespaces: ContainerNameSpace
+)
+
+# ContainerStats is the return struct for the stats of a container
+type ContainerStats (
+    id: string,
+    name: string,
+    cpu: float,
+    cpu_nano: int,
+    system_nano: int,
+    mem_usage: int,
+    mem_limit: int,
+    mem_perc: float,
+    net_input: int,
+    net_output: int,
+    block_output: int,
+    block_input: int,
+    pids: int
+)
+
+# ContainerMount describes the struct for mounts in a container
+type ContainerMount (
+    destination: string,
+    type: string,
+    source: string,
+    options: []string
+)
+
+# ContainerPortMappings describes the struct for portmappings in an existing container
+type ContainerPortMappings (
+    host_port: string,
+    host_ip: string,
+    protocol: string,
+    container_port: string
+)
+
+# ContainerNamespace describes the namespace structure for an existing container
+type ContainerNameSpace (
+    user: string,
+    uts: string,
+    pidns: string,
+    pid: string,
+    cgroup: string,
+    net: string,
+    mnt: string,
+    ipc: string
+)
+
 # System
 method Ping() -> (ping: StringResponse)
 method GetVersion() -> (version: Version)
 
 # Containers
-method ListContainers() -> (notimplemented: NotImplemented)
+method ListContainers() -> (containers: []ListContainerData)
+method GetContainer(name: string) -> (container: ListContainerData)
 method CreateContainer() -> (notimplemented: NotImplemented)
-method InspectContainer() -> (notimplemented: NotImplemented)
-method ListContainerProcesses() -> (notimplemented: NotImplemented)
-method GetContainerLogs() -> (notimplemented: NotImplemented)
-method ListContainerChanges() -> (notimplemented: NotImplemented)
-method ExportContainer() -> (notimplemented: NotImplemented)
-method GetContainerStats() -> (notimplemented: NotImplemented)
+method InspectContainer(name: string) -> (container: string)
+# TODO: Should this be made into a streaming response as opposed to a one off?
+method ListContainerProcesses(name: string, opts: []string) -> (container: []string)
+# TODO: Should this be made into a streaming response as opposed to a one off?
+method GetContainerLogs(name: string) -> (container: []string)
+method ListContainerChanges(name: string) -> (container: [string]string)
+# TODO: This should be made into a streaming response
+method ExportContainer(name: string, path: string) -> (tarfile: string)
+method GetContainerStats(name: string) -> (container: ContainerStats)
 method ResizeContainerTty() -> (notimplemented: NotImplemented)
 method StartContainer() -> (notimplemented: NotImplemented)
-method StopContainer() -> (notimplemented: NotImplemented)
-method RestartContainer() -> (notimplemented: NotImplemented)
-method KillContainer() -> (notimplemented: NotImplemented)
+method StopContainer(name: string, timeout: int) -> (container: string)
+method RestartContainer(name: string, timeout: int) -> (container: string)
+method KillContainer(name: string, signal: int) -> (container: string)
 method UpdateContainer() -> (notimplemented: NotImplemented)
 method RenameContainer() -> (notimplemented: NotImplemented)
-method PauseContainer() -> (notimplemented: NotImplemented)
-method UnpauseContainer() -> (notimplemented: NotImplemented)
+method PauseContainer(name: string) -> (container: string)
+method UnpauseContainer(name: string) -> (container: string)
 method AttachToContainer() -> (notimplemented: NotImplemented)
-method WaitContainer() -> (notimplemented: NotImplemented)
-method RemoveContainer() -> (notimplemented: NotImplemented)
-method DeleteStoppedContainers() -> (notimplemented: NotImplemented)
+method WaitContainer(name: string) -> (exitcode: int)
+method RemoveContainer(name: string, force: bool) -> (container: string)
+method DeleteStoppedContainers() -> (containers: []string)
 
 # Images
 method ListImages() -> (images: []ImageInList)
@@ -99,6 +167,7 @@ method PullImage(name: string) -> (id: string)
 
 # Something failed
 error ActionFailed (reason: string)
-error ImageNotFound (imagename: string)
+error ImageNotFound (name: string)
+error ContainerNotFound (name: string)
 error ErrorOccurred (reason: string)
 error RuntimeError (reason: string)

--- a/cmd/podman/varlink/ioprojectatomicpodman.go
+++ b/cmd/podman/varlink/ioprojectatomicpodman.go
@@ -4,8 +4,43 @@ package ioprojectatomicpodman
 import "github.com/varlink/go/varlink"
 
 // Type declarations
+type Version struct {
+	Version    string `json:"version"`
+	Go_version string `json:"go_version"`
+	Git_commit string `json:"git_commit"`
+	Built      int64  `json:"built"`
+	Os_arch    string `json:"os_arch"`
+}
+
+type NotImplemented struct {
+	Comment string `json:"comment"`
+}
+
 type StringResponse struct {
 	Message string `json:"message"`
+}
+
+type ContainerStats struct {
+	Id           string  `json:"id"`
+	Name         string  `json:"name"`
+	Cpu          float64 `json:"cpu"`
+	Cpu_nano     int64   `json:"cpu_nano"`
+	System_nano  int64   `json:"system_nano"`
+	Mem_usage    int64   `json:"mem_usage"`
+	Mem_limit    int64   `json:"mem_limit"`
+	Mem_perc     float64 `json:"mem_perc"`
+	Net_input    int64   `json:"net_input"`
+	Net_output   int64   `json:"net_output"`
+	Block_output int64   `json:"block_output"`
+	Block_input  int64   `json:"block_input"`
+	Pids         int64   `json:"pids"`
+}
+
+type ContainerPortMappings struct {
+	Host_port      string `json:"host_port"`
+	Host_ip        string `json:"host_ip"`
+	Protocol       string `json:"protocol"`
+	Container_port string `json:"container_port"`
 }
 
 type ImageInList struct {
@@ -37,105 +72,127 @@ type ImageSearch struct {
 	Star_count   int64  `json:"star_count"`
 }
 
-type Version struct {
-	Version    string `json:"version"`
-	Go_version string `json:"go_version"`
-	Git_commit string `json:"git_commit"`
-	Built      int64  `json:"built"`
-	Os_arch    string `json:"os_arch"`
+type ListContainerData struct {
+	Id               string                  `json:"id"`
+	Image            string                  `json:"image"`
+	Imageid          string                  `json:"imageid"`
+	Command          []string                `json:"command"`
+	Createdat        string                  `json:"createdat"`
+	Runningfor       string                  `json:"runningfor"`
+	Status           string                  `json:"status"`
+	Ports            []ContainerPortMappings `json:"ports"`
+	Rootfssize       int64                   `json:"rootfssize"`
+	Rwsize           int64                   `json:"rwsize"`
+	Names            string                  `json:"names"`
+	Labels           map[string]string       `json:"labels"`
+	Mounts           []ContainerMount        `json:"mounts"`
+	Containerrunning bool                    `json:"containerrunning"`
+	Namespaces       ContainerNameSpace      `json:"namespaces"`
 }
 
-type NotImplemented struct {
-	Comment string `json:"comment"`
+type ContainerMount struct {
+	Destination string   `json:"destination"`
+	Type        string   `json:"type"`
+	Source      string   `json:"source"`
+	Options     []string `json:"options"`
+}
+
+type ContainerNameSpace struct {
+	User   string `json:"user"`
+	Uts    string `json:"uts"`
+	Pidns  string `json:"pidns"`
+	Pid    string `json:"pid"`
+	Cgroup string `json:"cgroup"`
+	Net    string `json:"net"`
+	Mnt    string `json:"mnt"`
+	Ipc    string `json:"ipc"`
 }
 
 // Client method calls and reply readers
-func GetContainerStats(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.GetContainerStats", nil, more__, oneway__)
+func HistoryImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.HistoryImage", in, more__, oneway__)
 }
 
-func ReadGetContainerStats_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadHistoryImage_(c__ *varlink.Connection, history_ *[]ImageHistory) (bool, error) {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		History []ImageHistory `json:"history"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
+	if history_ != nil {
+		*history_ = []ImageHistory(out.History)
 	}
 	return continues_, nil
 }
 
-func PauseContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.PauseContainer", nil, more__, oneway__)
+func TagImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, tagged_ string) error {
+	var in struct {
+		Name   string `json:"name"`
+		Tagged string `json:"tagged"`
+	}
+	in.Name = name_
+	in.Tagged = tagged_
+	return c__.Send("io.projectatomic.podman.TagImage", in, more__, oneway__)
 }
 
-func ReadPauseContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
+func ReadTagImage_(c__ *varlink.Connection) (bool, error) {
+	continues_, err := c__.Receive(nil)
 	if err != nil {
 		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
 	}
 	return continues_, nil
 }
 
-func WaitContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.WaitContainer", nil, more__, oneway__)
+func ExportContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, path_ string) error {
+	var in struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+	}
+	in.Name = name_
+	in.Path = path_
+	return c__.Send("io.projectatomic.podman.ExportContainer", in, more__, oneway__)
 }
 
-func ReadWaitContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadExportContainer_(c__ *varlink.Connection, tarfile_ *string) (bool, error) {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Tarfile string `json:"tarfile"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
+	if tarfile_ != nil {
+		*tarfile_ = out.Tarfile
 	}
 	return continues_, nil
 }
 
-func DeleteUnusedImages(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.DeleteUnusedImages", nil, more__, oneway__)
+func RestartContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, timeout_ int64) error {
+	var in struct {
+		Name    string `json:"name"`
+		Timeout int64  `json:"timeout"`
+	}
+	in.Name = name_
+	in.Timeout = timeout_
+	return c__.Send("io.projectatomic.podman.RestartContainer", in, more__, oneway__)
 }
 
-func ReadDeleteUnusedImages_(c__ *varlink.Connection, images_ *[]string) (bool, error) {
+func ReadRestartContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
 	var out struct {
-		Images []string `json:"images"`
+		Container string `json:"container"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if images_ != nil {
-		*images_ = []string(out.Images)
-	}
-	return continues_, nil
-}
-
-func RestartContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.RestartContainer", nil, more__, oneway__)
-}
-
-func ReadRestartContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
+	if container_ != nil {
+		*container_ = out.Container
 	}
 	return continues_, nil
 }
@@ -158,11 +215,77 @@ func ReadListImages_(c__ *varlink.Connection, images_ *[]ImageInList) (bool, err
 	return continues_, nil
 }
 
-func CreateImage(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.CreateImage", nil, more__, oneway__)
+func PullImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.PullImage", in, more__, oneway__)
 }
 
-func ReadCreateImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadPullImage_(c__ *varlink.Connection, id_ *string) (bool, error) {
+	var out struct {
+		Id string `json:"id"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if id_ != nil {
+		*id_ = out.Id
+	}
+	return continues_, nil
+}
+
+func PauseContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.PauseContainer", in, more__, oneway__)
+}
+
+func ReadPauseContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
+	var out struct {
+		Container string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = out.Container
+	}
+	return continues_, nil
+}
+
+func WaitContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.WaitContainer", in, more__, oneway__)
+}
+
+func ReadWaitContainer_(c__ *varlink.Connection, exitcode_ *int64) (bool, error) {
+	var out struct {
+		Exitcode int64 `json:"exitcode"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if exitcode_ != nil {
+		*exitcode_ = out.Exitcode
+	}
+	return continues_, nil
+}
+
+func StartContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.StartContainer", nil, more__, oneway__)
+}
+
+func ReadStartContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
@@ -172,6 +295,286 @@ func ReadCreateImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) 
 	}
 	if notimplemented_ != nil {
 		*notimplemented_ = out.Notimplemented
+	}
+	return continues_, nil
+}
+
+func AttachToContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.AttachToContainer", nil, more__, oneway__)
+}
+
+func ReadAttachToContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if notimplemented_ != nil {
+		*notimplemented_ = out.Notimplemented
+	}
+	return continues_, nil
+}
+
+func ListContainerProcesses(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, opts_ []string) error {
+	var in struct {
+		Name string   `json:"name"`
+		Opts []string `json:"opts"`
+	}
+	in.Name = name_
+	in.Opts = []string(opts_)
+	return c__.Send("io.projectatomic.podman.ListContainerProcesses", in, more__, oneway__)
+}
+
+func ReadListContainerProcesses_(c__ *varlink.Connection, container_ *[]string) (bool, error) {
+	var out struct {
+		Container []string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = []string(out.Container)
+	}
+	return continues_, nil
+}
+
+func ListContainerChanges(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.ListContainerChanges", in, more__, oneway__)
+}
+
+func ReadListContainerChanges_(c__ *varlink.Connection, container_ *map[string]string) (bool, error) {
+	var out struct {
+		Container map[string]string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = map[string]string(out.Container)
+	}
+	return continues_, nil
+}
+
+func RemoveImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, force_ bool) error {
+	var in struct {
+		Name  string `json:"name"`
+		Force bool   `json:"force"`
+	}
+	in.Name = name_
+	in.Force = force_
+	return c__.Send("io.projectatomic.podman.RemoveImage", in, more__, oneway__)
+}
+
+func ReadRemoveImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
+	var out struct {
+		Image string `json:"image"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if image_ != nil {
+		*image_ = out.Image
+	}
+	return continues_, nil
+}
+
+func ImportImage(c__ *varlink.Connection, more__ bool, oneway__ bool, source_ string, reference_ string, message_ string, changes_ []string) error {
+	var in struct {
+		Source    string   `json:"source"`
+		Reference string   `json:"reference"`
+		Message   string   `json:"message"`
+		Changes   []string `json:"changes"`
+	}
+	in.Source = source_
+	in.Reference = reference_
+	in.Message = message_
+	in.Changes = []string(changes_)
+	return c__.Send("io.projectatomic.podman.ImportImage", in, more__, oneway__)
+}
+
+func ReadImportImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
+	var out struct {
+		Image string `json:"image"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if image_ != nil {
+		*image_ = out.Image
+	}
+	return continues_, nil
+}
+
+func GetContainerLogs(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.GetContainerLogs", in, more__, oneway__)
+}
+
+func ReadGetContainerLogs_(c__ *varlink.Connection, container_ *[]string) (bool, error) {
+	var out struct {
+		Container []string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = []string(out.Container)
+	}
+	return continues_, nil
+}
+
+func BuildImage(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.BuildImage", nil, more__, oneway__)
+}
+
+func ReadBuildImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if notimplemented_ != nil {
+		*notimplemented_ = out.Notimplemented
+	}
+	return continues_, nil
+}
+
+func ResizeContainerTty(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.ResizeContainerTty", nil, more__, oneway__)
+}
+
+func ReadResizeContainerTty_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if notimplemented_ != nil {
+		*notimplemented_ = out.Notimplemented
+	}
+	return continues_, nil
+}
+
+func KillContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, signal_ int64) error {
+	var in struct {
+		Name   string `json:"name"`
+		Signal int64  `json:"signal"`
+	}
+	in.Name = name_
+	in.Signal = signal_
+	return c__.Send("io.projectatomic.podman.KillContainer", in, more__, oneway__)
+}
+
+func ReadKillContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
+	var out struct {
+		Container string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = out.Container
+	}
+	return continues_, nil
+}
+
+func SearchImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, limit_ int64) error {
+	var in struct {
+		Name  string `json:"name"`
+		Limit int64  `json:"limit"`
+	}
+	in.Name = name_
+	in.Limit = limit_
+	return c__.Send("io.projectatomic.podman.SearchImage", in, more__, oneway__)
+}
+
+func ReadSearchImage_(c__ *varlink.Connection, images_ *[]ImageSearch) (bool, error) {
+	var out struct {
+		Images []ImageSearch `json:"images"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if images_ != nil {
+		*images_ = []ImageSearch(out.Images)
+	}
+	return continues_, nil
+}
+
+func DeleteUnusedImages(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.DeleteUnusedImages", nil, more__, oneway__)
+}
+
+func ReadDeleteUnusedImages_(c__ *varlink.Connection, images_ *[]string) (bool, error) {
+	var out struct {
+		Images []string `json:"images"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if images_ != nil {
+		*images_ = []string(out.Images)
+	}
+	return continues_, nil
+}
+
+func Ping(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.Ping", nil, more__, oneway__)
+}
+
+func ReadPing_(c__ *varlink.Connection, ping_ *StringResponse) (bool, error) {
+	var out struct {
+		Ping StringResponse `json:"ping"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if ping_ != nil {
+		*ping_ = out.Ping
+	}
+	return continues_, nil
+}
+
+func GetContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.GetContainer", in, more__, oneway__)
+}
+
+func ReadGetContainer_(c__ *varlink.Connection, container_ *ListContainerData) (bool, error) {
+	var out struct {
+		Container ListContainerData `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = out.Container
 	}
 	return continues_, nil
 }
@@ -198,11 +601,11 @@ func ReadInspectImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
 	return continues_, nil
 }
 
-func InspectContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.InspectContainer", nil, more__, oneway__)
+func RenameContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.RenameContainer", nil, more__, oneway__)
 }
 
-func ReadInspectContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadRenameContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
@@ -216,11 +619,11 @@ func ReadInspectContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemen
 	return continues_, nil
 }
 
-func ListContainerChanges(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ListContainerChanges", nil, more__, oneway__)
+func CreateImage(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.CreateImage", nil, more__, oneway__)
 }
 
-func ReadListContainerChanges_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadCreateImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
@@ -234,74 +637,44 @@ func ReadListContainerChanges_(c__ *varlink.Connection, notimplemented_ *NotImpl
 	return continues_, nil
 }
 
-func StopContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.StopContainer", nil, more__, oneway__)
+func RemoveContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, force_ bool) error {
+	var in struct {
+		Name  string `json:"name"`
+		Force bool   `json:"force"`
+	}
+	in.Name = name_
+	in.Force = force_
+	return c__.Send("io.projectatomic.podman.RemoveContainer", in, more__, oneway__)
 }
 
-func ReadStopContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadRemoveContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Container string `json:"container"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
+	if container_ != nil {
+		*container_ = out.Container
 	}
 	return continues_, nil
 }
 
-func KillContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.KillContainer", nil, more__, oneway__)
+func DeleteStoppedContainers(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.DeleteStoppedContainers", nil, more__, oneway__)
 }
 
-func ReadKillContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadDeleteStoppedContainers_(c__ *varlink.Connection, containers_ *[]string) (bool, error) {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Containers []string `json:"containers"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func UnpauseContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.UnpauseContainer", nil, more__, oneway__)
-}
-
-func ReadUnpauseContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func BuildImage(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.BuildImage", nil, more__, oneway__)
-}
-
-func ReadBuildImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
+	if containers_ != nil {
+		*containers_ = []string(out.Containers)
 	}
 	return continues_, nil
 }
@@ -346,30 +719,146 @@ func ReadExportImage_(c__ *varlink.Connection) (bool, error) {
 	return continues_, nil
 }
 
-func ImportImage(c__ *varlink.Connection, more__ bool, oneway__ bool, source_ string, reference_ string, message_ string, changes_ []string) error {
+func GetContainerStats(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
 	var in struct {
-		Source    string   `json:"source"`
-		Reference string   `json:"reference"`
-		Message   string   `json:"message"`
-		Changes   []string `json:"changes"`
+		Name string `json:"name"`
 	}
-	in.Source = source_
-	in.Reference = reference_
-	in.Message = message_
-	in.Changes = []string(changes_)
-	return c__.Send("io.projectatomic.podman.ImportImage", in, more__, oneway__)
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.GetContainerStats", in, more__, oneway__)
 }
 
-func ReadImportImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
+func ReadGetContainerStats_(c__ *varlink.Connection, container_ *ContainerStats) (bool, error) {
 	var out struct {
-		Image string `json:"image"`
+		Container ContainerStats `json:"container"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if image_ != nil {
-		*image_ = out.Image
+	if container_ != nil {
+		*container_ = out.Container
+	}
+	return continues_, nil
+}
+
+func UpdateContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.UpdateContainer", nil, more__, oneway__)
+}
+
+func ReadUpdateContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if notimplemented_ != nil {
+		*notimplemented_ = out.Notimplemented
+	}
+	return continues_, nil
+}
+
+func CreateContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.CreateContainer", nil, more__, oneway__)
+}
+
+func ReadCreateContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if notimplemented_ != nil {
+		*notimplemented_ = out.Notimplemented
+	}
+	return continues_, nil
+}
+
+func InspectContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.InspectContainer", in, more__, oneway__)
+}
+
+func ReadInspectContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
+	var out struct {
+		Container string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = out.Container
+	}
+	return continues_, nil
+}
+
+func StopContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, timeout_ int64) error {
+	var in struct {
+		Name    string `json:"name"`
+		Timeout int64  `json:"timeout"`
+	}
+	in.Name = name_
+	in.Timeout = timeout_
+	return c__.Send("io.projectatomic.podman.StopContainer", in, more__, oneway__)
+}
+
+func ReadStopContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
+	var out struct {
+		Container string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = out.Container
+	}
+	return continues_, nil
+}
+
+func UnpauseContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_
+	return c__.Send("io.projectatomic.podman.UnpauseContainer", in, more__, oneway__)
+}
+
+func ReadUnpauseContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
+	var out struct {
+		Container string `json:"container"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if container_ != nil {
+		*container_ = out.Container
+	}
+	return continues_, nil
+}
+
+func CreateFromContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
+	return c__.Send("io.projectatomic.podman.CreateFromContainer", nil, more__, oneway__)
+}
+
+func ReadCreateFromContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	continues_, err := c__.Receive(&out)
+	if err != nil {
+		return false, err
+	}
+	if notimplemented_ != nil {
+		*notimplemented_ = out.Notimplemented
 	}
 	return continues_, nil
 }
@@ -396,423 +885,80 @@ func ListContainers(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
 	return c__.Send("io.projectatomic.podman.ListContainers", nil, more__, oneway__)
 }
 
-func ReadListContainers_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
+func ReadListContainers_(c__ *varlink.Connection, containers_ *[]ListContainerData) (bool, error) {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Containers []ListContainerData `json:"containers"`
 	}
 	continues_, err := c__.Receive(&out)
 	if err != nil {
 		return false, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func GetContainerLogs(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.GetContainerLogs", nil, more__, oneway__)
-}
-
-func ReadGetContainerLogs_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func UpdateContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.UpdateContainer", nil, more__, oneway__)
-}
-
-func ReadUpdateContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func HistoryImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.HistoryImage", in, more__, oneway__)
-}
-
-func ReadHistoryImage_(c__ *varlink.Connection, history_ *[]ImageHistory) (bool, error) {
-	var out struct {
-		History []ImageHistory `json:"history"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if history_ != nil {
-		*history_ = []ImageHistory(out.History)
-	}
-	return continues_, nil
-}
-
-func CreateFromContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.CreateFromContainer", nil, more__, oneway__)
-}
-
-func ReadCreateFromContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func AttachToContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.AttachToContainer", nil, more__, oneway__)
-}
-
-func ReadAttachToContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func TagImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, tagged_ string) error {
-	var in struct {
-		Name   string `json:"name"`
-		Tagged string `json:"tagged"`
-	}
-	in.Name = name_
-	in.Tagged = tagged_
-	return c__.Send("io.projectatomic.podman.TagImage", in, more__, oneway__)
-}
-
-func ReadTagImage_(c__ *varlink.Connection) (bool, error) {
-	continues_, err := c__.Receive(nil)
-	if err != nil {
-		return false, err
-	}
-	return continues_, nil
-}
-
-func Ping(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.Ping", nil, more__, oneway__)
-}
-
-func ReadPing_(c__ *varlink.Connection, ping_ *StringResponse) (bool, error) {
-	var out struct {
-		Ping StringResponse `json:"ping"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if ping_ != nil {
-		*ping_ = out.Ping
-	}
-	return continues_, nil
-}
-
-func CreateContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.CreateContainer", nil, more__, oneway__)
-}
-
-func ReadCreateContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func ExportContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ExportContainer", nil, more__, oneway__)
-}
-
-func ReadExportContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func StartContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.StartContainer", nil, more__, oneway__)
-}
-
-func ReadStartContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func RenameContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.RenameContainer", nil, more__, oneway__)
-}
-
-func ReadRenameContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func DeleteStoppedContainers(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.DeleteStoppedContainers", nil, more__, oneway__)
-}
-
-func ReadDeleteStoppedContainers_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func ListContainerProcesses(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ListContainerProcesses", nil, more__, oneway__)
-}
-
-func ReadListContainerProcesses_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func ResizeContainerTty(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ResizeContainerTty", nil, more__, oneway__)
-}
-
-func ReadResizeContainerTty_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func RemoveContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.RemoveContainer", nil, more__, oneway__)
-}
-
-func ReadRemoveContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func RemoveImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, force_ bool) error {
-	var in struct {
-		Name  string `json:"name"`
-		Force bool   `json:"force"`
-	}
-	in.Name = name_
-	in.Force = force_
-	return c__.Send("io.projectatomic.podman.RemoveImage", in, more__, oneway__)
-}
-
-func ReadRemoveImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
-	var out struct {
-		Image string `json:"image"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if image_ != nil {
-		*image_ = out.Image
-	}
-	return continues_, nil
-}
-
-func SearchImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, limit_ int64) error {
-	var in struct {
-		Name  string `json:"name"`
-		Limit int64  `json:"limit"`
-	}
-	in.Name = name_
-	in.Limit = limit_
-	return c__.Send("io.projectatomic.podman.SearchImage", in, more__, oneway__)
-}
-
-func ReadSearchImage_(c__ *varlink.Connection, images_ *[]ImageSearch) (bool, error) {
-	var out struct {
-		Images []ImageSearch `json:"images"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if images_ != nil {
-		*images_ = []ImageSearch(out.Images)
-	}
-	return continues_, nil
-}
-
-func PullImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.PullImage", in, more__, oneway__)
-}
-
-func ReadPullImage_(c__ *varlink.Connection, id_ *string) (bool, error) {
-	var out struct {
-		Id string `json:"id"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if id_ != nil {
-		*id_ = out.Id
+	if containers_ != nil {
+		*containers_ = []ListContainerData(out.Containers)
 	}
 	return continues_, nil
 }
 
 // Service interface with all methods
 type ioprojectatomicpodmanInterface interface {
-	AttachToContainer(c__ VarlinkCall) error
-	TagImage(c__ VarlinkCall, name_ string, tagged_ string) error
-	DeleteStoppedContainers(c__ VarlinkCall) error
-	Ping(c__ VarlinkCall) error
-	CreateContainer(c__ VarlinkCall) error
-	ExportContainer(c__ VarlinkCall) error
-	StartContainer(c__ VarlinkCall) error
-	RenameContainer(c__ VarlinkCall) error
-	PullImage(c__ VarlinkCall, name_ string) error
-	ListContainerProcesses(c__ VarlinkCall) error
-	ResizeContainerTty(c__ VarlinkCall) error
-	RemoveContainer(c__ VarlinkCall) error
-	RemoveImage(c__ VarlinkCall, name_ string, force_ bool) error
-	SearchImage(c__ VarlinkCall, name_ string, limit_ int64) error
-	GetContainerStats(c__ VarlinkCall) error
-	PauseContainer(c__ VarlinkCall) error
-	WaitContainer(c__ VarlinkCall) error
-	DeleteUnusedImages(c__ VarlinkCall) error
-	RestartContainer(c__ VarlinkCall) error
+	PauseContainer(c__ VarlinkCall, name_ string) error
+	WaitContainer(c__ VarlinkCall, name_ string) error
 	ListImages(c__ VarlinkCall) error
+	PullImage(c__ VarlinkCall, name_ string) error
+	ListContainerProcesses(c__ VarlinkCall, name_ string, opts_ []string) error
+	ListContainerChanges(c__ VarlinkCall, name_ string) error
+	StartContainer(c__ VarlinkCall) error
+	AttachToContainer(c__ VarlinkCall) error
+	GetContainerLogs(c__ VarlinkCall, name_ string) error
 	BuildImage(c__ VarlinkCall) error
+	RemoveImage(c__ VarlinkCall, name_ string, force_ bool) error
+	ImportImage(c__ VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error
+	SearchImage(c__ VarlinkCall, name_ string, limit_ int64) error
+	DeleteUnusedImages(c__ VarlinkCall) error
+	Ping(c__ VarlinkCall) error
+	GetContainer(c__ VarlinkCall, name_ string) error
+	ResizeContainerTty(c__ VarlinkCall) error
+	KillContainer(c__ VarlinkCall, name_ string, signal_ int64) error
+	RenameContainer(c__ VarlinkCall) error
 	CreateImage(c__ VarlinkCall) error
 	InspectImage(c__ VarlinkCall, name_ string) error
-	InspectContainer(c__ VarlinkCall) error
-	ListContainerChanges(c__ VarlinkCall) error
-	StopContainer(c__ VarlinkCall) error
-	KillContainer(c__ VarlinkCall) error
-	UnpauseContainer(c__ VarlinkCall) error
 	PushImage(c__ VarlinkCall, name_ string, tag_ string, tlsverify_ bool) error
 	ExportImage(c__ VarlinkCall, name_ string, destination_ string, compress_ bool) error
+	GetContainerStats(c__ VarlinkCall, name_ string) error
+	UpdateContainer(c__ VarlinkCall) error
+	RemoveContainer(c__ VarlinkCall, name_ string, force_ bool) error
+	DeleteStoppedContainers(c__ VarlinkCall) error
+	StopContainer(c__ VarlinkCall, name_ string, timeout_ int64) error
+	UnpauseContainer(c__ VarlinkCall, name_ string) error
 	CreateFromContainer(c__ VarlinkCall) error
-	ImportImage(c__ VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error
 	GetVersion(c__ VarlinkCall) error
 	ListContainers(c__ VarlinkCall) error
-	GetContainerLogs(c__ VarlinkCall) error
-	UpdateContainer(c__ VarlinkCall) error
+	CreateContainer(c__ VarlinkCall) error
+	InspectContainer(c__ VarlinkCall, name_ string) error
+	ExportContainer(c__ VarlinkCall, name_ string, path_ string) error
+	RestartContainer(c__ VarlinkCall, name_ string, timeout_ int64) error
 	HistoryImage(c__ VarlinkCall, name_ string) error
+	TagImage(c__ VarlinkCall, name_ string, tagged_ string) error
 }
 
 // Service object with all methods
 type VarlinkCall struct{ varlink.Call }
 
 // Reply methods for all varlink errors
-func (c__ *VarlinkCall) ReplyActionFailed(reason_ string) error {
+func (c__ *VarlinkCall) ReplyImageNotFound(name_ string) error {
 	var out struct {
-		Reason string `json:"reason"`
+		Name string `json:"name"`
 	}
-	out.Reason = reason_
-	return c__.ReplyError("io.projectatomic.podman.ActionFailed", &out)
+	out.Name = name_
+	return c__.ReplyError("io.projectatomic.podman.ImageNotFound", &out)
 }
 
-func (c__ *VarlinkCall) ReplyImageNotFound(imagename_ string) error {
+func (c__ *VarlinkCall) ReplyContainerNotFound(name_ string) error {
 	var out struct {
-		Imagename string `json:"imagename"`
+		Name string `json:"name"`
 	}
-	out.Imagename = imagename_
-	return c__.ReplyError("io.projectatomic.podman.ImageNotFound", &out)
+	out.Name = name_
+	return c__.ReplyError("io.projectatomic.podman.ContainerNotFound", &out)
 }
 
 func (c__ *VarlinkCall) ReplyErrorOccurred(reason_ string) error {
@@ -831,80 +977,20 @@ func (c__ *VarlinkCall) ReplyRuntimeError(reason_ string) error {
 	return c__.ReplyError("io.projectatomic.podman.RuntimeError", &out)
 }
 
+func (c__ *VarlinkCall) ReplyActionFailed(reason_ string) error {
+	var out struct {
+		Reason string `json:"reason"`
+	}
+	out.Reason = reason_
+	return c__.ReplyError("io.projectatomic.podman.ActionFailed", &out)
+}
+
 // Reply methods for all varlink methods
-func (c__ *VarlinkCall) ReplyAttachToContainer(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyKillContainer(container_ string) error {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Container string `json:"container"`
 	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyTagImage() error {
-	return c__.Reply(nil)
-}
-
-func (c__ *VarlinkCall) ReplyExportContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyStartContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRenameContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyDeleteStoppedContainers(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyPing(ping_ StringResponse) error {
-	var out struct {
-		Ping StringResponse `json:"ping"`
-	}
-	out.Ping = ping_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyCreateContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRemoveContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRemoveImage(image_ string) error {
-	var out struct {
-		Image string `json:"image"`
-	}
-	out.Image = image_
+	out.Container = container_
 	return c__.Reply(&out)
 }
 
@@ -916,19 +1002,27 @@ func (c__ *VarlinkCall) ReplySearchImage(images_ []ImageSearch) error {
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyPullImage(id_ string) error {
+func (c__ *VarlinkCall) ReplyDeleteUnusedImages(images_ []string) error {
 	var out struct {
-		Id string `json:"id"`
+		Images []string `json:"images"`
 	}
-	out.Id = id_
+	out.Images = []string(images_)
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyListContainerProcesses(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyPing(ping_ StringResponse) error {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Ping StringResponse `json:"ping"`
 	}
-	out.Notimplemented = notimplemented_
+	out.Ping = ping_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyGetContainer(container_ ListContainerData) error {
+	var out struct {
+		Container ListContainerData `json:"container"`
+	}
+	out.Container = container_
 	return c__.Reply(&out)
 }
 
@@ -940,79 +1034,7 @@ func (c__ *VarlinkCall) ReplyResizeContainerTty(notimplemented_ NotImplemented) 
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyWaitContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyDeleteUnusedImages(images_ []string) error {
-	var out struct {
-		Images []string `json:"images"`
-	}
-	out.Images = []string(images_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyGetContainerStats(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyPauseContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRestartContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyListImages(images_ []ImageInList) error {
-	var out struct {
-		Images []ImageInList `json:"images"`
-	}
-	out.Images = []ImageInList(images_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyStopContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyKillContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyUnpauseContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyBuildImage(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyRenameContainer(notimplemented_ NotImplemented) error {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
@@ -1036,19 +1058,11 @@ func (c__ *VarlinkCall) ReplyInspectImage(image_ string) error {
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyInspectContainer(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyDeleteStoppedContainers(containers_ []string) error {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Containers []string `json:"containers"`
 	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyListContainerChanges(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
+	out.Containers = []string(containers_)
 	return c__.Reply(&out)
 }
 
@@ -1060,11 +1074,11 @@ func (c__ *VarlinkCall) ReplyExportImage() error {
 	return c__.Reply(nil)
 }
 
-func (c__ *VarlinkCall) ReplyGetContainerLogs(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyGetContainerStats(container_ ContainerStats) error {
 	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
+		Container ContainerStats `json:"container"`
 	}
-	out.Notimplemented = notimplemented_
+	out.Container = container_
 	return c__.Reply(&out)
 }
 
@@ -1076,6 +1090,90 @@ func (c__ *VarlinkCall) ReplyUpdateContainer(notimplemented_ NotImplemented) err
 	return c__.Reply(&out)
 }
 
+func (c__ *VarlinkCall) ReplyRemoveContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyInspectContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyStopContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyUnpauseContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyCreateFromContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyGetVersion(version_ Version) error {
+	var out struct {
+		Version Version `json:"version"`
+	}
+	out.Version = version_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyListContainers(containers_ []ListContainerData) error {
+	var out struct {
+		Containers []ListContainerData `json:"containers"`
+	}
+	out.Containers = []ListContainerData(containers_)
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyCreateContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyTagImage() error {
+	return c__.Reply(nil)
+}
+
+func (c__ *VarlinkCall) ReplyExportContainer(tarfile_ string) error {
+	var out struct {
+		Tarfile string `json:"tarfile"`
+	}
+	out.Tarfile = tarfile_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyRestartContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c__.Reply(&out)
+}
+
 func (c__ *VarlinkCall) ReplyHistoryImage(history_ []ImageHistory) error {
 	var out struct {
 		History []ImageHistory `json:"history"`
@@ -1084,7 +1182,63 @@ func (c__ *VarlinkCall) ReplyHistoryImage(history_ []ImageHistory) error {
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyCreateFromContainer(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyPullImage(id_ string) error {
+	var out struct {
+		Id string `json:"id"`
+	}
+	out.Id = id_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyPauseContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyWaitContainer(exitcode_ int64) error {
+	var out struct {
+		Exitcode int64 `json:"exitcode"`
+	}
+	out.Exitcode = exitcode_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyListImages(images_ []ImageInList) error {
+	var out struct {
+		Images []ImageInList `json:"images"`
+	}
+	out.Images = []ImageInList(images_)
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyAttachToContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyListContainerProcesses(container_ []string) error {
+	var out struct {
+		Container []string `json:"container"`
+	}
+	out.Container = []string(container_)
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyListContainerChanges(container_ map[string]string) error {
+	var out struct {
+		Container map[string]string `json:"container"`
+	}
+	out.Container = map[string]string(container_)
+	return c__.Reply(&out)
+}
+
+func (c__ *VarlinkCall) ReplyStartContainer(notimplemented_ NotImplemented) error {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
@@ -1100,15 +1254,15 @@ func (c__ *VarlinkCall) ReplyImportImage(image_ string) error {
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyGetVersion(version_ Version) error {
+func (c__ *VarlinkCall) ReplyGetContainerLogs(container_ []string) error {
 	var out struct {
-		Version Version `json:"version"`
+		Container []string `json:"container"`
 	}
-	out.Version = version_
+	out.Container = []string(container_)
 	return c__.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyListContainers(notimplemented_ NotImplemented) error {
+func (c__ *VarlinkCall) ReplyBuildImage(notimplemented_ NotImplemented) error {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
@@ -1116,85 +1270,89 @@ func (c__ *VarlinkCall) ReplyListContainers(notimplemented_ NotImplemented) erro
 	return c__.Reply(&out)
 }
 
+func (c__ *VarlinkCall) ReplyRemoveImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c__.Reply(&out)
+}
+
 // Dummy methods for all varlink methods
-func (s__ *VarlinkInterface) RenameContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("RenameContainer")
-}
-
-func (s__ *VarlinkInterface) DeleteStoppedContainers(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("DeleteStoppedContainers")
-}
-
-func (s__ *VarlinkInterface) Ping(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("Ping")
-}
-
-func (s__ *VarlinkInterface) CreateContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("CreateContainer")
-}
-
-func (s__ *VarlinkInterface) ExportContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ExportContainer")
-}
-
-func (s__ *VarlinkInterface) StartContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("StartContainer")
-}
-
-func (s__ *VarlinkInterface) SearchImage(c__ VarlinkCall, name_ string, limit_ int64) error {
-	return c__.ReplyMethodNotImplemented("SearchImage")
-}
-
-func (s__ *VarlinkInterface) PullImage(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("PullImage")
-}
-
-func (s__ *VarlinkInterface) ListContainerProcesses(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ListContainerProcesses")
-}
-
-func (s__ *VarlinkInterface) ResizeContainerTty(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ResizeContainerTty")
-}
-
-func (s__ *VarlinkInterface) RemoveContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("RemoveContainer")
-}
-
-func (s__ *VarlinkInterface) RemoveImage(c__ VarlinkCall, name_ string, force_ bool) error {
-	return c__.ReplyMethodNotImplemented("RemoveImage")
-}
-
-func (s__ *VarlinkInterface) GetContainerStats(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("GetContainerStats")
-}
-
-func (s__ *VarlinkInterface) PauseContainer(c__ VarlinkCall) error {
+func (s__ *VarlinkInterface) PauseContainer(c__ VarlinkCall, name_ string) error {
 	return c__.ReplyMethodNotImplemented("PauseContainer")
 }
 
-func (s__ *VarlinkInterface) WaitContainer(c__ VarlinkCall) error {
+func (s__ *VarlinkInterface) WaitContainer(c__ VarlinkCall, name_ string) error {
 	return c__.ReplyMethodNotImplemented("WaitContainer")
-}
-
-func (s__ *VarlinkInterface) DeleteUnusedImages(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("DeleteUnusedImages")
-}
-
-func (s__ *VarlinkInterface) RestartContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("RestartContainer")
 }
 
 func (s__ *VarlinkInterface) ListImages(c__ VarlinkCall) error {
 	return c__.ReplyMethodNotImplemented("ListImages")
 }
 
-func (s__ *VarlinkInterface) UnpauseContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("UnpauseContainer")
+func (s__ *VarlinkInterface) PullImage(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("PullImage")
+}
+
+func (s__ *VarlinkInterface) ListContainerProcesses(c__ VarlinkCall, name_ string, opts_ []string) error {
+	return c__.ReplyMethodNotImplemented("ListContainerProcesses")
+}
+
+func (s__ *VarlinkInterface) ListContainerChanges(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("ListContainerChanges")
+}
+
+func (s__ *VarlinkInterface) StartContainer(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("StartContainer")
+}
+
+func (s__ *VarlinkInterface) AttachToContainer(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("AttachToContainer")
+}
+
+func (s__ *VarlinkInterface) GetContainerLogs(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("GetContainerLogs")
 }
 
 func (s__ *VarlinkInterface) BuildImage(c__ VarlinkCall) error {
 	return c__.ReplyMethodNotImplemented("BuildImage")
+}
+
+func (s__ *VarlinkInterface) RemoveImage(c__ VarlinkCall, name_ string, force_ bool) error {
+	return c__.ReplyMethodNotImplemented("RemoveImage")
+}
+
+func (s__ *VarlinkInterface) ImportImage(c__ VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error {
+	return c__.ReplyMethodNotImplemented("ImportImage")
+}
+
+func (s__ *VarlinkInterface) Ping(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("Ping")
+}
+
+func (s__ *VarlinkInterface) GetContainer(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("GetContainer")
+}
+
+func (s__ *VarlinkInterface) ResizeContainerTty(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("ResizeContainerTty")
+}
+
+func (s__ *VarlinkInterface) KillContainer(c__ VarlinkCall, name_ string, signal_ int64) error {
+	return c__.ReplyMethodNotImplemented("KillContainer")
+}
+
+func (s__ *VarlinkInterface) SearchImage(c__ VarlinkCall, name_ string, limit_ int64) error {
+	return c__.ReplyMethodNotImplemented("SearchImage")
+}
+
+func (s__ *VarlinkInterface) DeleteUnusedImages(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("DeleteUnusedImages")
+}
+
+func (s__ *VarlinkInterface) RenameContainer(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("RenameContainer")
 }
 
 func (s__ *VarlinkInterface) CreateImage(c__ VarlinkCall) error {
@@ -1205,20 +1363,20 @@ func (s__ *VarlinkInterface) InspectImage(c__ VarlinkCall, name_ string) error {
 	return c__.ReplyMethodNotImplemented("InspectImage")
 }
 
-func (s__ *VarlinkInterface) InspectContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("InspectContainer")
+func (s__ *VarlinkInterface) GetContainerStats(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("GetContainerStats")
 }
 
-func (s__ *VarlinkInterface) ListContainerChanges(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ListContainerChanges")
+func (s__ *VarlinkInterface) UpdateContainer(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("UpdateContainer")
 }
 
-func (s__ *VarlinkInterface) StopContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("StopContainer")
+func (s__ *VarlinkInterface) RemoveContainer(c__ VarlinkCall, name_ string, force_ bool) error {
+	return c__.ReplyMethodNotImplemented("RemoveContainer")
 }
 
-func (s__ *VarlinkInterface) KillContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("KillContainer")
+func (s__ *VarlinkInterface) DeleteStoppedContainers(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("DeleteStoppedContainers")
 }
 
 func (s__ *VarlinkInterface) PushImage(c__ VarlinkCall, name_ string, tag_ string, tlsverify_ bool) error {
@@ -1229,18 +1387,6 @@ func (s__ *VarlinkInterface) ExportImage(c__ VarlinkCall, name_ string, destinat
 	return c__.ReplyMethodNotImplemented("ExportImage")
 }
 
-func (s__ *VarlinkInterface) HistoryImage(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("HistoryImage")
-}
-
-func (s__ *VarlinkInterface) CreateFromContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("CreateFromContainer")
-}
-
-func (s__ *VarlinkInterface) ImportImage(c__ VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error {
-	return c__.ReplyMethodNotImplemented("ImportImage")
-}
-
 func (s__ *VarlinkInterface) GetVersion(c__ VarlinkCall) error {
 	return c__.ReplyMethodNotImplemented("GetVersion")
 }
@@ -1249,16 +1395,36 @@ func (s__ *VarlinkInterface) ListContainers(c__ VarlinkCall) error {
 	return c__.ReplyMethodNotImplemented("ListContainers")
 }
 
-func (s__ *VarlinkInterface) GetContainerLogs(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("GetContainerLogs")
+func (s__ *VarlinkInterface) CreateContainer(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("CreateContainer")
 }
 
-func (s__ *VarlinkInterface) UpdateContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("UpdateContainer")
+func (s__ *VarlinkInterface) InspectContainer(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("InspectContainer")
 }
 
-func (s__ *VarlinkInterface) AttachToContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("AttachToContainer")
+func (s__ *VarlinkInterface) StopContainer(c__ VarlinkCall, name_ string, timeout_ int64) error {
+	return c__.ReplyMethodNotImplemented("StopContainer")
+}
+
+func (s__ *VarlinkInterface) UnpauseContainer(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("UnpauseContainer")
+}
+
+func (s__ *VarlinkInterface) CreateFromContainer(c__ VarlinkCall) error {
+	return c__.ReplyMethodNotImplemented("CreateFromContainer")
+}
+
+func (s__ *VarlinkInterface) ExportContainer(c__ VarlinkCall, name_ string, path_ string) error {
+	return c__.ReplyMethodNotImplemented("ExportContainer")
+}
+
+func (s__ *VarlinkInterface) RestartContainer(c__ VarlinkCall, name_ string, timeout_ int64) error {
+	return c__.ReplyMethodNotImplemented("RestartContainer")
+}
+
+func (s__ *VarlinkInterface) HistoryImage(c__ VarlinkCall, name_ string) error {
+	return c__.ReplyMethodNotImplemented("HistoryImage")
 }
 
 func (s__ *VarlinkInterface) TagImage(c__ VarlinkCall, name_ string, tagged_ string) error {
@@ -1268,7 +1434,7 @@ func (s__ *VarlinkInterface) TagImage(c__ VarlinkCall, name_ string, tagged_ str
 // Method call dispatcher
 func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname string) error {
 	switch methodname {
-	case "PullImage":
+	case "GetContainerLogs":
 		var in struct {
 			Name string `json:"name"`
 		}
@@ -1276,16 +1442,10 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		if err != nil {
 			return call.ReplyInvalidParameter("parameters")
 		}
-		return s__.ioprojectatomicpodmanInterface.PullImage(VarlinkCall{call}, in.Name)
+		return s__.ioprojectatomicpodmanInterface.GetContainerLogs(VarlinkCall{call}, in.Name)
 
-	case "ListContainerProcesses":
-		return s__.ioprojectatomicpodmanInterface.ListContainerProcesses(VarlinkCall{call})
-
-	case "ResizeContainerTty":
-		return s__.ioprojectatomicpodmanInterface.ResizeContainerTty(VarlinkCall{call})
-
-	case "RemoveContainer":
-		return s__.ioprojectatomicpodmanInterface.RemoveContainer(VarlinkCall{call})
+	case "BuildImage":
+		return s__.ioprojectatomicpodmanInterface.BuildImage(VarlinkCall{call})
 
 	case "RemoveImage":
 		var in struct {
@@ -1298,6 +1458,46 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		}
 		return s__.ioprojectatomicpodmanInterface.RemoveImage(VarlinkCall{call}, in.Name, in.Force)
 
+	case "ImportImage":
+		var in struct {
+			Source    string   `json:"source"`
+			Reference string   `json:"reference"`
+			Message   string   `json:"message"`
+			Changes   []string `json:"changes"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.ImportImage(VarlinkCall{call}, in.Source, in.Reference, in.Message, []string(in.Changes))
+
+	case "Ping":
+		return s__.ioprojectatomicpodmanInterface.Ping(VarlinkCall{call})
+
+	case "GetContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.GetContainer(VarlinkCall{call}, in.Name)
+
+	case "ResizeContainerTty":
+		return s__.ioprojectatomicpodmanInterface.ResizeContainerTty(VarlinkCall{call})
+
+	case "KillContainer":
+		var in struct {
+			Name   string `json:"name"`
+			Signal int64  `json:"signal"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.KillContainer(VarlinkCall{call}, in.Name, in.Signal)
+
 	case "SearchImage":
 		var in struct {
 			Name  string `json:"name"`
@@ -1309,26 +1509,11 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		}
 		return s__.ioprojectatomicpodmanInterface.SearchImage(VarlinkCall{call}, in.Name, in.Limit)
 
-	case "GetContainerStats":
-		return s__.ioprojectatomicpodmanInterface.GetContainerStats(VarlinkCall{call})
-
-	case "PauseContainer":
-		return s__.ioprojectatomicpodmanInterface.PauseContainer(VarlinkCall{call})
-
-	case "WaitContainer":
-		return s__.ioprojectatomicpodmanInterface.WaitContainer(VarlinkCall{call})
-
 	case "DeleteUnusedImages":
 		return s__.ioprojectatomicpodmanInterface.DeleteUnusedImages(VarlinkCall{call})
 
-	case "RestartContainer":
-		return s__.ioprojectatomicpodmanInterface.RestartContainer(VarlinkCall{call})
-
-	case "ListImages":
-		return s__.ioprojectatomicpodmanInterface.ListImages(VarlinkCall{call})
-
-	case "BuildImage":
-		return s__.ioprojectatomicpodmanInterface.BuildImage(VarlinkCall{call})
+	case "RenameContainer":
+		return s__.ioprojectatomicpodmanInterface.RenameContainer(VarlinkCall{call})
 
 	case "CreateImage":
 		return s__.ioprojectatomicpodmanInterface.CreateImage(VarlinkCall{call})
@@ -1343,20 +1528,32 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		}
 		return s__.ioprojectatomicpodmanInterface.InspectImage(VarlinkCall{call}, in.Name)
 
-	case "InspectContainer":
-		return s__.ioprojectatomicpodmanInterface.InspectContainer(VarlinkCall{call})
+	case "GetContainerStats":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.GetContainerStats(VarlinkCall{call}, in.Name)
 
-	case "ListContainerChanges":
-		return s__.ioprojectatomicpodmanInterface.ListContainerChanges(VarlinkCall{call})
+	case "UpdateContainer":
+		return s__.ioprojectatomicpodmanInterface.UpdateContainer(VarlinkCall{call})
 
-	case "StopContainer":
-		return s__.ioprojectatomicpodmanInterface.StopContainer(VarlinkCall{call})
+	case "RemoveContainer":
+		var in struct {
+			Name  string `json:"name"`
+			Force bool   `json:"force"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.RemoveContainer(VarlinkCall{call}, in.Name, in.Force)
 
-	case "KillContainer":
-		return s__.ioprojectatomicpodmanInterface.KillContainer(VarlinkCall{call})
-
-	case "UnpauseContainer":
-		return s__.ioprojectatomicpodmanInterface.UnpauseContainer(VarlinkCall{call})
+	case "DeleteStoppedContainers":
+		return s__.ioprojectatomicpodmanInterface.DeleteStoppedContainers(VarlinkCall{call})
 
 	case "PushImage":
 		var in struct {
@@ -1385,30 +1582,67 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 	case "CreateFromContainer":
 		return s__.ioprojectatomicpodmanInterface.CreateFromContainer(VarlinkCall{call})
 
-	case "ImportImage":
-		var in struct {
-			Source    string   `json:"source"`
-			Reference string   `json:"reference"`
-			Message   string   `json:"message"`
-			Changes   []string `json:"changes"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.ImportImage(VarlinkCall{call}, in.Source, in.Reference, in.Message, []string(in.Changes))
-
 	case "GetVersion":
 		return s__.ioprojectatomicpodmanInterface.GetVersion(VarlinkCall{call})
 
 	case "ListContainers":
 		return s__.ioprojectatomicpodmanInterface.ListContainers(VarlinkCall{call})
 
-	case "GetContainerLogs":
-		return s__.ioprojectatomicpodmanInterface.GetContainerLogs(VarlinkCall{call})
+	case "CreateContainer":
+		return s__.ioprojectatomicpodmanInterface.CreateContainer(VarlinkCall{call})
 
-	case "UpdateContainer":
-		return s__.ioprojectatomicpodmanInterface.UpdateContainer(VarlinkCall{call})
+	case "InspectContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.InspectContainer(VarlinkCall{call}, in.Name)
+
+	case "StopContainer":
+		var in struct {
+			Name    string `json:"name"`
+			Timeout int64  `json:"timeout"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.StopContainer(VarlinkCall{call}, in.Name, in.Timeout)
+
+	case "UnpauseContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.UnpauseContainer(VarlinkCall{call}, in.Name)
+
+	case "ExportContainer":
+		var in struct {
+			Name string `json:"name"`
+			Path string `json:"path"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.ExportContainer(VarlinkCall{call}, in.Name, in.Path)
+
+	case "RestartContainer":
+		var in struct {
+			Name    string `json:"name"`
+			Timeout int64  `json:"timeout"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.RestartContainer(VarlinkCall{call}, in.Name, in.Timeout)
 
 	case "HistoryImage":
 		var in struct {
@@ -1419,9 +1653,6 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 			return call.ReplyInvalidParameter("parameters")
 		}
 		return s__.ioprojectatomicpodmanInterface.HistoryImage(VarlinkCall{call}, in.Name)
-
-	case "AttachToContainer":
-		return s__.ioprojectatomicpodmanInterface.AttachToContainer(VarlinkCall{call})
 
 	case "TagImage":
 		var in struct {
@@ -1434,23 +1665,65 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		}
 		return s__.ioprojectatomicpodmanInterface.TagImage(VarlinkCall{call}, in.Name, in.Tagged)
 
-	case "DeleteStoppedContainers":
-		return s__.ioprojectatomicpodmanInterface.DeleteStoppedContainers(VarlinkCall{call})
+	case "PauseContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.PauseContainer(VarlinkCall{call}, in.Name)
 
-	case "Ping":
-		return s__.ioprojectatomicpodmanInterface.Ping(VarlinkCall{call})
+	case "WaitContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.WaitContainer(VarlinkCall{call}, in.Name)
 
-	case "CreateContainer":
-		return s__.ioprojectatomicpodmanInterface.CreateContainer(VarlinkCall{call})
+	case "ListImages":
+		return s__.ioprojectatomicpodmanInterface.ListImages(VarlinkCall{call})
 
-	case "ExportContainer":
-		return s__.ioprojectatomicpodmanInterface.ExportContainer(VarlinkCall{call})
+	case "PullImage":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.PullImage(VarlinkCall{call}, in.Name)
+
+	case "ListContainerProcesses":
+		var in struct {
+			Name string   `json:"name"`
+			Opts []string `json:"opts"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.ListContainerProcesses(VarlinkCall{call}, in.Name, []string(in.Opts))
+
+	case "ListContainerChanges":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s__.ioprojectatomicpodmanInterface.ListContainerChanges(VarlinkCall{call}, in.Name)
 
 	case "StartContainer":
 		return s__.ioprojectatomicpodmanInterface.StartContainer(VarlinkCall{call})
 
-	case "RenameContainer":
-		return s__.ioprojectatomicpodmanInterface.RenameContainer(VarlinkCall{call})
+	case "AttachToContainer":
+		return s__.ioprojectatomicpodmanInterface.AttachToContainer(VarlinkCall{call})
 
 	default:
 		return call.ReplyMethodNotFound(methodname)
@@ -1519,32 +1792,100 @@ type ImageSearch (
     star_count: int
 )
 
+# ListContainer is the returned struct for an individual container
+type ListContainerData (
+    id: string,
+    image: string,
+    imageid: string,
+    command: []string,
+    createdat: string,
+    runningfor: string,
+    status: string,
+    ports: []ContainerPortMappings,
+    rootfssize: int,
+    rwsize: int,
+    names: string,
+    labels: [string]string,
+    mounts: []ContainerMount,
+    containerrunning: bool,
+    namespaces: ContainerNameSpace
+)
+
+# ContainerStats is the return struct for the stats of a container
+type ContainerStats (
+    id: string,
+    name: string,
+    cpu: float,
+    cpu_nano: int,
+    system_nano: int,
+    mem_usage: int,
+    mem_limit: int,
+    mem_perc: float,
+    net_input: int,
+    net_output: int,
+    block_output: int,
+    block_input: int,
+    pids: int
+)
+
+# ContainerMount describes the struct for mounts in a container
+type ContainerMount (
+    destination: string,
+    type: string,
+    source: string,
+    options: []string
+)
+
+# ContainerPortMappings describes the struct for portmappings in an existing container
+type ContainerPortMappings (
+    host_port: string,
+    host_ip: string,
+    protocol: string,
+    container_port: string
+)
+
+# ContainerNamespace describes the namespace structure for an existing container
+type ContainerNameSpace (
+    user: string,
+    uts: string,
+    pidns: string,
+    pid: string,
+    cgroup: string,
+    net: string,
+    mnt: string,
+    ipc: string
+)
+
 # System
 method Ping() -> (ping: StringResponse)
 method GetVersion() -> (version: Version)
 
 # Containers
-method ListContainers() -> (notimplemented: NotImplemented)
+method ListContainers() -> (containers: []ListContainerData)
+method GetContainer(name: string) -> (container: ListContainerData)
 method CreateContainer() -> (notimplemented: NotImplemented)
-method InspectContainer() -> (notimplemented: NotImplemented)
-method ListContainerProcesses() -> (notimplemented: NotImplemented)
-method GetContainerLogs() -> (notimplemented: NotImplemented)
-method ListContainerChanges() -> (notimplemented: NotImplemented)
-method ExportContainer() -> (notimplemented: NotImplemented)
-method GetContainerStats() -> (notimplemented: NotImplemented)
+method InspectContainer(name: string) -> (container: string)
+# TODO: Should this be made into a streaming response as opposed to a one off?
+method ListContainerProcesses(name: string, opts: []string) -> (container: []string)
+# TODO: Should this be made into a streaming response as opposed to a one off?
+method GetContainerLogs(name: string) -> (container: []string)
+method ListContainerChanges(name: string) -> (container: [string]string)
+# TODO: This should be made into a streaming response
+method ExportContainer(name: string, path: string) -> (tarfile: string)
+method GetContainerStats(name: string) -> (container: ContainerStats)
 method ResizeContainerTty() -> (notimplemented: NotImplemented)
 method StartContainer() -> (notimplemented: NotImplemented)
-method StopContainer() -> (notimplemented: NotImplemented)
-method RestartContainer() -> (notimplemented: NotImplemented)
-method KillContainer() -> (notimplemented: NotImplemented)
+method StopContainer(name: string, timeout: int) -> (container: string)
+method RestartContainer(name: string, timeout: int) -> (container: string)
+method KillContainer(name: string, signal: int) -> (container: string)
 method UpdateContainer() -> (notimplemented: NotImplemented)
 method RenameContainer() -> (notimplemented: NotImplemented)
-method PauseContainer() -> (notimplemented: NotImplemented)
-method UnpauseContainer() -> (notimplemented: NotImplemented)
+method PauseContainer(name: string) -> (container: string)
+method UnpauseContainer(name: string) -> (container: string)
 method AttachToContainer() -> (notimplemented: NotImplemented)
-method WaitContainer() -> (notimplemented: NotImplemented)
-method RemoveContainer() -> (notimplemented: NotImplemented)
-method DeleteStoppedContainers() -> (notimplemented: NotImplemented)
+method WaitContainer(name: string) -> (exitcode: int)
+method RemoveContainer(name: string, force: bool) -> (container: string)
+method DeleteStoppedContainers() -> (containers: []string)
 
 # Images
 method ListImages() -> (images: []ImageInList)
@@ -1565,7 +1906,8 @@ method PullImage(name: string) -> (id: string)
 
 # Something failed
 error ActionFailed (reason: string)
-error ImageNotFound (imagename: string)
+error ImageNotFound (name: string)
+error ContainerNotFound (name: string)
 error ErrorOccurred (reason: string)
 error RuntimeError (reason: string)
 `

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -455,7 +455,6 @@ func (c *Container) reinit(ctx context.Context) error {
 	if err := c.runtime.ociRuntime.deleteContainer(c); err != nil {
 		return errors.Wrapf(err, "error removing container %s from runtime", c.ID())
 	}
-
 	// Our state is now Configured, as we've removed ourself from
 	// the runtime
 	// Set and save now to make sure that, if the init() below fails
@@ -541,7 +540,6 @@ func (c *Container) start() error {
 	if err := c.runtime.ociRuntime.startContainer(c); err != nil {
 		return err
 	}
-
 	logrus.Debugf("Started container %s", c.ID())
 
 	c.state.State = ContainerStateRunning

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -1,12 +1,67 @@
 package varlinkapi
 
 import (
-	ioprojectatomicpodman "github.com/projectatomic/libpod/cmd/podman/varlink"
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/cmd/podman/batchcontainer"
+	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
+	"github.com/projectatomic/libpod/cmd/podman/varlink"
+	"github.com/projectatomic/libpod/libpod"
 )
 
 // ListContainers ...
 func (i *LibpodAPI) ListContainers(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("ListContainers")
+	var (
+		listContainers []ioprojectatomicpodman.ListContainerData
+	)
+
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	containers, err := runtime.GetAllContainers()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	opts := batchcontainer.PsOptions{
+		Namespace: true,
+		Size:      true,
+	}
+	for _, ctr := range containers {
+		batchInfo, err := batchcontainer.BatchContainerOp(ctr, opts)
+		if err != nil {
+			return call.ReplyErrorOccurred(err.Error())
+		}
+
+		listContainers = append(listContainers, makeListContainer(ctr.ID(), batchInfo))
+	}
+	return call.ReplyListContainers(listContainers)
+}
+
+// GetContainer ...
+func (i *LibpodAPI) GetContainer(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	opts := batchcontainer.PsOptions{
+		Namespace: true,
+		Size:      true,
+	}
+	batchInfo, err := batchcontainer.BatchContainerOp(ctr, opts)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyGetContainer(makeListContainer(ctr.ID(), batchInfo))
 }
 
 // CreateContainer ...
@@ -15,33 +70,158 @@ func (i *LibpodAPI) CreateContainer(call ioprojectatomicpodman.VarlinkCall) erro
 }
 
 // InspectContainer ...
-func (i *LibpodAPI) InspectContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("InspectContainer")
+func (i *LibpodAPI) InspectContainer(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	inspectInfo, err := ctr.Inspect(true)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	b, err := json.Marshal(inspectInfo)
+	if err != nil {
+		return call.ReplyErrorOccurred(fmt.Sprintf("unable to serialize"))
+	}
+	return call.ReplyInspectContainer(string(b))
 }
 
 // ListContainerProcesses ...
-func (i *LibpodAPI) ListContainerProcesses(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("ListContainerProcesses")
+func (i *LibpodAPI) ListContainerProcesses(call ioprojectatomicpodman.VarlinkCall, name string, opts []string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	containerState, err := ctr.State()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	if containerState != libpod.ContainerStateRunning {
+		return call.ReplyErrorOccurred(fmt.Sprintf("container %s is not running", name))
+	}
+	var psArgs []string
+	psOpts := []string{"-o", "uid,pid,ppid,c,stime,tname,time,cmd"}
+	if len(opts) > 1 {
+		psOpts = opts
+	}
+	psArgs = append(psArgs, psOpts...)
+	psOutput, err := ctr.GetContainerPidInformation(psArgs)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyListContainerProcesses(psOutput)
 }
 
 // GetContainerLogs ...
-func (i *LibpodAPI) GetContainerLogs(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("GetContainerLogs")
+func (i *LibpodAPI) GetContainerLogs(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	var logs []string
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	logPath := ctr.LogPath()
+
+	containerState, err := ctr.State()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		if containerState == libpod.ContainerStateConfigured {
+			return call.ReplyGetContainerLogs(logs)
+		}
+	}
+	file, err := os.Open(logPath)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read container log file")
+	}
+	defer file.Close()
+	reader := bufio.NewReader(file)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+		logs = append(logs, line)
+	}
+	return call.ReplyGetContainerLogs(logs)
 }
 
 // ListContainerChanges ...
-func (i *LibpodAPI) ListContainerChanges(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("ListContianerChanges")
+func (i *LibpodAPI) ListContainerChanges(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	changes, err := runtime.GetDiff("", name)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	m := make(map[string]string)
+	for _, change := range changes {
+		m[change.Path] = change.Kind.String()
+	}
+	return call.ReplyListContainerChanges(m)
 }
 
 // ExportContainer ...
-func (i *LibpodAPI) ExportContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("ExportContainer")
+func (i *LibpodAPI) ExportContainer(call ioprojectatomicpodman.VarlinkCall, name, path string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := ctr.Export(path); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyExportContainer(path)
 }
 
 // GetContainerStats ...
-func (i *LibpodAPI) GetContainerStats(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("GetContainerStates")
+func (i *LibpodAPI) GetContainerStats(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	containerStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	cs := ioprojectatomicpodman.ContainerStats{
+		Id:           ctr.ID(),
+		Name:         ctr.Name(),
+		Cpu:          containerStats.CPU,
+		Cpu_nano:     int64(containerStats.CPUNano),
+		System_nano:  int64(containerStats.SystemNano),
+		Mem_usage:    int64(containerStats.MemUsage),
+		Mem_limit:    int64(containerStats.MemLimit),
+		Mem_perc:     containerStats.MemPerc,
+		Net_input:    int64(containerStats.NetInput),
+		Net_output:   int64(containerStats.NetOutput),
+		Block_input:  int64(containerStats.BlockInput),
+		Block_output: int64(containerStats.BlockOutput),
+		Pids:         int64(containerStats.PIDs),
+	}
+	return call.ReplyGetContainerStats(cs)
 }
 
 // ResizeContainerTty ...
@@ -55,18 +235,56 @@ func (i *LibpodAPI) StartContainer(call ioprojectatomicpodman.VarlinkCall) error
 }
 
 // StopContainer ...
-func (i *LibpodAPI) StopContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("StopContainer")
+func (i *LibpodAPI) StopContainer(call ioprojectatomicpodman.VarlinkCall, name string, timeout int64) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := ctr.StopWithTimeout(uint(timeout)); err != nil && err != libpod.ErrCtrStopped {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyStopContainer(ctr.ID())
 }
 
 // RestartContainer ...
-func (i *LibpodAPI) RestartContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("RestartContainer")
+func (i *LibpodAPI) RestartContainer(call ioprojectatomicpodman.VarlinkCall, name string, timeout int64) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := ctr.RestartWithTimeout(getContext(), uint(timeout)); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyRestartContainer(ctr.ID())
 }
 
-// KillContainer ...
-func (i *LibpodAPI) KillContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("KillContainer")
+// KillContainer kills a running container.  If you want to use the default SIGTERM signal, just send a -1
+// for the signal arg.
+func (i *LibpodAPI) KillContainer(call ioprojectatomicpodman.VarlinkCall, name string, signal int64) error {
+	var killSignal uint = uint(syscall.SIGTERM)
+	if signal != -1 {
+		killSignal = uint(signal)
+	}
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := ctr.Kill(killSignal); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyKillContainer(ctr.ID())
 }
 
 // UpdateContainer ...
@@ -80,13 +298,35 @@ func (i *LibpodAPI) RenameContainer(call ioprojectatomicpodman.VarlinkCall) erro
 }
 
 // PauseContainer ...
-func (i *LibpodAPI) PauseContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("PauseContainer")
+func (i *LibpodAPI) PauseContainer(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := ctr.Pause(); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyPauseContainer(ctr.ID())
 }
 
 // UnpauseContainer ...
-func (i *LibpodAPI) UnpauseContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("UnpauseContainer")
+func (i *LibpodAPI) UnpauseContainer(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := ctr.Unpause(); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyUnpauseContainer(ctr.ID())
 }
 
 // AttachToContainer ...
@@ -96,16 +336,62 @@ func (i *LibpodAPI) AttachToContainer(call ioprojectatomicpodman.VarlinkCall) er
 }
 
 // WaitContainer ...
-func (i *LibpodAPI) WaitContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("WaitContainer")
+func (i *LibpodAPI) WaitContainer(call ioprojectatomicpodman.VarlinkCall, name string) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	exitCode, err := ctr.Wait()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyWaitContainer(int64(exitCode))
+
 }
 
 // RemoveContainer ...
-func (i *LibpodAPI) RemoveContainer(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("RemoveContainer")
+func (i *LibpodAPI) RemoveContainer(call ioprojectatomicpodman.VarlinkCall, name string, force bool) error {
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	ctr, err := runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyContainerNotFound(name)
+	}
+	if err := runtime.RemoveContainer(ctr, force); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyRemoveContainer(ctr.ID())
+
 }
 
 // DeleteStoppedContainers ...
 func (i *LibpodAPI) DeleteStoppedContainers(call ioprojectatomicpodman.VarlinkCall) error {
-	return call.ReplyMethodNotImplemented("DeleteContainer")
+	var deletedContainers []string
+	runtime, err := libpodruntime.GetRuntime(i.Cli)
+	if err != nil {
+		return call.ReplyRuntimeError(err.Error())
+	}
+	containers, err := runtime.GetAllContainers()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	for _, ctr := range containers {
+		state, err := ctr.State()
+		if err != nil {
+			return call.ReplyErrorOccurred(err.Error())
+		}
+		if state != libpod.ContainerStateRunning {
+			if err := runtime.RemoveContainer(ctr, false); err != nil {
+				return call.ReplyErrorOccurred(err.Error())
+			}
+			deletedContainers = append(deletedContainers, ctr.ID())
+		}
+	}
+	return call.ReplyDeleteStoppedContainers(deletedContainers)
 }

--- a/pkg/varlinkapi/util.go
+++ b/pkg/varlinkapi/util.go
@@ -2,9 +2,76 @@ package varlinkapi
 
 import (
 	"context"
+	"strconv"
+	"time"
+
+	"github.com/projectatomic/libpod/cmd/podman/batchcontainer"
+	"github.com/projectatomic/libpod/cmd/podman/varlink"
+	"github.com/projectatomic/libpod/libpod"
 )
 
 // getContext returns a non-nil, empty context
 func getContext() context.Context {
 	return context.TODO()
+}
+
+func makeListContainer(containerID string, batchInfo batchcontainer.BatchContainerStruct) ioprojectatomicpodman.ListContainerData {
+	var (
+		mounts []ioprojectatomicpodman.ContainerMount
+		ports  []ioprojectatomicpodman.ContainerPortMappings
+	)
+	ns := batchcontainer.GetNamespaces(batchInfo.Pid)
+
+	for _, mount := range batchInfo.ConConfig.Spec.Mounts {
+		m := ioprojectatomicpodman.ContainerMount{
+			Destination: mount.Destination,
+			Type:        mount.Type,
+			Source:      mount.Source,
+			Options:     mount.Options,
+		}
+		mounts = append(mounts, m)
+	}
+
+	for _, pm := range batchInfo.ConConfig.PortMappings {
+		p := ioprojectatomicpodman.ContainerPortMappings{
+			Host_port:      strconv.Itoa(int(pm.HostPort)),
+			Host_ip:        pm.HostIP,
+			Protocol:       pm.Protocol,
+			Container_port: strconv.Itoa(int(pm.ContainerPort)),
+		}
+		ports = append(ports, p)
+
+	}
+
+	// If we find this needs to be done for other container endpoints, we should
+	// convert this to a separate function or a generic map from struct function.
+	namespace := ioprojectatomicpodman.ContainerNameSpace{
+		User:   ns.User,
+		Uts:    ns.UTS,
+		Pidns:  ns.PIDNS,
+		Pid:    ns.PID,
+		Cgroup: ns.Cgroup,
+		Net:    ns.NET,
+		Mnt:    ns.MNT,
+		Ipc:    ns.IPC,
+	}
+
+	lc := ioprojectatomicpodman.ListContainerData{
+		Id:               containerID,
+		Image:            batchInfo.ConConfig.RootfsImageName,
+		Imageid:          batchInfo.ConConfig.RootfsImageID,
+		Command:          batchInfo.ConConfig.Spec.Process.Args,
+		Createdat:        batchInfo.ConConfig.CreatedTime.String(),
+		Runningfor:       time.Since(batchInfo.ConConfig.CreatedTime).String(),
+		Status:           batchInfo.ConState.String(),
+		Ports:            ports,
+		Rootfssize:       batchInfo.RootFsSize,
+		Rwsize:           batchInfo.RwSize,
+		Names:            batchInfo.ConConfig.Name,
+		Labels:           batchInfo.ConConfig.Labels,
+		Mounts:           mounts,
+		Containerrunning: batchInfo.ConState == libpod.ContainerStateRunning,
+		Namespaces:       namespace,
+	}
+	return lc
 }


### PR DESCRIPTION
first pass at adding in the container related endpoints/methods for the libpod
backend. Couple of important notes:

* endpoints that can use a console are not going to be done until we have "remote" console
* several of the container methods should probably be able to stream as opposed to a one-off return

Signed-off-by: baude <bbaude@redhat.com>