### PR TITLE
Allow streaming on some varlink container methods

### DIFF
--- a/cmd/podman/varlink/io.projectatomic.podman.varlink
+++ b/cmd/podman/varlink/io.projectatomic.podman.varlink
@@ -126,12 +126,9 @@ method ListContainers() -> (containers: []ListContainerData)
 method GetContainer(name: string) -> (container: ListContainerData)
 method CreateContainer() -> (notimplemented: NotImplemented)
 method InspectContainer(name: string) -> (container: string)
-# TODO: Should this be made into a streaming response as opposed to a one off?
 method ListContainerProcesses(name: string, opts: []string) -> (container: []string)
-# TODO: Should this be made into a streaming response as opposed to a one off?
 method GetContainerLogs(name: string) -> (container: []string)
 method ListContainerChanges(name: string) -> (container: [string]string)
-# TODO: This should be made into a streaming response
 method ExportContainer(name: string, path: string) -> (tarfile: string)
 method GetContainerStats(name: string) -> (container: ContainerStats)
 method ResizeContainerTty() -> (notimplemented: NotImplemented)

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -1,7 +1,7 @@
 package varlinkapi
 
 import (
-	ioprojectatomicpodman "github.com/projectatomic/libpod/cmd/podman/varlink"
+	"github.com/projectatomic/libpod/cmd/podman/varlink"
 	"github.com/projectatomic/libpod/libpod"
 )
 


### PR DESCRIPTION
The following methods should support streaming requests from the client:

* GetContainerLogs

A reference for a python stream implementation can be found here:

https://github.com/varlink/python/blob/master/varlink/tests/test_orgexamplemore.py#L29-L42

Signed-off-by: baude <bbaude@redhat.com>