### PR TITLE
Make invalid state nonfatal when cleaning up in run

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -217,7 +217,10 @@ func runCmd(c *cli.Context) error {
 
 	if err := ctr.Cleanup(); err != nil {
 		// If the container has been removed already, no need to error on cleanup
-		if errors.Cause(err) == libpod.ErrNoSuchCtr || errors.Cause(err) == libpod.ErrCtrRemoved {
+		// Also, if it was restarted, don't error either
+		if errors.Cause(err) == libpod.ErrNoSuchCtr ||
+			errors.Cause(err) == libpod.ErrCtrRemoved ||
+			errors.Cause(err) == libpod.ErrCtrStateInvalid {
 			return nil
 		}
 


### PR DESCRIPTION
ErrCtrStateInvalid occurs during cleanup when the container is running. The most common cause of this is going to be a container that was restarted with `podman restart`. As such, we shouldn't error when we get an ErrCtrStateInvalid back when trying to clean up, there's no need to clean up as the container is once again running