### PR TITLE
Fix podman logout --all flag

### DIFF
--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -36,9 +36,9 @@ var (
 func logoutCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) > 1 {
-		return errors.Errorf("too many arguments, logout takes only 1 argument")
+		return errors.Errorf("too many arguments, logout takes at most 1 argument")
 	}
-	if len(args) == 0 {
+	if len(args) == 0 && !c.IsSet("all") {
 		return errors.Errorf("registry must be given")
 	}
 	var server string


### PR DESCRIPTION
podman logout --all should remove cached credentials for all registries in
the auth.json file.
Before this, it was asking for a registry to be given with the --all flag also.

Fixes issue raised by QE in https://trello.com/c/9ZLT0tmV/635-1-cri-okpod-add-podman-logout-command

Signed-off-by: umohnani8 <umohnani@redhat.com>