### PR TITLE
bashcompletion enhancements

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1364,7 +1364,7 @@ _podman_rmi() {
             COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
             ;;
         *)
-            __podman_list_images
+            __podman_complete_images --id
             ;;
     esac
 }
@@ -1389,7 +1389,7 @@ _podman_stats() {
     esac
 }
 
-podman_tag() {
+_podman_tag() {
     local options_with_args="
     "
     local boolean_options="
@@ -1397,7 +1397,7 @@ podman_tag() {
     _complete_ "$options_with_args" "$boolean_options"
 }
 
-podman_top() {
+_podman_top() {
     local options_with_args="
     "
     local boolean_options="
@@ -1694,4 +1694,4 @@ _cli_bash_autocomplete() {
      return 0
 }
 
-complete -F _cli_bash_autocomplete $PROG
+complete -F _cli_bash_autocomplete podman


### PR DESCRIPTION
* now all podman subcommands can be completed
* images can be completed when run as root (not sudo)
* bug corrected that made podman_top and podman_tag

Signed-off-by: baude <bbaude@redhat.com>