### PR TITLE
chrootuser: default to GID 0 when given a numeric --user

### DIFF
--- a/pkg/chrootuser/user_basic.go
+++ b/pkg/chrootuser/user_basic.go
@@ -17,3 +17,7 @@ func lookupGroupInContainer(rootdir, groupname string) (uint64, error) {
 func lookupGroupForUIDInContainer(rootdir string, userid uint64) (string, uint64, error) {
 	return "", 0, errors.New("primary group lookup by uid not supported")
 }
+
+func lookupAdditionalGroupsForUIDInContainer(rootdir string, userid uint64) (gid []uint32, err error) {
+	return nil, errors.New("supplemental groups list lookup by uid not supported")
+}


### PR DESCRIPTION
When we're given a numeric --user value, default to GID 0 if the numeric ID doesn't correspond to a user entry in /etc/passwd that can provide us with the user's primary group ID.  If we're explicitly given a group to run as, don't look up supplemental groups.

Also test various user:group forms.