### PR TITLE
Remove extra close from attach resize channel

### DIFF
--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -17,7 +17,6 @@ import (
 // Attach to a container
 func attachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool) error {
 	resize := make(chan remotecommand.TerminalSize)
-	defer close(resize)
 
 	haveTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 
@@ -69,7 +68,6 @@ func attachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys
 // Start and attach to a container
 func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool) error {
 	resize := make(chan remotecommand.TerminalSize)
-	defer close(resize)
 
 	haveTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 


### PR DESCRIPTION
We already close the resize channel in the goroutine we spawn to forward signals. There is a potential race where a terminal resize event is received after the attach finishes and attachCtr closes the channel, but before the remaining cleanup occurs, allowing the goroutine to send a signal along the (now-closed) channel and causing a panic. Let the goroutine manage the lifetime of the channel to avoid this.