### PR TITLE
Generate varlink API documentation automatically

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,624 @@
+## Index
+
+[func ListImages() ImageInList](#ListImages)
+
+[func PushImage(name: string, tag: string, tlsverify: bool) string](#PushImage)
+
+[func TagImage(name: string, tagged: string) string](#TagImage)
+
+[func GetContainer(name: string) ListContainerData](#GetContainer)
+
+[func CreateContainer() NotImplemented](#CreateContainer)
+
+[func GetContainerLogs(name: string) []string](#GetContainerLogs)
+
+[func KillContainer(name: string, signal: int) string](#KillContainer)
+
+[func UnpauseContainer(name: string) string](#UnpauseContainer)
+
+[func AttachToContainer() NotImplemented](#AttachToContainer)
+
+[func BuildImage() NotImplemented](#BuildImage)
+
+[func RemoveImage(name: string, force: bool) string](#RemoveImage)
+
+[func ListContainers() ListContainerData](#ListContainers)
+
+[func ResizeContainerTty() NotImplemented](#ResizeContainerTty)
+
+[func UpdateContainer() NotImplemented](#UpdateContainer)
+
+[func RenameContainer() NotImplemented](#RenameContainer)
+
+[func SearchImage(name: string, limit: int) ImageSearch](#SearchImage)
+
+[func StartContainer() NotImplemented](#StartContainer)
+
+[func StopContainer(name: string, timeout: int) string](#StopContainer)
+
+[func RestartContainer(name: string, timeout: int) string](#RestartContainer)
+
+[func DeleteUnusedImages() []string](#DeleteUnusedImages)
+
+[func Ping() StringResponse](#Ping)
+
+[func GetVersion() Version](#GetVersion)
+
+[func InspectContainer(name: string) string](#InspectContainer)
+
+[func ListContainerChanges(name: string) ContainerChanges](#ListContainerChanges)
+
+[func ExportImage(name: string, destination: string, compress: bool) string](#ExportImage)
+
+[func CreateFromContainer() NotImplemented](#CreateFromContainer)
+
+[func RemoveContainer(name: string, force: bool) string](#RemoveContainer)
+
+[func CreateImage() NotImplemented](#CreateImage)
+
+[func InspectImage(name: string) string](#InspectImage)
+
+[func HistoryImage(name: string) ImageHistory](#HistoryImage)
+
+[func ExportContainer(name: string, path: string) string](#ExportContainer)
+
+[func WaitContainer(name: string) int](#WaitContainer)
+
+[func ImportImage(source: string, reference: string, message: string, changes: []string) string](#ImportImage)
+
+[func PullImage(name: string) string](#PullImage)
+
+[func DeleteStoppedContainers() []string](#DeleteStoppedContainers)
+
+[func ListContainerProcesses(name: string, opts: []string) []string](#ListContainerProcesses)
+
+[func GetContainerStats(name: string) ContainerStats](#GetContainerStats)
+
+[func PauseContainer(name: string) string](#PauseContainer)
+[type ContainerMount](#ContainerMount)
+
+[type ImageHistory](#ImageHistory)
+
+[type ImageSearch](#ImageSearch)
+
+[type StringResponse](#StringResponse)
+
+[type ContainerChanges](#ContainerChanges)
+
+[type ImageInList](#ImageInList)
+
+[type ListContainerData](#ListContainerData)
+
+[type ContainerStats](#ContainerStats)
+
+[type ContainerPortMappings](#ContainerPortMappings)
+
+[type Version](#Version)
+
+[type NotImplemented](#NotImplemented)
+
+[type ContainerNameSpace](#ContainerNameSpace)
+
+[error ErrorOccurred](#ErrorOccurred)
+
+[error RuntimeError](#RuntimeError)
+
+[error ImageNotFound](#ImageNotFound)
+
+[error ContainerNotFound](#ContainerNotFound)
+
+## Methods
+### <a name="ListImages"></a>func ListImages
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ListImages() [ImageInList](#ImageInList)</div>
+ListImages returns an array of ImageInList structures which provide basic information about
+an image currenly in storage.  See also [InspectImage](InspectImage).
+### <a name="PushImage"></a>func PushImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method PushImage(name: [string](https://godoc.org/builtin#string), tag: [string](https://godoc.org/builtin#string), tlsverify: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+PushImage takes three input arguments: the name or ID of an image, the fully-qualified destination name of the image,
+and a boolean as to whether tls-verify should be used.  It will return an [ImageNotFound](#ImageNotFound) error if
+the image cannot be found in local storage; otherwise the ID of the image will be returned on success.
+### <a name="TagImage"></a>func TagImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method TagImage(name: [string](https://godoc.org/builtin#string), tagged: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+TagImage takes the name or ID of an image in local storage as well as the desired tag name.  If the image cannot
+be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
+### <a name="GetContainer"></a>func GetContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method GetContainer(name: [string](https://godoc.org/builtin#string)) [ListContainerData](#ListContainerData)</div>
+GetContainer takes a name or ID of a container and returns single ListContainerData
+structure.  A [ContainerNotFound](#ContainerNotFound) error will be returned if the container cannot be found.
+See also [ListContainers](ListContainers) and [InspectContainer](InspectContainer).
+### <a name="CreateContainer"></a>func CreateContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method CreateContainer() [NotImplemented](#NotImplemented)</div>
+This method has not been implemented yet.
+### <a name="GetContainerLogs"></a>func GetContainerLogs
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method GetContainerLogs(name: [string](https://godoc.org/builtin#string)) [[]string](#[]string)</div>
+GetContainerLogs takes a name or ID of a container and returns the logs of that container.
+If the container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+The container logs are returned as an array of strings.  GetContainerLogs will honor the streaming
+capability of varlink if the client invokes it.
+### <a name="KillContainer"></a>func KillContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method KillContainer(name: [string](https://godoc.org/builtin#string), signal: [int](https://godoc.org/builtin#int)) [string](https://godoc.org/builtin#string)</div>
+KillContainer takes the name or ID of a container as well as a signal to be applied to the container.  Once the
+container has been killed, the container's ID is returned.  If the container cannot be found, a
+[ContainerNotFound](#ContainerNotFound) error is returned. See also [StopContainer](StopContainer).
+### <a name="UnpauseContainer"></a>func UnpauseContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method UnpauseContainer(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+UnpauseContainer takes the name or ID of container and unpauses a paused container.  If the container cannot be
+found, a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
+See also [PauseContainer](PauseContainer).
+### <a name="AttachToContainer"></a>func AttachToContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method AttachToContainer() [NotImplemented](#NotImplemented)</div>
+This method has not be implemented yet.
+### <a name="BuildImage"></a>func BuildImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method BuildImage() [NotImplemented](#NotImplemented)</div>
+This function is not implemented yet.
+### <a name="RemoveImage"></a>func RemoveImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RemoveImage(name: [string](https://godoc.org/builtin#string), force: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+RemoveImage takes the name or ID of an image as well as a booleon that determines if containers using that image
+should be deleted.  If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned.  The
+ID of the removed image is returned when complete.  See also [DeleteUnusedImages](DeleteUnusedImages).
+#### Example
+~~~
+varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.RemoveImage '{"name": "registry.fedoraproject.org/fedora", "force": true}'
+{
+  "image": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
+}
+~~~
+### <a name="ListContainers"></a>func ListContainers
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ListContainers() [ListContainerData](#ListContainerData)</div>
+ListContainers returns a list of containers in no particular order.  There are
+returned as an array of ListContainerData structs.  See also [GetContainer](#GetContainer).
+### <a name="ResizeContainerTty"></a>func ResizeContainerTty
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ResizeContainerTty() [NotImplemented](#NotImplemented)</div>
+This method has not be implemented yet.
+### <a name="UpdateContainer"></a>func UpdateContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method UpdateContainer() [NotImplemented](#NotImplemented)</div>
+This method has not be implemented yet.
+### <a name="RenameContainer"></a>func RenameContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RenameContainer() [NotImplemented](#NotImplemented)</div>
+This method has not be implemented yet.
+### <a name="SearchImage"></a>func SearchImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method SearchImage(name: [string](https://godoc.org/builtin#string), limit: [int](https://godoc.org/builtin#int)) [ImageSearch](#ImageSearch)</div>
+SearchImage takes the string of an image name and a limit of searches from each registries to be returned.  SearchImage
+will then use a glob-like match to find the image you are searching for.  The images are returned in an array of
+ImageSearch structures which contain information about the image as well as its fully-qualified name.
+### <a name="StartContainer"></a>func StartContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method StartContainer() [NotImplemented](#NotImplemented)</div>
+This method has not be implemented yet.
+### <a name="StopContainer"></a>func StopContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method StopContainer(name: [string](https://godoc.org/builtin#string), timeout: [int](https://godoc.org/builtin#int)) [string](https://godoc.org/builtin#string)</div>
+StopContainer stops a container given a timeout.  It takes the name or ID of a container as well as a
+timeout value.  The timeout value the time before a forceable stop to the container is applied.  It
+returns the container ID once stopped. If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+error will be returned instead. See also [KillContainer](KillContainer).
+#### Error
+~~~
+$ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.StopContainer '{"name": "135d71b9495f", "timeout": 5}'
+{
+  "container": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+}
+~~~
+### <a name="RestartContainer"></a>func RestartContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RestartContainer(name: [string](https://godoc.org/builtin#string), timeout: [int](https://godoc.org/builtin#int)) [string](https://godoc.org/builtin#string)</div>
+RestartContainer will restart a running container given a container name or ID and timeout value. The timeout
+value is the time before a forceable stop is used to stop the container.  If the container cannot be found by
+name or ID, a [ContainerNotFound](#ContainerNotFound)  error will be returned; otherwise, the ID of the
+container will be returned.
+### <a name="DeleteUnusedImages"></a>func DeleteUnusedImages
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method DeleteUnusedImages() [[]string](#[]string)</div>
+DeleteUnusedImages deletes any images not associated with a container.  The IDs of the deleted images are returned
+in a string array.
+### <a name="Ping"></a>func Ping
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method Ping() [StringResponse](#StringResponse)</div>
+Ping provides a response for developers to ensure their varlink setup is working.
+#### Example
+~~~
+$ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.Ping
+{
+  "ping": {
+    "message": "OK"
+  }
+}
+~~~
+### <a name="GetVersion"></a>func GetVersion
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method GetVersion() [Version](#Version)</div>
+GetVersion returns a Version structure describing the libpod setup on their
+system.
+### <a name="InspectContainer"></a>func InspectContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method InspectContainer(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+InspectContainer data takes a name or ID of a container returns the inspection
+data in string format.  You can then serialize the string into JSON.  A [ContainerNotFound](#ContainerNotFound)
+error will be returned if the container cannot be found. See also [InspectImage](#InspectImage).
+### <a name="ListContainerChanges"></a>func ListContainerChanges
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ListContainerChanges(name: [string](https://godoc.org/builtin#string)) [ContainerChanges](#ContainerChanges)</div>
+ListContainerChanges takes a name or ID of a container and returns changes between the container and
+its base image. It returns a struct of changed, deleted, and added path names. If the
+container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+### <a name="ExportImage"></a>func ExportImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ExportImage(name: [string](https://godoc.org/builtin#string), destination: [string](https://godoc.org/builtin#string), compress: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+ExportImage takes the name or ID of an image and exports it to a destination like a tarball.  There is also
+a booleon option to force compression.  Upon completion, the ID of the image is returned. If the image cannot
+be found in local storage, an [ImageNotFound](#ImageNotFound) error will be returned. See also [ImportImage](ImportImage).
+### <a name="CreateFromContainer"></a>func CreateFromContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method CreateFromContainer() [NotImplemented](#NotImplemented)</div>
+This method is not implemented.
+### <a name="RemoveContainer"></a>func RemoveContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RemoveContainer(name: [string](https://godoc.org/builtin#string), force: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+RemoveContainer takes requires the name or ID of container as well a boolean representing whether a running
+container can be stopped and removed.  Upon sucessful removal of the container, its ID is returned.  If the
+container cannot be found by name or ID, an [ContainerNotFound](#ContainerNotFound) error will be returned.
+#### Error
+~~~
+$ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.RemoveContainer '{"name": "62f4fd98cb57"}'
+{
+  "container": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
+}
+~~~
+### <a name="CreateImage"></a>func CreateImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method CreateImage() [NotImplemented](#NotImplemented)</div>
+This function is not implemented yet.
+### <a name="InspectImage"></a>func InspectImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method InspectImage(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+InspectImage takes the name or ID of an image and returns a string respresentation of data associated with the
+mage.  You must serialize the string into JSON to use it further.  An [ImageNotFound](#ImageNotFound) error will
+be returned if the image cannot be found.
+### <a name="HistoryImage"></a>func HistoryImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method HistoryImage(name: [string](https://godoc.org/builtin#string)) [ImageHistory](#ImageHistory)</div>
+HistoryImage takes the name or ID of an image and returns information about its history and layers.  The returned
+history is in the form of an array of ImageHistory structures.  If the image cannot be found, an
+[ImageNotFound](#ImageNotFound) error is returned.
+### <a name="ExportContainer"></a>func ExportContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ExportContainer(name: [string](https://godoc.org/builtin#string), path: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+ExportContainer creates an image from a container.  It takes the name or ID of a container and a
+path representing the target tarfile.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+error will be returned.
+The return value is the written tarfile.
+### <a name="WaitContainer"></a>func WaitContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method WaitContainer(name: [string](https://godoc.org/builtin#string)) [int](https://godoc.org/builtin#int)</div>
+WaitContainer takes the name of ID of a container and waits until the container stops.  Upon stopping, the return
+code of the container is returned. If the container container cannot be found by ID or name,
+a [ContainerNotFound](#ContainerNotFound) error is returned.
+### <a name="ImportImage"></a>func ImportImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ImportImage(source: [string](https://godoc.org/builtin#string), reference: [string](https://godoc.org/builtin#string), message: [string](https://godoc.org/builtin#string), changes: [[]string](#[]string)) [string](https://godoc.org/builtin#string)</div>
+ImportImage imports an image from a source (like tarball) into local storage.  The image can have additional
+descriptions added to it using the message and changes options. See also [ExportImage](ExportImage).
+### <a name="PullImage"></a>func PullImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method PullImage(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+PullImage pulls an image from a repository to local storage.  After the pull is successful, the ID of the image
+is returned.
+#### Example
+~~~
+$ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.PullImage '{"name": "registry.fedoraproject.org/fedora"}'
+{
+  "id": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
+}
+~~~
+### <a name="DeleteStoppedContainers"></a>func DeleteStoppedContainers
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method DeleteStoppedContainers() [[]string](#[]string)</div>
+DeleteStoppedContainers will delete all containers that are not running. It will return a list the deleted
+container IDs.  See also [RemoveContainer](RemoveContainer).
+### <a name="ListContainerProcesses"></a>func ListContainerProcesses
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ListContainerProcesses(name: [string](https://godoc.org/builtin#string), opts: [[]string](#[]string)) [[]string](#[]string)</div>
+ListContainerProcesses takes a name or ID of a container and returns the processes
+running inside the container as array of strings.  It will accept an array of string
+arguements that represent ps options.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+error will be returned.
+#### Example
+~~~
+$ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.ListContainerProcesses '{"name": "135d71b9495f", "opts": []}'
+{
+  "container": [
+    "  UID   PID  PPID  C STIME TTY          TIME CMD",
+    "    0 21220 21210  0 09:05 pts/0    00:00:00 /bin/sh",
+    "    0 21232 21220  0 09:05 pts/0    00:00:00 top",
+    "    0 21284 21220  0 09:05 pts/0    00:00:00 vi /etc/hosts"
+  ]
+}
+~~~
+### <a name="GetContainerStats"></a>func GetContainerStats
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method GetContainerStats(name: [string](https://godoc.org/builtin#string)) [ContainerStats](#ContainerStats)</div>
+GetContainerStats takes the name or ID of a container and returns a single ContainerStats structure which
+contains attributes like memory and cpu usage.  If the container cannot be found, a
+[ContainerNotFound](#ContainerNotFound)  error will be returned.
+#### Example
+~~~
+$ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.GetContainerStats '{"name": "c33e4164f384"}'
+{
+  "container": {
+    "block_input": 0,
+    "block_output": 0,
+    "cpu": 2.571123918839990154678e-08,
+    "cpu_nano": 49037378,
+    "id": "c33e4164f384aa9d979072a63319d66b74fd7a128be71fa68ede24f33ec6cfee",
+    "mem_limit": 33080606720,
+    "mem_perc": 2.166828456524753747370e-03,
+    "mem_usage": 716800,
+    "name": "competent_wozniak",
+    "net_input": 768,
+    "net_output": 5910,
+    "pids": 1,
+    "system_nano": 10000000
+  }
+}
+~~~
+### <a name="PauseContainer"></a>func PauseContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method PauseContainer(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+PauseContainer takes the name or ID of container and pauses it.  If the container cannot be found,
+a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
+See also [UnpauseContainer](UnpauseContainer).
+## Types
+### <a name="ContainerMount"></a>type ContainerMount
+
+ContainerMount describes the struct for mounts in a container
+
+destination [string](https://godoc.org/builtin#string)
+
+type [string](https://godoc.org/builtin#string)
+
+source [string](https://godoc.org/builtin#string)
+
+options [[]string](#[]string)
+### <a name="ImageHistory"></a>type ImageHistory
+
+ImageHistory describes the returned structure from ImageHistory.
+
+id [string](https://godoc.org/builtin#string)
+
+created [string](https://godoc.org/builtin#string)
+
+createdBy [string](https://godoc.org/builtin#string)
+
+tags [[]string](#[]string)
+
+size [int](https://godoc.org/builtin#int)
+
+comment [string](https://godoc.org/builtin#string)
+### <a name="ImageSearch"></a>type ImageSearch
+
+ImageSearch is the returned structure for SearchImage.  It is returned
+in arrary form.
+
+description [string](https://godoc.org/builtin#string)
+
+is_official [bool](https://godoc.org/builtin#bool)
+
+is_automated [bool](https://godoc.org/builtin#bool)
+
+name [string](https://godoc.org/builtin#string)
+
+star_count [int](https://godoc.org/builtin#int)
+### <a name="StringResponse"></a>type StringResponse
+
+
+
+message [string](https://godoc.org/builtin#string)
+### <a name="ContainerChanges"></a>type ContainerChanges
+
+ContainerChanges describes the return struct for ListContainerChanges
+
+changed [[]string](#[]string)
+
+added [[]string](#[]string)
+
+deleted [[]string](#[]string)
+### <a name="ImageInList"></a>type ImageInList
+
+ImageInList describes the structure that is returned in
+ListImages.
+
+id [string](https://godoc.org/builtin#string)
+
+parentId [string](https://godoc.org/builtin#string)
+
+repoTags [[]string](#[]string)
+
+repoDigests [[]string](#[]string)
+
+created [string](https://godoc.org/builtin#string)
+
+size [int](https://godoc.org/builtin#int)
+
+virtualSize [int](https://godoc.org/builtin#int)
+
+containers [int](https://godoc.org/builtin#int)
+
+labels [map[string]](#map[string])
+### <a name="ListContainerData"></a>type ListContainerData
+
+ListContainer is the returned struct for an individual container
+
+id [string](https://godoc.org/builtin#string)
+
+image [string](https://godoc.org/builtin#string)
+
+imageid [string](https://godoc.org/builtin#string)
+
+command [[]string](#[]string)
+
+createdat [string](https://godoc.org/builtin#string)
+
+runningfor [string](https://godoc.org/builtin#string)
+
+status [string](https://godoc.org/builtin#string)
+
+ports [ContainerPortMappings](#ContainerPortMappings)
+
+rootfssize [int](https://godoc.org/builtin#int)
+
+rwsize [int](https://godoc.org/builtin#int)
+
+names [string](https://godoc.org/builtin#string)
+
+labels [map[string]](#map[string])
+
+mounts [ContainerMount](#ContainerMount)
+
+containerrunning [bool](https://godoc.org/builtin#bool)
+
+namespaces [ContainerNameSpace](#ContainerNameSpace)
+### <a name="ContainerStats"></a>type ContainerStats
+
+ContainerStats is the return struct for the stats of a container
+
+id [string](https://godoc.org/builtin#string)
+
+name [string](https://godoc.org/builtin#string)
+
+cpu [float](https://golang.org/src/builtin/builtin.go#L58)
+
+cpu_nano [int](https://godoc.org/builtin#int)
+
+system_nano [int](https://godoc.org/builtin#int)
+
+mem_usage [int](https://godoc.org/builtin#int)
+
+mem_limit [int](https://godoc.org/builtin#int)
+
+mem_perc [float](https://golang.org/src/builtin/builtin.go#L58)
+
+net_input [int](https://godoc.org/builtin#int)
+
+net_output [int](https://godoc.org/builtin#int)
+
+block_output [int](https://godoc.org/builtin#int)
+
+block_input [int](https://godoc.org/builtin#int)
+
+pids [int](https://godoc.org/builtin#int)
+### <a name="ContainerPortMappings"></a>type ContainerPortMappings
+
+ContainerPortMappings describes the struct for portmappings in an existing container
+
+host_port [string](https://godoc.org/builtin#string)
+
+host_ip [string](https://godoc.org/builtin#string)
+
+protocol [string](https://godoc.org/builtin#string)
+
+container_port [string](https://godoc.org/builtin#string)
+### <a name="Version"></a>type Version
+
+Version is the structure returned by GetVersion
+
+version [string](https://godoc.org/builtin#string)
+
+go_version [string](https://godoc.org/builtin#string)
+
+git_commit [string](https://godoc.org/builtin#string)
+
+built [int](https://godoc.org/builtin#int)
+
+os_arch [string](https://godoc.org/builtin#string)
+### <a name="NotImplemented"></a>type NotImplemented
+
+
+
+comment [string](https://godoc.org/builtin#string)
+### <a name="ContainerNameSpace"></a>type ContainerNameSpace
+
+ContainerNamespace describes the namespace structure for an existing container
+
+user [string](https://godoc.org/builtin#string)
+
+uts [string](https://godoc.org/builtin#string)
+
+pidns [string](https://godoc.org/builtin#string)
+
+pid [string](https://godoc.org/builtin#string)
+
+cgroup [string](https://godoc.org/builtin#string)
+
+net [string](https://godoc.org/builtin#string)
+
+mnt [string](https://godoc.org/builtin#string)
+
+ipc [string](https://godoc.org/builtin#string)
+## Errors
+### <a name="ErrorOccurred"></a>type ErrorOccurred
+
+ErrorOccurred is a generic error for an error that occurs during the execution.  The actual error message
+is includes as part of the error's text.
+### <a name="RuntimeError"></a>type RuntimeError
+
+RuntimeErrors generally means a runtime could not be found or gotten.
+### <a name="ImageNotFound"></a>type ImageNotFound
+
+ImageNotFound means the image could not be found by the provided name or ID in local storage.
+### <a name="ContainerNotFound"></a>type ContainerNotFound
+
+ContainerNotFound means the container could not be found by the provided name or ID in local storage.

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test/copyimg/copyimg: .gopathok $(wildcard test/copyimg/*.go)
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/test/checkseccomp
 
-podman: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/podman $(PROJECT)) varlink_generate
+podman: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/podman $(PROJECT)) varlink_generate varlink_api_generate
 	$(GO) build -i $(LDFLAGS_PODMAN) -tags "$(BUILDTAGS)" -o bin/$@ $(PROJECT)/cmd/podman
 
 clean:
@@ -251,6 +251,7 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man
 	fi
 
 varlink_generate: .gopathok cmd/podman/varlink/ioprojectatomicpodman.go
+varlink_api_generate: .gopathok API.md
 
 .PHONY: install.libseccomp.sudo
 install.libseccomp.sudo:
@@ -261,6 +262,9 @@ install.libseccomp.sudo:
 
 cmd/podman/varlink/ioprojectatomicpodman.go: cmd/podman/varlink/io.projectatomic.podman.varlink
 	$(GO) generate ./cmd/podman/varlink/...
+
+API.md: cmd/podman/varlink/io.projectatomic.podman.varlink
+	$(GO) generate ./docs/...
 
 validate: gofmt .gitvalidation
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ showing the commands in use.
 Useful information for ops and dev transfer as it relates to infrastructure that utilizes Podman.  This page
 includes tables showing Docker commands and their Podman equivalent commands.
 
+**[Podman API](/API.md)**
+Documentation on the Podman API using varlink.
+
 **[Tutorials](docs/tutorials)**
 Tutorials on the Podman utility.
 

--- a/cmd/podman/varlink/io.projectatomic.podman.varlink
+++ b/cmd/podman/varlink/io.projectatomic.podman.varlink
@@ -18,6 +18,12 @@ type NotImplemented (
 type StringResponse (
     message: string
 )
+# ContainerChanges describes the return struct for ListContainerChanges
+type ContainerChanges (
+   changed: []string,
+   added: []string,
+   deleted: []string
+)
 
 # ImageInList describes the structure that is returned in
 # ListImages.
@@ -117,54 +123,254 @@ type ContainerNameSpace (
     ipc: string
 )
 
-# System
+# Ping provides a response for developers to ensure their varlink setup is working.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.Ping
+# {
+#   "ping": {
+#     "message": "OK"
+#   }
+# }
+# ~~~
 method Ping() -> (ping: StringResponse)
+
+# GetVersion returns a Version structure describing the libpod setup on their
+# system.
 method GetVersion() -> (version: Version)
 
-# Containers
+
+# ListContainers returns a list of containers in no particular order.  There are
+# returned as an array of ListContainerData structs.  See also [GetContainer](#GetContainer).
 method ListContainers() -> (containers: []ListContainerData)
+
+# GetContainer takes a name or ID of a container and returns single ListContainerData
+# structure.  A [ContainerNotFound](#ContainerNotFound) error will be returned if the container cannot be found.
+# See also [ListContainers](ListContainers) and [InspectContainer](InspectContainer).
 method GetContainer(name: string) -> (container: ListContainerData)
+
+# This method has not been implemented yet.
 method CreateContainer() -> (notimplemented: NotImplemented)
+
+# InspectContainer data takes a name or ID of a container returns the inspection
+# data in string format.  You can then serialize the string into JSON.  A [ContainerNotFound](#ContainerNotFound)
+# error will be returned if the container cannot be found. See also [InspectImage](#InspectImage).
 method InspectContainer(name: string) -> (container: string)
+
+# ListContainerProcesses takes a name or ID of a container and returns the processes
+# running inside the container as array of strings.  It will accept an array of string
+# arguements that represent ps options.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+# error will be returned.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.ListContainerProcesses '{"name": "135d71b9495f", "opts": []}'
+# {
+#   "container": [
+#     "  UID   PID  PPID  C STIME TTY          TIME CMD",
+#     "    0 21220 21210  0 09:05 pts/0    00:00:00 /bin/sh",
+#     "    0 21232 21220  0 09:05 pts/0    00:00:00 top",
+#     "    0 21284 21220  0 09:05 pts/0    00:00:00 vi /etc/hosts"
+#   ]
+# }
+# ~~~
 method ListContainerProcesses(name: string, opts: []string) -> (container: []string)
+
+# GetContainerLogs takes a name or ID of a container and returns the logs of that container.
+# If the container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+# The container logs are returned as an array of strings.  GetContainerLogs will honor the streaming
+# capability of varlink if the client invokes it.
 method GetContainerLogs(name: string) -> (container: []string)
-method ListContainerChanges(name: string) -> (container: [string]string)
+
+# ListContainerChanges takes a name or ID of a container and returns changes between the container and
+# its base image. It returns a struct of changed, deleted, and added path names. If the
+# container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+method ListContainerChanges(name: string) -> (container: ContainerChanges)
+
+# ExportContainer creates an image from a container.  It takes the name or ID of a container and a
+# path representing the target tarfile.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+# error will be returned.
+# The return value is the written tarfile.
 method ExportContainer(name: string, path: string) -> (tarfile: string)
+
+# GetContainerStats takes the name or ID of a container and returns a single ContainerStats structure which
+# contains attributes like memory and cpu usage.  If the container cannot be found, a
+# [ContainerNotFound](#ContainerNotFound)  error will be returned.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.GetContainerStats '{"name": "c33e4164f384"}'
+# {
+#   "container": {
+#     "block_input": 0,
+#     "block_output": 0,
+#     "cpu": 2.571123918839990154678e-08,
+#     "cpu_nano": 49037378,
+#     "id": "c33e4164f384aa9d979072a63319d66b74fd7a128be71fa68ede24f33ec6cfee",
+#     "mem_limit": 33080606720,
+#     "mem_perc": 2.166828456524753747370e-03,
+#     "mem_usage": 716800,
+#     "name": "competent_wozniak",
+#     "net_input": 768,
+#     "net_output": 5910,
+#     "pids": 1,
+#     "system_nano": 10000000
+#   }
+# }
+# ~~~
 method GetContainerStats(name: string) -> (container: ContainerStats)
+
+# This method has not be implemented yet.
 method ResizeContainerTty() -> (notimplemented: NotImplemented)
+
+# This method has not be implemented yet.
 method StartContainer() -> (notimplemented: NotImplemented)
+
+# StopContainer stops a container given a timeout.  It takes the name or ID of a container as well as a
+# timeout value.  The timeout value the time before a forceable stop to the container is applied.  It
+# returns the container ID once stopped. If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+# error will be returned instead. See also [KillContainer](KillContainer).
+# #### Error
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.StopContainer '{"name": "135d71b9495f", "timeout": 5}'
+# {
+#   "container": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+# }
+# ~~~
 method StopContainer(name: string, timeout: int) -> (container: string)
+
+# RestartContainer will restart a running container given a container name or ID and timeout value. The timeout
+# value is the time before a forceable stop is used to stop the container.  If the container cannot be found by
+# name or ID, a [ContainerNotFound](#ContainerNotFound)  error will be returned; otherwise, the ID of the
+# container will be returned.
 method RestartContainer(name: string, timeout: int) -> (container: string)
+
+# KillContainer takes the name or ID of a container as well as a signal to be applied to the container.  Once the
+# container has been killed, the container's ID is returned.  If the container cannot be found, a
+# [ContainerNotFound](#ContainerNotFound) error is returned. See also [StopContainer](StopContainer).
 method KillContainer(name: string, signal: int) -> (container: string)
+
+# This method has not be implemented yet.
 method UpdateContainer() -> (notimplemented: NotImplemented)
+
+# This method has not be implemented yet.
 method RenameContainer() -> (notimplemented: NotImplemented)
+
+# PauseContainer takes the name or ID of container and pauses it.  If the container cannot be found,
+# a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
+# See also [UnpauseContainer](UnpauseContainer).
 method PauseContainer(name: string) -> (container: string)
+
+# UnpauseContainer takes the name or ID of container and unpauses a paused container.  If the container cannot be
+# found, a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
+# See also [PauseContainer](PauseContainer).
 method UnpauseContainer(name: string) -> (container: string)
+
+# This method has not be implemented yet.
 method AttachToContainer() -> (notimplemented: NotImplemented)
+
+# WaitContainer takes the name of ID of a container and waits until the container stops.  Upon stopping, the return
+# code of the container is returned. If the container container cannot be found by ID or name,
+# a [ContainerNotFound](#ContainerNotFound) error is returned.
 method WaitContainer(name: string) -> (exitcode: int)
+
+# RemoveContainer takes requires the name or ID of container as well a boolean representing whether a running
+# container can be stopped and removed.  Upon sucessful removal of the container, its ID is returned.  If the
+# container cannot be found by name or ID, an [ContainerNotFound](#ContainerNotFound) error will be returned.
+# #### Error
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.RemoveContainer '{"name": "62f4fd98cb57"}'
+# {
+#   "container": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
+# }
+# ~~~
 method RemoveContainer(name: string, force: bool) -> (container: string)
+
+# DeleteStoppedContainers will delete all containers that are not running. It will return a list the deleted
+# container IDs.  See also [RemoveContainer](RemoveContainer).
 method DeleteStoppedContainers() -> (containers: []string)
 
-# Images
+# ListImages returns an array of ImageInList structures which provide basic information about
+# an image currenly in storage.  See also [InspectImage](InspectImage).
 method ListImages() -> (images: []ImageInList)
+
+# This function is not implemented yet.
 method BuildImage() -> (notimplemented: NotImplemented)
+
+# This function is not implemented yet.
 method CreateImage() -> (notimplemented: NotImplemented)
+
+# InspectImage takes the name or ID of an image and returns a string respresentation of data associated with the
+#image.  You must serialize the string into JSON to use it further.  An [ImageNotFound](#ImageNotFound) error will
+# be returned if the image cannot be found.
 method InspectImage(name: string) -> (image: string)
+
+# HistoryImage takes the name or ID of an image and returns information about its history and layers.  The returned
+# history is in the form of an array of ImageHistory structures.  If the image cannot be found, an
+# [ImageNotFound](#ImageNotFound) error is returned.
 method HistoryImage(name: string) -> (history: []ImageHistory)
-method PushImage(name: string, tag: string, tlsverify: bool) -> ()
-method TagImage(name: string, tagged: string) -> ()
+
+# PushImage takes three input arguments: the name or ID of an image, the fully-qualified destination name of the image,
+# and a boolean as to whether tls-verify should be used.  It will return an [ImageNotFound](#ImageNotFound) error if
+# the image cannot be found in local storage; otherwise the ID of the image will be returned on success.
+method PushImage(name: string, tag: string, tlsverify: bool) -> (image: string)
+
+# TagImage takes the name or ID of an image in local storage as well as the desired tag name.  If the image cannot
+# be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
+method TagImage(name: string, tagged: string) -> (image: string)
+
+# RemoveImage takes the name or ID of an image as well as a booleon that determines if containers using that image
+# should be deleted.  If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned.  The
+# ID of the removed image is returned when complete.  See also [DeleteUnusedImages](DeleteUnusedImages).
+# #### Example
+# ~~~
+# varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.RemoveImage '{"name": "registry.fedoraproject.org/fedora", "force": true}'
+# {
+#   "image": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
+# }
+# ~~~
 method RemoveImage(name: string, force: bool) -> (image: string)
+
+# SearchImage takes the string of an image name and a limit of searches from each registries to be returned.  SearchImage
+# will then use a glob-like match to find the image you are searching for.  The images are returned in an array of
+# ImageSearch structures which contain information about the image as well as its fully-qualified name.
 method SearchImage(name: string, limit: int) -> (images: []ImageSearch)
+
+# DeleteUnusedImages deletes any images not associated with a container.  The IDs of the deleted images are returned
+# in a string array.
 method DeleteUnusedImages() -> (images: []string)
+
+# This method is not implemented.
 method CreateFromContainer() -> (notimplemented: NotImplemented)
+
+# ImportImage imports an image from a source (like tarball) into local storage.  The image can have additional
+# descriptions added to it using the message and changes options. See also [ExportImage](ExportImage).
 method ImportImage(source: string, reference: string, message: string, changes: []string) -> (image: string)
-method ExportImage(name: string, destination: string, compress: bool) -> ()
+
+# ExportImage takes the name or ID of an image and exports it to a destination like a tarball.  There is also
+# a booleon option to force compression.  Upon completion, the ID of the image is returned. If the image cannot
+# be found in local storage, an [ImageNotFound](#ImageNotFound) error will be returned. See also [ImportImage](ImportImage).
+method ExportImage(name: string, destination: string, compress: bool) -> (image: string)
+
+# PullImage pulls an image from a repository to local storage.  After the pull is successful, the ID of the image
+# is returned.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.PullImage '{"name": "registry.fedoraproject.org/fedora"}'
+# {
+#   "id": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
+# }
+# ~~~
 method PullImage(name: string) -> (id: string)
 
 
-# Something failed
-error ActionFailed (reason: string)
+# ImageNotFound means the image could not be found by the provided name or ID in local storage.
 error ImageNotFound (name: string)
+
+# ContainerNotFound means the container could not be found by the provided name or ID in local storage.
 error ContainerNotFound (name: string)
+
+# ErrorOccurred is a generic error for an error that occurs during the execution.  The actual error message
+# is includes as part of the error's text.
 error ErrorOccurred (reason: string)
+
+# RuntimeErrors generally means a runtime could not be found or gotten.
 error RuntimeError (reason: string)

--- a/cmd/podman/varlink/ioprojectatomicpodman.go
+++ b/cmd/podman/varlink/ioprojectatomicpodman.go
@@ -4,36 +4,19 @@ package ioprojectatomicpodman
 import "github.com/varlink/go/varlink"
 
 // Type declarations
-type Version struct {
-	Version    string `json:"version"`
-	Go_version string `json:"go_version"`
-	Git_commit string `json:"git_commit"`
-	Built      int64  `json:"built"`
-	Os_arch    string `json:"os_arch"`
+type ImageSearch struct {
+	Description  string `json:"description"`
+	Is_official  bool   `json:"is_official"`
+	Is_automated bool   `json:"is_automated"`
+	Name         string `json:"name"`
+	Star_count   int64  `json:"star_count"`
 }
 
-type NotImplemented struct {
-	Comment string `json:"comment"`
-}
-
-type StringResponse struct {
-	Message string `json:"message"`
-}
-
-type ContainerStats struct {
-	Id           string  `json:"id"`
-	Name         string  `json:"name"`
-	Cpu          float64 `json:"cpu"`
-	Cpu_nano     int64   `json:"cpu_nano"`
-	System_nano  int64   `json:"system_nano"`
-	Mem_usage    int64   `json:"mem_usage"`
-	Mem_limit    int64   `json:"mem_limit"`
-	Mem_perc     float64 `json:"mem_perc"`
-	Net_input    int64   `json:"net_input"`
-	Net_output   int64   `json:"net_output"`
-	Block_output int64   `json:"block_output"`
-	Block_input  int64   `json:"block_input"`
-	Pids         int64   `json:"pids"`
+type ContainerMount struct {
+	Destination string   `json:"destination"`
+	Type        string   `json:"type"`
+	Source      string   `json:"source"`
+	Options     []string `json:"options"`
 }
 
 type ContainerPortMappings struct {
@@ -43,16 +26,15 @@ type ContainerPortMappings struct {
 	Container_port string `json:"container_port"`
 }
 
-type ImageInList struct {
-	Id          string            `json:"id"`
-	ParentId    string            `json:"parentId"`
-	RepoTags    []string          `json:"repoTags"`
-	RepoDigests []string          `json:"repoDigests"`
-	Created     string            `json:"created"`
-	Size        int64             `json:"size"`
-	VirtualSize int64             `json:"virtualSize"`
-	Containers  int64             `json:"containers"`
-	Labels      map[string]string `json:"labels"`
+type ContainerNameSpace struct {
+	User   string `json:"user"`
+	Uts    string `json:"uts"`
+	Pidns  string `json:"pidns"`
+	Pid    string `json:"pid"`
+	Cgroup string `json:"cgroup"`
+	Net    string `json:"net"`
+	Mnt    string `json:"mnt"`
+	Ipc    string `json:"ipc"`
 }
 
 type ImageHistory struct {
@@ -62,14 +44,6 @@ type ImageHistory struct {
 	Tags      []string `json:"tags"`
 	Size      int64    `json:"size"`
 	Comment   string   `json:"comment"`
-}
-
-type ImageSearch struct {
-	Description  string `json:"description"`
-	Is_official  bool   `json:"is_official"`
-	Is_automated bool   `json:"is_automated"`
-	Name         string `json:"name"`
-	Star_count   int64  `json:"star_count"`
 }
 
 type ListContainerData struct {
@@ -90,1350 +64,1934 @@ type ListContainerData struct {
 	Namespaces       ContainerNameSpace      `json:"namespaces"`
 }
 
-type ContainerMount struct {
-	Destination string   `json:"destination"`
-	Type        string   `json:"type"`
-	Source      string   `json:"source"`
-	Options     []string `json:"options"`
+type ContainerStats struct {
+	Id           string  `json:"id"`
+	Name         string  `json:"name"`
+	Cpu          float64 `json:"cpu"`
+	Cpu_nano     int64   `json:"cpu_nano"`
+	System_nano  int64   `json:"system_nano"`
+	Mem_usage    int64   `json:"mem_usage"`
+	Mem_limit    int64   `json:"mem_limit"`
+	Mem_perc     float64 `json:"mem_perc"`
+	Net_input    int64   `json:"net_input"`
+	Net_output   int64   `json:"net_output"`
+	Block_output int64   `json:"block_output"`
+	Block_input  int64   `json:"block_input"`
+	Pids         int64   `json:"pids"`
 }
 
-type ContainerNameSpace struct {
-	User   string `json:"user"`
-	Uts    string `json:"uts"`
-	Pidns  string `json:"pidns"`
-	Pid    string `json:"pid"`
-	Cgroup string `json:"cgroup"`
-	Net    string `json:"net"`
-	Mnt    string `json:"mnt"`
-	Ipc    string `json:"ipc"`
+type Version struct {
+	Version    string `json:"version"`
+	Go_version string `json:"go_version"`
+	Git_commit string `json:"git_commit"`
+	Built      int64  `json:"built"`
+	Os_arch    string `json:"os_arch"`
 }
 
-// Client method calls and reply readers
-func HistoryImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+type NotImplemented struct {
+	Comment string `json:"comment"`
+}
+
+type StringResponse struct {
+	Message string `json:"message"`
+}
+
+type ContainerChanges struct {
+	Changed []string `json:"changed"`
+	Added   []string `json:"added"`
+	Deleted []string `json:"deleted"`
+}
+
+type ImageInList struct {
+	Id          string            `json:"id"`
+	ParentId    string            `json:"parentId"`
+	RepoTags    []string          `json:"repoTags"`
+	RepoDigests []string          `json:"repoDigests"`
+	Created     string            `json:"created"`
+	Size        int64             `json:"size"`
+	VirtualSize int64             `json:"virtualSize"`
+	Containers  int64             `json:"containers"`
+	Labels      map[string]string `json:"labels"`
+}
+
+// Client method calls
+type SearchImage_methods struct{}
+
+func SearchImage() SearchImage_methods { return SearchImage_methods{} }
+
+func (m SearchImage_methods) Call(c *varlink.Connection, name_in_ string, limit_in_ int64) (images_out_ []ImageSearch, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, limit_in_)
+	if err_ != nil {
+		return
+	}
+	images_out_, _, err_ = receive()
+	return
+}
+
+func (m SearchImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, limit_in_ int64) (func() ([]ImageSearch, uint64, error), error) {
+	var in struct {
+		Name  string `json:"name"`
+		Limit int64  `json:"limit"`
+	}
+	in.Name = name_in_
+	in.Limit = limit_in_
+	receive, err := c.Send("io.projectatomic.podman.SearchImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (images_out_ []ImageSearch, flags uint64, err error) {
+		var out struct {
+			Images []ImageSearch `json:"images"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		images_out_ = []ImageSearch(out.Images)
+		return
+	}, nil
+}
+
+type DeleteUnusedImages_methods struct{}
+
+func DeleteUnusedImages() DeleteUnusedImages_methods { return DeleteUnusedImages_methods{} }
+
+func (m DeleteUnusedImages_methods) Call(c *varlink.Connection) (images_out_ []string, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	images_out_, _, err_ = receive()
+	return
+}
+
+func (m DeleteUnusedImages_methods) Send(c *varlink.Connection, flags uint64) (func() ([]string, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.DeleteUnusedImages", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (images_out_ []string, flags uint64, err error) {
+		var out struct {
+			Images []string `json:"images"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		images_out_ = []string(out.Images)
+		return
+	}, nil
+}
+
+type Ping_methods struct{}
+
+func Ping() Ping_methods { return Ping_methods{} }
+
+func (m Ping_methods) Call(c *varlink.Connection) (ping_out_ StringResponse, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	ping_out_, _, err_ = receive()
+	return
+}
+
+func (m Ping_methods) Send(c *varlink.Connection, flags uint64) (func() (StringResponse, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.Ping", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (ping_out_ StringResponse, flags uint64, err error) {
+		var out struct {
+			Ping StringResponse `json:"ping"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		ping_out_ = out.Ping
+		return
+	}, nil
+}
+
+type InspectContainer_methods struct{}
+
+func InspectContainer() InspectContainer_methods { return InspectContainer_methods{} }
+
+func (m InspectContainer_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m InspectContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (string, uint64, error), error) {
 	var in struct {
 		Name string `json:"name"`
 	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.HistoryImage", in, more__, oneway__)
-}
-
-func ReadHistoryImage_(c__ *varlink.Connection, history_ *[]ImageHistory) (bool, error) {
-	var out struct {
-		History []ImageHistory `json:"history"`
-	}
-	continues_, err := c__.Receive(&out)
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.InspectContainer", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if history_ != nil {
-		*history_ = []ImageHistory(out.History)
-	}
-	return continues_, nil
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
 }
 
-func TagImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, tagged_ string) error {
+type GetContainerLogs_methods struct{}
+
+func GetContainerLogs() GetContainerLogs_methods { return GetContainerLogs_methods{} }
+
+func (m GetContainerLogs_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ []string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m GetContainerLogs_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() ([]string, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.GetContainerLogs", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ []string, flags uint64, err error) {
+		var out struct {
+			Container []string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = []string(out.Container)
+		return
+	}, nil
+}
+
+type ListContainerChanges_methods struct{}
+
+func ListContainerChanges() ListContainerChanges_methods { return ListContainerChanges_methods{} }
+
+func (m ListContainerChanges_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ ContainerChanges, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m ListContainerChanges_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (ContainerChanges, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.ListContainerChanges", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ ContainerChanges, flags uint64, err error) {
+		var out struct {
+			Container ContainerChanges `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
+}
+
+type KillContainer_methods struct{}
+
+func KillContainer() KillContainer_methods { return KillContainer_methods{} }
+
+func (m KillContainer_methods) Call(c *varlink.Connection, name_in_ string, signal_in_ int64) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, signal_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m KillContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, signal_in_ int64) (func() (string, uint64, error), error) {
 	var in struct {
 		Name   string `json:"name"`
-		Tagged string `json:"tagged"`
+		Signal int64  `json:"signal"`
 	}
-	in.Name = name_
-	in.Tagged = tagged_
-	return c__.Send("io.projectatomic.podman.TagImage", in, more__, oneway__)
-}
-
-func ReadTagImage_(c__ *varlink.Connection) (bool, error) {
-	continues_, err := c__.Receive(nil)
+	in.Name = name_in_
+	in.Signal = signal_in_
+	receive, err := c.Send("io.projectatomic.podman.KillContainer", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return continues_, nil
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
 }
 
-func ExportContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, path_ string) error {
-	var in struct {
-		Name string `json:"name"`
-		Path string `json:"path"`
+type RemoveContainer_methods struct{}
+
+func RemoveContainer() RemoveContainer_methods { return RemoveContainer_methods{} }
+
+func (m RemoveContainer_methods) Call(c *varlink.Connection, name_in_ string, force_in_ bool) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, force_in_)
+	if err_ != nil {
+		return
 	}
-	in.Name = name_
-	in.Path = path_
-	return c__.Send("io.projectatomic.podman.ExportContainer", in, more__, oneway__)
+	container_out_, _, err_ = receive()
+	return
 }
 
-func ReadExportContainer_(c__ *varlink.Connection, tarfile_ *string) (bool, error) {
-	var out struct {
-		Tarfile string `json:"tarfile"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if tarfile_ != nil {
-		*tarfile_ = out.Tarfile
-	}
-	return continues_, nil
-}
-
-func RestartContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, timeout_ int64) error {
-	var in struct {
-		Name    string `json:"name"`
-		Timeout int64  `json:"timeout"`
-	}
-	in.Name = name_
-	in.Timeout = timeout_
-	return c__.Send("io.projectatomic.podman.RestartContainer", in, more__, oneway__)
-}
-
-func ReadRestartContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func ListImages(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ListImages", nil, more__, oneway__)
-}
-
-func ReadListImages_(c__ *varlink.Connection, images_ *[]ImageInList) (bool, error) {
-	var out struct {
-		Images []ImageInList `json:"images"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if images_ != nil {
-		*images_ = []ImageInList(out.Images)
-	}
-	return continues_, nil
-}
-
-func PullImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.PullImage", in, more__, oneway__)
-}
-
-func ReadPullImage_(c__ *varlink.Connection, id_ *string) (bool, error) {
-	var out struct {
-		Id string `json:"id"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if id_ != nil {
-		*id_ = out.Id
-	}
-	return continues_, nil
-}
-
-func PauseContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.PauseContainer", in, more__, oneway__)
-}
-
-func ReadPauseContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func WaitContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.WaitContainer", in, more__, oneway__)
-}
-
-func ReadWaitContainer_(c__ *varlink.Connection, exitcode_ *int64) (bool, error) {
-	var out struct {
-		Exitcode int64 `json:"exitcode"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if exitcode_ != nil {
-		*exitcode_ = out.Exitcode
-	}
-	return continues_, nil
-}
-
-func StartContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.StartContainer", nil, more__, oneway__)
-}
-
-func ReadStartContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func AttachToContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.AttachToContainer", nil, more__, oneway__)
-}
-
-func ReadAttachToContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func ListContainerProcesses(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, opts_ []string) error {
-	var in struct {
-		Name string   `json:"name"`
-		Opts []string `json:"opts"`
-	}
-	in.Name = name_
-	in.Opts = []string(opts_)
-	return c__.Send("io.projectatomic.podman.ListContainerProcesses", in, more__, oneway__)
-}
-
-func ReadListContainerProcesses_(c__ *varlink.Connection, container_ *[]string) (bool, error) {
-	var out struct {
-		Container []string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = []string(out.Container)
-	}
-	return continues_, nil
-}
-
-func ListContainerChanges(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.ListContainerChanges", in, more__, oneway__)
-}
-
-func ReadListContainerChanges_(c__ *varlink.Connection, container_ *map[string]string) (bool, error) {
-	var out struct {
-		Container map[string]string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = map[string]string(out.Container)
-	}
-	return continues_, nil
-}
-
-func RemoveImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, force_ bool) error {
+func (m RemoveContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, force_in_ bool) (func() (string, uint64, error), error) {
 	var in struct {
 		Name  string `json:"name"`
 		Force bool   `json:"force"`
 	}
-	in.Name = name_
-	in.Force = force_
-	return c__.Send("io.projectatomic.podman.RemoveImage", in, more__, oneway__)
-}
-
-func ReadRemoveImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
-	var out struct {
-		Image string `json:"image"`
-	}
-	continues_, err := c__.Receive(&out)
+	in.Name = name_in_
+	in.Force = force_in_
+	receive, err := c.Send("io.projectatomic.podman.RemoveContainer", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if image_ != nil {
-		*image_ = out.Image
-	}
-	return continues_, nil
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
 }
 
-func ImportImage(c__ *varlink.Connection, more__ bool, oneway__ bool, source_ string, reference_ string, message_ string, changes_ []string) error {
+type InspectImage_methods struct{}
+
+func InspectImage() InspectImage_methods { return InspectImage_methods{} }
+
+func (m InspectImage_methods) Call(c *varlink.Connection, name_in_ string) (image_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	image_out_, _, err_ = receive()
+	return
+}
+
+func (m InspectImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (string, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.InspectImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (image_out_ string, flags uint64, err error) {
+		var out struct {
+			Image string `json:"image"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		image_out_ = out.Image
+		return
+	}, nil
+}
+
+type TagImage_methods struct{}
+
+func TagImage() TagImage_methods { return TagImage_methods{} }
+
+func (m TagImage_methods) Call(c *varlink.Connection, name_in_ string, tagged_in_ string) (image_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, tagged_in_)
+	if err_ != nil {
+		return
+	}
+	image_out_, _, err_ = receive()
+	return
+}
+
+func (m TagImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, tagged_in_ string) (func() (string, uint64, error), error) {
+	var in struct {
+		Name   string `json:"name"`
+		Tagged string `json:"tagged"`
+	}
+	in.Name = name_in_
+	in.Tagged = tagged_in_
+	receive, err := c.Send("io.projectatomic.podman.TagImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (image_out_ string, flags uint64, err error) {
+		var out struct {
+			Image string `json:"image"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		image_out_ = out.Image
+		return
+	}, nil
+}
+
+type GetContainerStats_methods struct{}
+
+func GetContainerStats() GetContainerStats_methods { return GetContainerStats_methods{} }
+
+func (m GetContainerStats_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ ContainerStats, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m GetContainerStats_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (ContainerStats, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.GetContainerStats", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ ContainerStats, flags uint64, err error) {
+		var out struct {
+			Container ContainerStats `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
+}
+
+type StopContainer_methods struct{}
+
+func StopContainer() StopContainer_methods { return StopContainer_methods{} }
+
+func (m StopContainer_methods) Call(c *varlink.Connection, name_in_ string, timeout_in_ int64) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, timeout_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m StopContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, timeout_in_ int64) (func() (string, uint64, error), error) {
+	var in struct {
+		Name    string `json:"name"`
+		Timeout int64  `json:"timeout"`
+	}
+	in.Name = name_in_
+	in.Timeout = timeout_in_
+	receive, err := c.Send("io.projectatomic.podman.StopContainer", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
+}
+
+type RestartContainer_methods struct{}
+
+func RestartContainer() RestartContainer_methods { return RestartContainer_methods{} }
+
+func (m RestartContainer_methods) Call(c *varlink.Connection, name_in_ string, timeout_in_ int64) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, timeout_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m RestartContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, timeout_in_ int64) (func() (string, uint64, error), error) {
+	var in struct {
+		Name    string `json:"name"`
+		Timeout int64  `json:"timeout"`
+	}
+	in.Name = name_in_
+	in.Timeout = timeout_in_
+	receive, err := c.Send("io.projectatomic.podman.RestartContainer", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
+}
+
+type UpdateContainer_methods struct{}
+
+func UpdateContainer() UpdateContainer_methods { return UpdateContainer_methods{} }
+
+func (m UpdateContainer_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m UpdateContainer_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.UpdateContainer", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type BuildImage_methods struct{}
+
+func BuildImage() BuildImage_methods { return BuildImage_methods{} }
+
+func (m BuildImage_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m BuildImage_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.BuildImage", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type CreateImage_methods struct{}
+
+func CreateImage() CreateImage_methods { return CreateImage_methods{} }
+
+func (m CreateImage_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m CreateImage_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.CreateImage", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type ListContainers_methods struct{}
+
+func ListContainers() ListContainers_methods { return ListContainers_methods{} }
+
+func (m ListContainers_methods) Call(c *varlink.Connection) (containers_out_ []ListContainerData, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	containers_out_, _, err_ = receive()
+	return
+}
+
+func (m ListContainers_methods) Send(c *varlink.Connection, flags uint64) (func() ([]ListContainerData, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.ListContainers", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (containers_out_ []ListContainerData, flags uint64, err error) {
+		var out struct {
+			Containers []ListContainerData `json:"containers"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		containers_out_ = []ListContainerData(out.Containers)
+		return
+	}, nil
+}
+
+type ExportContainer_methods struct{}
+
+func ExportContainer() ExportContainer_methods { return ExportContainer_methods{} }
+
+func (m ExportContainer_methods) Call(c *varlink.Connection, name_in_ string, path_in_ string) (tarfile_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, path_in_)
+	if err_ != nil {
+		return
+	}
+	tarfile_out_, _, err_ = receive()
+	return
+}
+
+func (m ExportContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, path_in_ string) (func() (string, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+	}
+	in.Name = name_in_
+	in.Path = path_in_
+	receive, err := c.Send("io.projectatomic.podman.ExportContainer", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (tarfile_out_ string, flags uint64, err error) {
+		var out struct {
+			Tarfile string `json:"tarfile"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		tarfile_out_ = out.Tarfile
+		return
+	}, nil
+}
+
+type CreateFromContainer_methods struct{}
+
+func CreateFromContainer() CreateFromContainer_methods { return CreateFromContainer_methods{} }
+
+func (m CreateFromContainer_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m CreateFromContainer_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.CreateFromContainer", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type ExportImage_methods struct{}
+
+func ExportImage() ExportImage_methods { return ExportImage_methods{} }
+
+func (m ExportImage_methods) Call(c *varlink.Connection, name_in_ string, destination_in_ string, compress_in_ bool) (image_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, destination_in_, compress_in_)
+	if err_ != nil {
+		return
+	}
+	image_out_, _, err_ = receive()
+	return
+}
+
+func (m ExportImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, destination_in_ string, compress_in_ bool) (func() (string, uint64, error), error) {
+	var in struct {
+		Name        string `json:"name"`
+		Destination string `json:"destination"`
+		Compress    bool   `json:"compress"`
+	}
+	in.Name = name_in_
+	in.Destination = destination_in_
+	in.Compress = compress_in_
+	receive, err := c.Send("io.projectatomic.podman.ExportImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (image_out_ string, flags uint64, err error) {
+		var out struct {
+			Image string `json:"image"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		image_out_ = out.Image
+		return
+	}, nil
+}
+
+type GetVersion_methods struct{}
+
+func GetVersion() GetVersion_methods { return GetVersion_methods{} }
+
+func (m GetVersion_methods) Call(c *varlink.Connection) (version_out_ Version, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	version_out_, _, err_ = receive()
+	return
+}
+
+func (m GetVersion_methods) Send(c *varlink.Connection, flags uint64) (func() (Version, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.GetVersion", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (version_out_ Version, flags uint64, err error) {
+		var out struct {
+			Version Version `json:"version"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		version_out_ = out.Version
+		return
+	}, nil
+}
+
+type GetContainer_methods struct{}
+
+func GetContainer() GetContainer_methods { return GetContainer_methods{} }
+
+func (m GetContainer_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ ListContainerData, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m GetContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (ListContainerData, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.GetContainer", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ ListContainerData, flags uint64, err error) {
+		var out struct {
+			Container ListContainerData `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
+}
+
+type HistoryImage_methods struct{}
+
+func HistoryImage() HistoryImage_methods { return HistoryImage_methods{} }
+
+func (m HistoryImage_methods) Call(c *varlink.Connection, name_in_ string) (history_out_ []ImageHistory, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	history_out_, _, err_ = receive()
+	return
+}
+
+func (m HistoryImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() ([]ImageHistory, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.HistoryImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (history_out_ []ImageHistory, flags uint64, err error) {
+		var out struct {
+			History []ImageHistory `json:"history"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		history_out_ = []ImageHistory(out.History)
+		return
+	}, nil
+}
+
+type CreateContainer_methods struct{}
+
+func CreateContainer() CreateContainer_methods { return CreateContainer_methods{} }
+
+func (m CreateContainer_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m CreateContainer_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.CreateContainer", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type RenameContainer_methods struct{}
+
+func RenameContainer() RenameContainer_methods { return RenameContainer_methods{} }
+
+func (m RenameContainer_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m RenameContainer_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.RenameContainer", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type PushImage_methods struct{}
+
+func PushImage() PushImage_methods { return PushImage_methods{} }
+
+func (m PushImage_methods) Call(c *varlink.Connection, name_in_ string, tag_in_ string, tlsverify_in_ bool) (image_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, tag_in_, tlsverify_in_)
+	if err_ != nil {
+		return
+	}
+	image_out_, _, err_ = receive()
+	return
+}
+
+func (m PushImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, tag_in_ string, tlsverify_in_ bool) (func() (string, uint64, error), error) {
+	var in struct {
+		Name      string `json:"name"`
+		Tag       string `json:"tag"`
+		Tlsverify bool   `json:"tlsverify"`
+	}
+	in.Name = name_in_
+	in.Tag = tag_in_
+	in.Tlsverify = tlsverify_in_
+	receive, err := c.Send("io.projectatomic.podman.PushImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (image_out_ string, flags uint64, err error) {
+		var out struct {
+			Image string `json:"image"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		image_out_ = out.Image
+		return
+	}, nil
+}
+
+type RemoveImage_methods struct{}
+
+func RemoveImage() RemoveImage_methods { return RemoveImage_methods{} }
+
+func (m RemoveImage_methods) Call(c *varlink.Connection, name_in_ string, force_in_ bool) (image_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, force_in_)
+	if err_ != nil {
+		return
+	}
+	image_out_, _, err_ = receive()
+	return
+}
+
+func (m RemoveImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, force_in_ bool) (func() (string, uint64, error), error) {
+	var in struct {
+		Name  string `json:"name"`
+		Force bool   `json:"force"`
+	}
+	in.Name = name_in_
+	in.Force = force_in_
+	receive, err := c.Send("io.projectatomic.podman.RemoveImage", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (image_out_ string, flags uint64, err error) {
+		var out struct {
+			Image string `json:"image"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		image_out_ = out.Image
+		return
+	}, nil
+}
+
+type PauseContainer_methods struct{}
+
+func PauseContainer() PauseContainer_methods { return PauseContainer_methods{} }
+
+func (m PauseContainer_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m PauseContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (string, uint64, error), error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.PauseContainer", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
+}
+
+type ImportImage_methods struct{}
+
+func ImportImage() ImportImage_methods { return ImportImage_methods{} }
+
+func (m ImportImage_methods) Call(c *varlink.Connection, source_in_ string, reference_in_ string, message_in_ string, changes_in_ []string) (image_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, source_in_, reference_in_, message_in_, changes_in_)
+	if err_ != nil {
+		return
+	}
+	image_out_, _, err_ = receive()
+	return
+}
+
+func (m ImportImage_methods) Send(c *varlink.Connection, flags uint64, source_in_ string, reference_in_ string, message_in_ string, changes_in_ []string) (func() (string, uint64, error), error) {
 	var in struct {
 		Source    string   `json:"source"`
 		Reference string   `json:"reference"`
 		Message   string   `json:"message"`
 		Changes   []string `json:"changes"`
 	}
-	in.Source = source_
-	in.Reference = reference_
-	in.Message = message_
-	in.Changes = []string(changes_)
-	return c__.Send("io.projectatomic.podman.ImportImage", in, more__, oneway__)
-}
-
-func ReadImportImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
-	var out struct {
-		Image string `json:"image"`
-	}
-	continues_, err := c__.Receive(&out)
+	in.Source = source_in_
+	in.Reference = reference_in_
+	in.Message = message_in_
+	in.Changes = []string(changes_in_)
+	receive, err := c.Send("io.projectatomic.podman.ImportImage", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if image_ != nil {
-		*image_ = out.Image
-	}
-	return continues_, nil
+	return func() (image_out_ string, flags uint64, err error) {
+		var out struct {
+			Image string `json:"image"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		image_out_ = out.Image
+		return
+	}, nil
 }
 
-func GetContainerLogs(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+type PullImage_methods struct{}
+
+func PullImage() PullImage_methods { return PullImage_methods{} }
+
+func (m PullImage_methods) Call(c *varlink.Connection, name_in_ string) (id_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	id_out_, _, err_ = receive()
+	return
+}
+
+func (m PullImage_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (string, uint64, error), error) {
 	var in struct {
 		Name string `json:"name"`
 	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.GetContainerLogs", in, more__, oneway__)
-}
-
-func ReadGetContainerLogs_(c__ *varlink.Connection, container_ *[]string) (bool, error) {
-	var out struct {
-		Container []string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.PullImage", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if container_ != nil {
-		*container_ = []string(out.Container)
-	}
-	return continues_, nil
+	return func() (id_out_ string, flags uint64, err error) {
+		var out struct {
+			Id string `json:"id"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		id_out_ = out.Id
+		return
+	}, nil
 }
 
-func BuildImage(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.BuildImage", nil, more__, oneway__)
+type ResizeContainerTty_methods struct{}
+
+func ResizeContainerTty() ResizeContainerTty_methods { return ResizeContainerTty_methods{} }
+
+func (m ResizeContainerTty_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
 }
 
-func ReadBuildImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
+func (m ResizeContainerTty_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.ResizeContainerTty", nil, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
 }
 
-func ResizeContainerTty(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ResizeContainerTty", nil, more__, oneway__)
+type StartContainer_methods struct{}
+
+func StartContainer() StartContainer_methods { return StartContainer_methods{} }
+
+func (m StartContainer_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
 }
 
-func ReadResizeContainerTty_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
+func (m StartContainer_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.StartContainer", nil, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
 }
 
-func KillContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, signal_ int64) error {
-	var in struct {
-		Name   string `json:"name"`
-		Signal int64  `json:"signal"`
+type UnpauseContainer_methods struct{}
+
+func UnpauseContainer() UnpauseContainer_methods { return UnpauseContainer_methods{} }
+
+func (m UnpauseContainer_methods) Call(c *varlink.Connection, name_in_ string) (container_out_ string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
 	}
-	in.Name = name_
-	in.Signal = signal_
-	return c__.Send("io.projectatomic.podman.KillContainer", in, more__, oneway__)
+	container_out_, _, err_ = receive()
+	return
 }
 
-func ReadKillContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func SearchImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, limit_ int64) error {
-	var in struct {
-		Name  string `json:"name"`
-		Limit int64  `json:"limit"`
-	}
-	in.Name = name_
-	in.Limit = limit_
-	return c__.Send("io.projectatomic.podman.SearchImage", in, more__, oneway__)
-}
-
-func ReadSearchImage_(c__ *varlink.Connection, images_ *[]ImageSearch) (bool, error) {
-	var out struct {
-		Images []ImageSearch `json:"images"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if images_ != nil {
-		*images_ = []ImageSearch(out.Images)
-	}
-	return continues_, nil
-}
-
-func DeleteUnusedImages(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.DeleteUnusedImages", nil, more__, oneway__)
-}
-
-func ReadDeleteUnusedImages_(c__ *varlink.Connection, images_ *[]string) (bool, error) {
-	var out struct {
-		Images []string `json:"images"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if images_ != nil {
-		*images_ = []string(out.Images)
-	}
-	return continues_, nil
-}
-
-func Ping(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.Ping", nil, more__, oneway__)
-}
-
-func ReadPing_(c__ *varlink.Connection, ping_ *StringResponse) (bool, error) {
-	var out struct {
-		Ping StringResponse `json:"ping"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if ping_ != nil {
-		*ping_ = out.Ping
-	}
-	return continues_, nil
-}
-
-func GetContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+func (m UnpauseContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (string, uint64, error), error) {
 	var in struct {
 		Name string `json:"name"`
 	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.GetContainer", in, more__, oneway__)
-}
-
-func ReadGetContainer_(c__ *varlink.Connection, container_ *ListContainerData) (bool, error) {
-	var out struct {
-		Container ListContainerData `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.UnpauseContainer", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
+	return func() (container_out_ string, flags uint64, err error) {
+		var out struct {
+			Container string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = out.Container
+		return
+	}, nil
 }
 
-func InspectImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
+type AttachToContainer_methods struct{}
+
+func AttachToContainer() AttachToContainer_methods { return AttachToContainer_methods{} }
+
+func (m AttachToContainer_methods) Call(c *varlink.Connection) (notimplemented_out_ NotImplemented, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	notimplemented_out_, _, err_ = receive()
+	return
+}
+
+func (m AttachToContainer_methods) Send(c *varlink.Connection, flags uint64) (func() (NotImplemented, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.AttachToContainer", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (notimplemented_out_ NotImplemented, flags uint64, err error) {
+		var out struct {
+			Notimplemented NotImplemented `json:"notimplemented"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		notimplemented_out_ = out.Notimplemented
+		return
+	}, nil
+}
+
+type DeleteStoppedContainers_methods struct{}
+
+func DeleteStoppedContainers() DeleteStoppedContainers_methods {
+	return DeleteStoppedContainers_methods{}
+}
+
+func (m DeleteStoppedContainers_methods) Call(c *varlink.Connection) (containers_out_ []string, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	containers_out_, _, err_ = receive()
+	return
+}
+
+func (m DeleteStoppedContainers_methods) Send(c *varlink.Connection, flags uint64) (func() ([]string, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.DeleteStoppedContainers", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (containers_out_ []string, flags uint64, err error) {
+		var out struct {
+			Containers []string `json:"containers"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		containers_out_ = []string(out.Containers)
+		return
+	}, nil
+}
+
+type ListImages_methods struct{}
+
+func ListImages() ListImages_methods { return ListImages_methods{} }
+
+func (m ListImages_methods) Call(c *varlink.Connection) (images_out_ []ImageInList, err_ error) {
+	receive, err_ := m.Send(c, 0)
+	if err_ != nil {
+		return
+	}
+	images_out_, _, err_ = receive()
+	return
+}
+
+func (m ListImages_methods) Send(c *varlink.Connection, flags uint64) (func() ([]ImageInList, uint64, error), error) {
+	receive, err := c.Send("io.projectatomic.podman.ListImages", nil, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (images_out_ []ImageInList, flags uint64, err error) {
+		var out struct {
+			Images []ImageInList `json:"images"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		images_out_ = []ImageInList(out.Images)
+		return
+	}, nil
+}
+
+type ListContainerProcesses_methods struct{}
+
+func ListContainerProcesses() ListContainerProcesses_methods { return ListContainerProcesses_methods{} }
+
+func (m ListContainerProcesses_methods) Call(c *varlink.Connection, name_in_ string, opts_in_ []string) (container_out_ []string, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_, opts_in_)
+	if err_ != nil {
+		return
+	}
+	container_out_, _, err_ = receive()
+	return
+}
+
+func (m ListContainerProcesses_methods) Send(c *varlink.Connection, flags uint64, name_in_ string, opts_in_ []string) (func() ([]string, uint64, error), error) {
+	var in struct {
+		Name string   `json:"name"`
+		Opts []string `json:"opts"`
+	}
+	in.Name = name_in_
+	in.Opts = []string(opts_in_)
+	receive, err := c.Send("io.projectatomic.podman.ListContainerProcesses", in, flags)
+	if err != nil {
+		return nil, err
+	}
+	return func() (container_out_ []string, flags uint64, err error) {
+		var out struct {
+			Container []string `json:"container"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		container_out_ = []string(out.Container)
+		return
+	}, nil
+}
+
+type WaitContainer_methods struct{}
+
+func WaitContainer() WaitContainer_methods { return WaitContainer_methods{} }
+
+func (m WaitContainer_methods) Call(c *varlink.Connection, name_in_ string) (exitcode_out_ int64, err_ error) {
+	receive, err_ := m.Send(c, 0, name_in_)
+	if err_ != nil {
+		return
+	}
+	exitcode_out_, _, err_ = receive()
+	return
+}
+
+func (m WaitContainer_methods) Send(c *varlink.Connection, flags uint64, name_in_ string) (func() (int64, uint64, error), error) {
 	var in struct {
 		Name string `json:"name"`
 	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.InspectImage", in, more__, oneway__)
-}
-
-func ReadInspectImage_(c__ *varlink.Connection, image_ *string) (bool, error) {
-	var out struct {
-		Image string `json:"image"`
-	}
-	continues_, err := c__.Receive(&out)
+	in.Name = name_in_
+	receive, err := c.Send("io.projectatomic.podman.WaitContainer", in, flags)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if image_ != nil {
-		*image_ = out.Image
-	}
-	return continues_, nil
-}
-
-func RenameContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.RenameContainer", nil, more__, oneway__)
-}
-
-func ReadRenameContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func CreateImage(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.CreateImage", nil, more__, oneway__)
-}
-
-func ReadCreateImage_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func RemoveContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, force_ bool) error {
-	var in struct {
-		Name  string `json:"name"`
-		Force bool   `json:"force"`
-	}
-	in.Name = name_
-	in.Force = force_
-	return c__.Send("io.projectatomic.podman.RemoveContainer", in, more__, oneway__)
-}
-
-func ReadRemoveContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func DeleteStoppedContainers(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.DeleteStoppedContainers", nil, more__, oneway__)
-}
-
-func ReadDeleteStoppedContainers_(c__ *varlink.Connection, containers_ *[]string) (bool, error) {
-	var out struct {
-		Containers []string `json:"containers"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if containers_ != nil {
-		*containers_ = []string(out.Containers)
-	}
-	return continues_, nil
-}
-
-func PushImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, tag_ string, tlsverify_ bool) error {
-	var in struct {
-		Name      string `json:"name"`
-		Tag       string `json:"tag"`
-		Tlsverify bool   `json:"tlsverify"`
-	}
-	in.Name = name_
-	in.Tag = tag_
-	in.Tlsverify = tlsverify_
-	return c__.Send("io.projectatomic.podman.PushImage", in, more__, oneway__)
-}
-
-func ReadPushImage_(c__ *varlink.Connection) (bool, error) {
-	continues_, err := c__.Receive(nil)
-	if err != nil {
-		return false, err
-	}
-	return continues_, nil
-}
-
-func ExportImage(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, destination_ string, compress_ bool) error {
-	var in struct {
-		Name        string `json:"name"`
-		Destination string `json:"destination"`
-		Compress    bool   `json:"compress"`
-	}
-	in.Name = name_
-	in.Destination = destination_
-	in.Compress = compress_
-	return c__.Send("io.projectatomic.podman.ExportImage", in, more__, oneway__)
-}
-
-func ReadExportImage_(c__ *varlink.Connection) (bool, error) {
-	continues_, err := c__.Receive(nil)
-	if err != nil {
-		return false, err
-	}
-	return continues_, nil
-}
-
-func GetContainerStats(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.GetContainerStats", in, more__, oneway__)
-}
-
-func ReadGetContainerStats_(c__ *varlink.Connection, container_ *ContainerStats) (bool, error) {
-	var out struct {
-		Container ContainerStats `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func UpdateContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.UpdateContainer", nil, more__, oneway__)
-}
-
-func ReadUpdateContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func CreateContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.CreateContainer", nil, more__, oneway__)
-}
-
-func ReadCreateContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func InspectContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.InspectContainer", in, more__, oneway__)
-}
-
-func ReadInspectContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func StopContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string, timeout_ int64) error {
-	var in struct {
-		Name    string `json:"name"`
-		Timeout int64  `json:"timeout"`
-	}
-	in.Name = name_
-	in.Timeout = timeout_
-	return c__.Send("io.projectatomic.podman.StopContainer", in, more__, oneway__)
-}
-
-func ReadStopContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func UnpauseContainer(c__ *varlink.Connection, more__ bool, oneway__ bool, name_ string) error {
-	var in struct {
-		Name string `json:"name"`
-	}
-	in.Name = name_
-	return c__.Send("io.projectatomic.podman.UnpauseContainer", in, more__, oneway__)
-}
-
-func ReadUnpauseContainer_(c__ *varlink.Connection, container_ *string) (bool, error) {
-	var out struct {
-		Container string `json:"container"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if container_ != nil {
-		*container_ = out.Container
-	}
-	return continues_, nil
-}
-
-func CreateFromContainer(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.CreateFromContainer", nil, more__, oneway__)
-}
-
-func ReadCreateFromContainer_(c__ *varlink.Connection, notimplemented_ *NotImplemented) (bool, error) {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if notimplemented_ != nil {
-		*notimplemented_ = out.Notimplemented
-	}
-	return continues_, nil
-}
-
-func GetVersion(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.GetVersion", nil, more__, oneway__)
-}
-
-func ReadGetVersion_(c__ *varlink.Connection, version_ *Version) (bool, error) {
-	var out struct {
-		Version Version `json:"version"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if version_ != nil {
-		*version_ = out.Version
-	}
-	return continues_, nil
-}
-
-func ListContainers(c__ *varlink.Connection, more__ bool, oneway__ bool) error {
-	return c__.Send("io.projectatomic.podman.ListContainers", nil, more__, oneway__)
-}
-
-func ReadListContainers_(c__ *varlink.Connection, containers_ *[]ListContainerData) (bool, error) {
-	var out struct {
-		Containers []ListContainerData `json:"containers"`
-	}
-	continues_, err := c__.Receive(&out)
-	if err != nil {
-		return false, err
-	}
-	if containers_ != nil {
-		*containers_ = []ListContainerData(out.Containers)
-	}
-	return continues_, nil
+	return func() (exitcode_out_ int64, flags uint64, err error) {
+		var out struct {
+			Exitcode int64 `json:"exitcode"`
+		}
+		flags, err = receive(&out)
+		if err != nil {
+			return
+		}
+		exitcode_out_ = out.Exitcode
+		return
+	}, nil
 }
 
 // Service interface with all methods
 type ioprojectatomicpodmanInterface interface {
-	PauseContainer(c__ VarlinkCall, name_ string) error
-	WaitContainer(c__ VarlinkCall, name_ string) error
-	ListImages(c__ VarlinkCall) error
-	PullImage(c__ VarlinkCall, name_ string) error
-	ListContainerProcesses(c__ VarlinkCall, name_ string, opts_ []string) error
-	ListContainerChanges(c__ VarlinkCall, name_ string) error
-	StartContainer(c__ VarlinkCall) error
-	AttachToContainer(c__ VarlinkCall) error
-	GetContainerLogs(c__ VarlinkCall, name_ string) error
-	BuildImage(c__ VarlinkCall) error
-	RemoveImage(c__ VarlinkCall, name_ string, force_ bool) error
-	ImportImage(c__ VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error
-	SearchImage(c__ VarlinkCall, name_ string, limit_ int64) error
-	DeleteUnusedImages(c__ VarlinkCall) error
-	Ping(c__ VarlinkCall) error
-	GetContainer(c__ VarlinkCall, name_ string) error
-	ResizeContainerTty(c__ VarlinkCall) error
-	KillContainer(c__ VarlinkCall, name_ string, signal_ int64) error
-	RenameContainer(c__ VarlinkCall) error
-	CreateImage(c__ VarlinkCall) error
-	InspectImage(c__ VarlinkCall, name_ string) error
-	PushImage(c__ VarlinkCall, name_ string, tag_ string, tlsverify_ bool) error
-	ExportImage(c__ VarlinkCall, name_ string, destination_ string, compress_ bool) error
-	GetContainerStats(c__ VarlinkCall, name_ string) error
-	UpdateContainer(c__ VarlinkCall) error
-	RemoveContainer(c__ VarlinkCall, name_ string, force_ bool) error
-	DeleteStoppedContainers(c__ VarlinkCall) error
-	StopContainer(c__ VarlinkCall, name_ string, timeout_ int64) error
-	UnpauseContainer(c__ VarlinkCall, name_ string) error
-	CreateFromContainer(c__ VarlinkCall) error
-	GetVersion(c__ VarlinkCall) error
-	ListContainers(c__ VarlinkCall) error
-	CreateContainer(c__ VarlinkCall) error
-	InspectContainer(c__ VarlinkCall, name_ string) error
-	ExportContainer(c__ VarlinkCall, name_ string, path_ string) error
-	RestartContainer(c__ VarlinkCall, name_ string, timeout_ int64) error
-	HistoryImage(c__ VarlinkCall, name_ string) error
-	TagImage(c__ VarlinkCall, name_ string, tagged_ string) error
+	PauseContainer(c VarlinkCall, name_ string) error
+	ImportImage(c VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error
+	PullImage(c VarlinkCall, name_ string) error
+	DeleteStoppedContainers(c VarlinkCall) error
+	ListImages(c VarlinkCall) error
+	ResizeContainerTty(c VarlinkCall) error
+	StartContainer(c VarlinkCall) error
+	UnpauseContainer(c VarlinkCall, name_ string) error
+	AttachToContainer(c VarlinkCall) error
+	ListContainerProcesses(c VarlinkCall, name_ string, opts_ []string) error
+	WaitContainer(c VarlinkCall, name_ string) error
+	KillContainer(c VarlinkCall, name_ string, signal_ int64) error
+	RemoveContainer(c VarlinkCall, name_ string, force_ bool) error
+	SearchImage(c VarlinkCall, name_ string, limit_ int64) error
+	DeleteUnusedImages(c VarlinkCall) error
+	Ping(c VarlinkCall) error
+	InspectContainer(c VarlinkCall, name_ string) error
+	GetContainerLogs(c VarlinkCall, name_ string) error
+	ListContainerChanges(c VarlinkCall, name_ string) error
+	BuildImage(c VarlinkCall) error
+	CreateImage(c VarlinkCall) error
+	InspectImage(c VarlinkCall, name_ string) error
+	TagImage(c VarlinkCall, name_ string, tagged_ string) error
+	GetContainerStats(c VarlinkCall, name_ string) error
+	StopContainer(c VarlinkCall, name_ string, timeout_ int64) error
+	RestartContainer(c VarlinkCall, name_ string, timeout_ int64) error
+	UpdateContainer(c VarlinkCall) error
+	ListContainers(c VarlinkCall) error
+	ExportContainer(c VarlinkCall, name_ string, path_ string) error
+	CreateFromContainer(c VarlinkCall) error
+	ExportImage(c VarlinkCall, name_ string, destination_ string, compress_ bool) error
+	GetVersion(c VarlinkCall) error
+	GetContainer(c VarlinkCall, name_ string) error
+	HistoryImage(c VarlinkCall, name_ string) error
+	CreateContainer(c VarlinkCall) error
+	RenameContainer(c VarlinkCall) error
+	PushImage(c VarlinkCall, name_ string, tag_ string, tlsverify_ bool) error
+	RemoveImage(c VarlinkCall, name_ string, force_ bool) error
 }
 
 // Service object with all methods
 type VarlinkCall struct{ varlink.Call }
 
 // Reply methods for all varlink errors
-func (c__ *VarlinkCall) ReplyImageNotFound(name_ string) error {
+func (c *VarlinkCall) ReplyErrorOccurred(reason_ string) error {
+	var out struct {
+		Reason string `json:"reason"`
+	}
+	out.Reason = reason_
+	return c.ReplyError("io.projectatomic.podman.ErrorOccurred", &out)
+}
+
+func (c *VarlinkCall) ReplyRuntimeError(reason_ string) error {
+	var out struct {
+		Reason string `json:"reason"`
+	}
+	out.Reason = reason_
+	return c.ReplyError("io.projectatomic.podman.RuntimeError", &out)
+}
+
+func (c *VarlinkCall) ReplyImageNotFound(name_ string) error {
 	var out struct {
 		Name string `json:"name"`
 	}
 	out.Name = name_
-	return c__.ReplyError("io.projectatomic.podman.ImageNotFound", &out)
+	return c.ReplyError("io.projectatomic.podman.ImageNotFound", &out)
 }
 
-func (c__ *VarlinkCall) ReplyContainerNotFound(name_ string) error {
+func (c *VarlinkCall) ReplyContainerNotFound(name_ string) error {
 	var out struct {
 		Name string `json:"name"`
 	}
 	out.Name = name_
-	return c__.ReplyError("io.projectatomic.podman.ContainerNotFound", &out)
-}
-
-func (c__ *VarlinkCall) ReplyErrorOccurred(reason_ string) error {
-	var out struct {
-		Reason string `json:"reason"`
-	}
-	out.Reason = reason_
-	return c__.ReplyError("io.projectatomic.podman.ErrorOccurred", &out)
-}
-
-func (c__ *VarlinkCall) ReplyRuntimeError(reason_ string) error {
-	var out struct {
-		Reason string `json:"reason"`
-	}
-	out.Reason = reason_
-	return c__.ReplyError("io.projectatomic.podman.RuntimeError", &out)
-}
-
-func (c__ *VarlinkCall) ReplyActionFailed(reason_ string) error {
-	var out struct {
-		Reason string `json:"reason"`
-	}
-	out.Reason = reason_
-	return c__.ReplyError("io.projectatomic.podman.ActionFailed", &out)
+	return c.ReplyError("io.projectatomic.podman.ContainerNotFound", &out)
 }
 
 // Reply methods for all varlink methods
-func (c__ *VarlinkCall) ReplyKillContainer(container_ string) error {
+func (c *VarlinkCall) ReplyListContainerProcesses(container_ []string) error {
 	var out struct {
-		Container string `json:"container"`
+		Container []string `json:"container"`
 	}
-	out.Container = container_
-	return c__.Reply(&out)
+	out.Container = []string(container_)
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplySearchImage(images_ []ImageSearch) error {
-	var out struct {
-		Images []ImageSearch `json:"images"`
-	}
-	out.Images = []ImageSearch(images_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyDeleteUnusedImages(images_ []string) error {
-	var out struct {
-		Images []string `json:"images"`
-	}
-	out.Images = []string(images_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyPing(ping_ StringResponse) error {
-	var out struct {
-		Ping StringResponse `json:"ping"`
-	}
-	out.Ping = ping_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyGetContainer(container_ ListContainerData) error {
-	var out struct {
-		Container ListContainerData `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyResizeContainerTty(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRenameContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyCreateImage(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyInspectImage(image_ string) error {
-	var out struct {
-		Image string `json:"image"`
-	}
-	out.Image = image_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyDeleteStoppedContainers(containers_ []string) error {
-	var out struct {
-		Containers []string `json:"containers"`
-	}
-	out.Containers = []string(containers_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyPushImage() error {
-	return c__.Reply(nil)
-}
-
-func (c__ *VarlinkCall) ReplyExportImage() error {
-	return c__.Reply(nil)
-}
-
-func (c__ *VarlinkCall) ReplyGetContainerStats(container_ ContainerStats) error {
-	var out struct {
-		Container ContainerStats `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyUpdateContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRemoveContainer(container_ string) error {
-	var out struct {
-		Container string `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyInspectContainer(container_ string) error {
-	var out struct {
-		Container string `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyStopContainer(container_ string) error {
-	var out struct {
-		Container string `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyUnpauseContainer(container_ string) error {
-	var out struct {
-		Container string `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyCreateFromContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyGetVersion(version_ Version) error {
-	var out struct {
-		Version Version `json:"version"`
-	}
-	out.Version = version_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyListContainers(containers_ []ListContainerData) error {
-	var out struct {
-		Containers []ListContainerData `json:"containers"`
-	}
-	out.Containers = []ListContainerData(containers_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyCreateContainer(notimplemented_ NotImplemented) error {
-	var out struct {
-		Notimplemented NotImplemented `json:"notimplemented"`
-	}
-	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyTagImage() error {
-	return c__.Reply(nil)
-}
-
-func (c__ *VarlinkCall) ReplyExportContainer(tarfile_ string) error {
-	var out struct {
-		Tarfile string `json:"tarfile"`
-	}
-	out.Tarfile = tarfile_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyRestartContainer(container_ string) error {
-	var out struct {
-		Container string `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyHistoryImage(history_ []ImageHistory) error {
-	var out struct {
-		History []ImageHistory `json:"history"`
-	}
-	out.History = []ImageHistory(history_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyPullImage(id_ string) error {
-	var out struct {
-		Id string `json:"id"`
-	}
-	out.Id = id_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyPauseContainer(container_ string) error {
-	var out struct {
-		Container string `json:"container"`
-	}
-	out.Container = container_
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyWaitContainer(exitcode_ int64) error {
+func (c *VarlinkCall) ReplyWaitContainer(exitcode_ int64) error {
 	var out struct {
 		Exitcode int64 `json:"exitcode"`
 	}
 	out.Exitcode = exitcode_
-	return c__.Reply(&out)
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyListImages(images_ []ImageInList) error {
+func (c *VarlinkCall) ReplyRemoveContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplySearchImage(images_ []ImageSearch) error {
+	var out struct {
+		Images []ImageSearch `json:"images"`
+	}
+	out.Images = []ImageSearch(images_)
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyDeleteUnusedImages(images_ []string) error {
+	var out struct {
+		Images []string `json:"images"`
+	}
+	out.Images = []string(images_)
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyPing(ping_ StringResponse) error {
+	var out struct {
+		Ping StringResponse `json:"ping"`
+	}
+	out.Ping = ping_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyInspectContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyGetContainerLogs(container_ []string) error {
+	var out struct {
+		Container []string `json:"container"`
+	}
+	out.Container = []string(container_)
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyListContainerChanges(container_ ContainerChanges) error {
+	var out struct {
+		Container ContainerChanges `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyKillContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyCreateImage(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyInspectImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyTagImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyGetContainerStats(container_ ContainerStats) error {
+	var out struct {
+		Container ContainerStats `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyStopContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyRestartContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyUpdateContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyBuildImage(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyListContainers(containers_ []ListContainerData) error {
+	var out struct {
+		Containers []ListContainerData `json:"containers"`
+	}
+	out.Containers = []ListContainerData(containers_)
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyExportContainer(tarfile_ string) error {
+	var out struct {
+		Tarfile string `json:"tarfile"`
+	}
+	out.Tarfile = tarfile_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyCreateFromContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyExportImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyGetVersion(version_ Version) error {
+	var out struct {
+		Version Version `json:"version"`
+	}
+	out.Version = version_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyGetContainer(container_ ListContainerData) error {
+	var out struct {
+		Container ListContainerData `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyHistoryImage(history_ []ImageHistory) error {
+	var out struct {
+		History []ImageHistory `json:"history"`
+	}
+	out.History = []ImageHistory(history_)
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyCreateContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyRenameContainer(notimplemented_ NotImplemented) error {
+	var out struct {
+		Notimplemented NotImplemented `json:"notimplemented"`
+	}
+	out.Notimplemented = notimplemented_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyPushImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyRemoveImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyPauseContainer(container_ string) error {
+	var out struct {
+		Container string `json:"container"`
+	}
+	out.Container = container_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyImportImage(image_ string) error {
+	var out struct {
+		Image string `json:"image"`
+	}
+	out.Image = image_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyPullImage(id_ string) error {
+	var out struct {
+		Id string `json:"id"`
+	}
+	out.Id = id_
+	return c.Reply(&out)
+}
+
+func (c *VarlinkCall) ReplyListImages(images_ []ImageInList) error {
 	var out struct {
 		Images []ImageInList `json:"images"`
 	}
 	out.Images = []ImageInList(images_)
-	return c__.Reply(&out)
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyAttachToContainer(notimplemented_ NotImplemented) error {
+func (c *VarlinkCall) ReplyResizeContainerTty(notimplemented_ NotImplemented) error {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
 	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyListContainerProcesses(container_ []string) error {
-	var out struct {
-		Container []string `json:"container"`
-	}
-	out.Container = []string(container_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyListContainerChanges(container_ map[string]string) error {
-	var out struct {
-		Container map[string]string `json:"container"`
-	}
-	out.Container = map[string]string(container_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyStartContainer(notimplemented_ NotImplemented) error {
+func (c *VarlinkCall) ReplyStartContainer(notimplemented_ NotImplemented) error {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
 	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyImportImage(image_ string) error {
+func (c *VarlinkCall) ReplyUnpauseContainer(container_ string) error {
 	var out struct {
-		Image string `json:"image"`
+		Container string `json:"container"`
 	}
-	out.Image = image_
-	return c__.Reply(&out)
+	out.Container = container_
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyGetContainerLogs(container_ []string) error {
-	var out struct {
-		Container []string `json:"container"`
-	}
-	out.Container = []string(container_)
-	return c__.Reply(&out)
-}
-
-func (c__ *VarlinkCall) ReplyBuildImage(notimplemented_ NotImplemented) error {
+func (c *VarlinkCall) ReplyAttachToContainer(notimplemented_ NotImplemented) error {
 	var out struct {
 		Notimplemented NotImplemented `json:"notimplemented"`
 	}
 	out.Notimplemented = notimplemented_
-	return c__.Reply(&out)
+	return c.Reply(&out)
 }
 
-func (c__ *VarlinkCall) ReplyRemoveImage(image_ string) error {
+func (c *VarlinkCall) ReplyDeleteStoppedContainers(containers_ []string) error {
 	var out struct {
-		Image string `json:"image"`
+		Containers []string `json:"containers"`
 	}
-	out.Image = image_
-	return c__.Reply(&out)
+	out.Containers = []string(containers_)
+	return c.Reply(&out)
 }
 
-// Dummy methods for all varlink methods
-func (s__ *VarlinkInterface) PauseContainer(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("PauseContainer")
+// Dummy implementations for all varlink methods
+func (s *VarlinkInterface) CreateFromContainer(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.CreateFromContainer")
 }
 
-func (s__ *VarlinkInterface) WaitContainer(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("WaitContainer")
+func (s *VarlinkInterface) ExportImage(c VarlinkCall, name_ string, destination_ string, compress_ bool) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ExportImage")
 }
 
-func (s__ *VarlinkInterface) ListImages(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ListImages")
+func (s *VarlinkInterface) ListContainers(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ListContainers")
 }
 
-func (s__ *VarlinkInterface) PullImage(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("PullImage")
+func (s *VarlinkInterface) ExportContainer(c VarlinkCall, name_ string, path_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ExportContainer")
 }
 
-func (s__ *VarlinkInterface) ListContainerProcesses(c__ VarlinkCall, name_ string, opts_ []string) error {
-	return c__.ReplyMethodNotImplemented("ListContainerProcesses")
+func (s *VarlinkInterface) HistoryImage(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.HistoryImage")
 }
 
-func (s__ *VarlinkInterface) ListContainerChanges(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("ListContainerChanges")
+func (s *VarlinkInterface) GetVersion(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.GetVersion")
 }
 
-func (s__ *VarlinkInterface) StartContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("StartContainer")
+func (s *VarlinkInterface) GetContainer(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.GetContainer")
 }
 
-func (s__ *VarlinkInterface) AttachToContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("AttachToContainer")
+func (s *VarlinkInterface) PushImage(c VarlinkCall, name_ string, tag_ string, tlsverify_ bool) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.PushImage")
 }
 
-func (s__ *VarlinkInterface) GetContainerLogs(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("GetContainerLogs")
+func (s *VarlinkInterface) RemoveImage(c VarlinkCall, name_ string, force_ bool) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.RemoveImage")
 }
 
-func (s__ *VarlinkInterface) BuildImage(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("BuildImage")
+func (s *VarlinkInterface) CreateContainer(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.CreateContainer")
 }
 
-func (s__ *VarlinkInterface) RemoveImage(c__ VarlinkCall, name_ string, force_ bool) error {
-	return c__.ReplyMethodNotImplemented("RemoveImage")
+func (s *VarlinkInterface) RenameContainer(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.RenameContainer")
 }
 
-func (s__ *VarlinkInterface) ImportImage(c__ VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error {
-	return c__.ReplyMethodNotImplemented("ImportImage")
+func (s *VarlinkInterface) PullImage(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.PullImage")
 }
 
-func (s__ *VarlinkInterface) Ping(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("Ping")
+func (s *VarlinkInterface) PauseContainer(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.PauseContainer")
 }
 
-func (s__ *VarlinkInterface) GetContainer(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("GetContainer")
+func (s *VarlinkInterface) ImportImage(c VarlinkCall, source_ string, reference_ string, message_ string, changes_ []string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ImportImage")
 }
 
-func (s__ *VarlinkInterface) ResizeContainerTty(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ResizeContainerTty")
+func (s *VarlinkInterface) UnpauseContainer(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.UnpauseContainer")
 }
 
-func (s__ *VarlinkInterface) KillContainer(c__ VarlinkCall, name_ string, signal_ int64) error {
-	return c__.ReplyMethodNotImplemented("KillContainer")
+func (s *VarlinkInterface) AttachToContainer(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.AttachToContainer")
 }
 
-func (s__ *VarlinkInterface) SearchImage(c__ VarlinkCall, name_ string, limit_ int64) error {
-	return c__.ReplyMethodNotImplemented("SearchImage")
+func (s *VarlinkInterface) DeleteStoppedContainers(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.DeleteStoppedContainers")
 }
 
-func (s__ *VarlinkInterface) DeleteUnusedImages(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("DeleteUnusedImages")
+func (s *VarlinkInterface) ListImages(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ListImages")
 }
 
-func (s__ *VarlinkInterface) RenameContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("RenameContainer")
+func (s *VarlinkInterface) ResizeContainerTty(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ResizeContainerTty")
 }
 
-func (s__ *VarlinkInterface) CreateImage(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("CreateImage")
+func (s *VarlinkInterface) StartContainer(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.StartContainer")
 }
 
-func (s__ *VarlinkInterface) InspectImage(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("InspectImage")
+func (s *VarlinkInterface) ListContainerProcesses(c VarlinkCall, name_ string, opts_ []string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ListContainerProcesses")
 }
 
-func (s__ *VarlinkInterface) GetContainerStats(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("GetContainerStats")
+func (s *VarlinkInterface) WaitContainer(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.WaitContainer")
 }
 
-func (s__ *VarlinkInterface) UpdateContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("UpdateContainer")
+func (s *VarlinkInterface) GetContainerLogs(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.GetContainerLogs")
 }
 
-func (s__ *VarlinkInterface) RemoveContainer(c__ VarlinkCall, name_ string, force_ bool) error {
-	return c__.ReplyMethodNotImplemented("RemoveContainer")
+func (s *VarlinkInterface) ListContainerChanges(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.ListContainerChanges")
 }
 
-func (s__ *VarlinkInterface) DeleteStoppedContainers(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("DeleteStoppedContainers")
+func (s *VarlinkInterface) KillContainer(c VarlinkCall, name_ string, signal_ int64) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.KillContainer")
 }
 
-func (s__ *VarlinkInterface) PushImage(c__ VarlinkCall, name_ string, tag_ string, tlsverify_ bool) error {
-	return c__.ReplyMethodNotImplemented("PushImage")
+func (s *VarlinkInterface) RemoveContainer(c VarlinkCall, name_ string, force_ bool) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.RemoveContainer")
 }
 
-func (s__ *VarlinkInterface) ExportImage(c__ VarlinkCall, name_ string, destination_ string, compress_ bool) error {
-	return c__.ReplyMethodNotImplemented("ExportImage")
+func (s *VarlinkInterface) SearchImage(c VarlinkCall, name_ string, limit_ int64) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.SearchImage")
 }
 
-func (s__ *VarlinkInterface) GetVersion(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("GetVersion")
+func (s *VarlinkInterface) DeleteUnusedImages(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.DeleteUnusedImages")
 }
 
-func (s__ *VarlinkInterface) ListContainers(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("ListContainers")
+func (s *VarlinkInterface) Ping(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.Ping")
 }
 
-func (s__ *VarlinkInterface) CreateContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("CreateContainer")
+func (s *VarlinkInterface) InspectContainer(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.InspectContainer")
 }
 
-func (s__ *VarlinkInterface) InspectContainer(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("InspectContainer")
+func (s *VarlinkInterface) RestartContainer(c VarlinkCall, name_ string, timeout_ int64) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.RestartContainer")
 }
 
-func (s__ *VarlinkInterface) StopContainer(c__ VarlinkCall, name_ string, timeout_ int64) error {
-	return c__.ReplyMethodNotImplemented("StopContainer")
+func (s *VarlinkInterface) UpdateContainer(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.UpdateContainer")
 }
 
-func (s__ *VarlinkInterface) UnpauseContainer(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("UnpauseContainer")
+func (s *VarlinkInterface) BuildImage(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.BuildImage")
 }
 
-func (s__ *VarlinkInterface) CreateFromContainer(c__ VarlinkCall) error {
-	return c__.ReplyMethodNotImplemented("CreateFromContainer")
+func (s *VarlinkInterface) CreateImage(c VarlinkCall) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.CreateImage")
 }
 
-func (s__ *VarlinkInterface) ExportContainer(c__ VarlinkCall, name_ string, path_ string) error {
-	return c__.ReplyMethodNotImplemented("ExportContainer")
+func (s *VarlinkInterface) InspectImage(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.InspectImage")
 }
 
-func (s__ *VarlinkInterface) RestartContainer(c__ VarlinkCall, name_ string, timeout_ int64) error {
-	return c__.ReplyMethodNotImplemented("RestartContainer")
+func (s *VarlinkInterface) TagImage(c VarlinkCall, name_ string, tagged_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.TagImage")
 }
 
-func (s__ *VarlinkInterface) HistoryImage(c__ VarlinkCall, name_ string) error {
-	return c__.ReplyMethodNotImplemented("HistoryImage")
+func (s *VarlinkInterface) GetContainerStats(c VarlinkCall, name_ string) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.GetContainerStats")
 }
 
-func (s__ *VarlinkInterface) TagImage(c__ VarlinkCall, name_ string, tagged_ string) error {
-	return c__.ReplyMethodNotImplemented("TagImage")
+func (s *VarlinkInterface) StopContainer(c VarlinkCall, name_ string, timeout_ int64) error {
+	return c.ReplyMethodNotImplemented("io.projectatomic.podman.StopContainer")
 }
 
 // Method call dispatcher
-func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname string) error {
+func (s *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname string) error {
 	switch methodname {
+	case "ListContainerProcesses":
+		var in struct {
+			Name string   `json:"name"`
+			Opts []string `json:"opts"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.ListContainerProcesses(VarlinkCall{call}, in.Name, []string(in.Opts))
+
+	case "WaitContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.WaitContainer(VarlinkCall{call}, in.Name)
+
+	case "Ping":
+		return s.ioprojectatomicpodmanInterface.Ping(VarlinkCall{call})
+
+	case "InspectContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.InspectContainer(VarlinkCall{call}, in.Name)
+
 	case "GetContainerLogs":
 		var in struct {
 			Name string `json:"name"`
@@ -1442,10 +2000,185 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		if err != nil {
 			return call.ReplyInvalidParameter("parameters")
 		}
-		return s__.ioprojectatomicpodmanInterface.GetContainerLogs(VarlinkCall{call}, in.Name)
+		return s.ioprojectatomicpodmanInterface.GetContainerLogs(VarlinkCall{call}, in.Name)
+
+	case "ListContainerChanges":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.ListContainerChanges(VarlinkCall{call}, in.Name)
+
+	case "KillContainer":
+		var in struct {
+			Name   string `json:"name"`
+			Signal int64  `json:"signal"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.KillContainer(VarlinkCall{call}, in.Name, in.Signal)
+
+	case "RemoveContainer":
+		var in struct {
+			Name  string `json:"name"`
+			Force bool   `json:"force"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.RemoveContainer(VarlinkCall{call}, in.Name, in.Force)
+
+	case "SearchImage":
+		var in struct {
+			Name  string `json:"name"`
+			Limit int64  `json:"limit"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.SearchImage(VarlinkCall{call}, in.Name, in.Limit)
+
+	case "DeleteUnusedImages":
+		return s.ioprojectatomicpodmanInterface.DeleteUnusedImages(VarlinkCall{call})
+
+	case "GetContainerStats":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.GetContainerStats(VarlinkCall{call}, in.Name)
+
+	case "StopContainer":
+		var in struct {
+			Name    string `json:"name"`
+			Timeout int64  `json:"timeout"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.StopContainer(VarlinkCall{call}, in.Name, in.Timeout)
+
+	case "RestartContainer":
+		var in struct {
+			Name    string `json:"name"`
+			Timeout int64  `json:"timeout"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.RestartContainer(VarlinkCall{call}, in.Name, in.Timeout)
+
+	case "UpdateContainer":
+		return s.ioprojectatomicpodmanInterface.UpdateContainer(VarlinkCall{call})
 
 	case "BuildImage":
-		return s__.ioprojectatomicpodmanInterface.BuildImage(VarlinkCall{call})
+		return s.ioprojectatomicpodmanInterface.BuildImage(VarlinkCall{call})
+
+	case "CreateImage":
+		return s.ioprojectatomicpodmanInterface.CreateImage(VarlinkCall{call})
+
+	case "InspectImage":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.InspectImage(VarlinkCall{call}, in.Name)
+
+	case "TagImage":
+		var in struct {
+			Name   string `json:"name"`
+			Tagged string `json:"tagged"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.TagImage(VarlinkCall{call}, in.Name, in.Tagged)
+
+	case "ListContainers":
+		return s.ioprojectatomicpodmanInterface.ListContainers(VarlinkCall{call})
+
+	case "ExportContainer":
+		var in struct {
+			Name string `json:"name"`
+			Path string `json:"path"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.ExportContainer(VarlinkCall{call}, in.Name, in.Path)
+
+	case "CreateFromContainer":
+		return s.ioprojectatomicpodmanInterface.CreateFromContainer(VarlinkCall{call})
+
+	case "ExportImage":
+		var in struct {
+			Name        string `json:"name"`
+			Destination string `json:"destination"`
+			Compress    bool   `json:"compress"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.ExportImage(VarlinkCall{call}, in.Name, in.Destination, in.Compress)
+
+	case "GetVersion":
+		return s.ioprojectatomicpodmanInterface.GetVersion(VarlinkCall{call})
+
+	case "GetContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.GetContainer(VarlinkCall{call}, in.Name)
+
+	case "HistoryImage":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.HistoryImage(VarlinkCall{call}, in.Name)
+
+	case "CreateContainer":
+		return s.ioprojectatomicpodmanInterface.CreateContainer(VarlinkCall{call})
+
+	case "RenameContainer":
+		return s.ioprojectatomicpodmanInterface.RenameContainer(VarlinkCall{call})
+
+	case "PushImage":
+		var in struct {
+			Name      string `json:"name"`
+			Tag       string `json:"tag"`
+			Tlsverify bool   `json:"tlsverify"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.PushImage(VarlinkCall{call}, in.Name, in.Tag, in.Tlsverify)
 
 	case "RemoveImage":
 		var in struct {
@@ -1456,7 +2189,17 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		if err != nil {
 			return call.ReplyInvalidParameter("parameters")
 		}
-		return s__.ioprojectatomicpodmanInterface.RemoveImage(VarlinkCall{call}, in.Name, in.Force)
+		return s.ioprojectatomicpodmanInterface.RemoveImage(VarlinkCall{call}, in.Name, in.Force)
+
+	case "PauseContainer":
+		var in struct {
+			Name string `json:"name"`
+		}
+		err := call.GetParameters(&in)
+		if err != nil {
+			return call.ReplyInvalidParameter("parameters")
+		}
+		return s.ioprojectatomicpodmanInterface.PauseContainer(VarlinkCall{call}, in.Name)
 
 	case "ImportImage":
 		var in struct {
@@ -1469,224 +2212,7 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		if err != nil {
 			return call.ReplyInvalidParameter("parameters")
 		}
-		return s__.ioprojectatomicpodmanInterface.ImportImage(VarlinkCall{call}, in.Source, in.Reference, in.Message, []string(in.Changes))
-
-	case "Ping":
-		return s__.ioprojectatomicpodmanInterface.Ping(VarlinkCall{call})
-
-	case "GetContainer":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.GetContainer(VarlinkCall{call}, in.Name)
-
-	case "ResizeContainerTty":
-		return s__.ioprojectatomicpodmanInterface.ResizeContainerTty(VarlinkCall{call})
-
-	case "KillContainer":
-		var in struct {
-			Name   string `json:"name"`
-			Signal int64  `json:"signal"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.KillContainer(VarlinkCall{call}, in.Name, in.Signal)
-
-	case "SearchImage":
-		var in struct {
-			Name  string `json:"name"`
-			Limit int64  `json:"limit"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.SearchImage(VarlinkCall{call}, in.Name, in.Limit)
-
-	case "DeleteUnusedImages":
-		return s__.ioprojectatomicpodmanInterface.DeleteUnusedImages(VarlinkCall{call})
-
-	case "RenameContainer":
-		return s__.ioprojectatomicpodmanInterface.RenameContainer(VarlinkCall{call})
-
-	case "CreateImage":
-		return s__.ioprojectatomicpodmanInterface.CreateImage(VarlinkCall{call})
-
-	case "InspectImage":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.InspectImage(VarlinkCall{call}, in.Name)
-
-	case "GetContainerStats":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.GetContainerStats(VarlinkCall{call}, in.Name)
-
-	case "UpdateContainer":
-		return s__.ioprojectatomicpodmanInterface.UpdateContainer(VarlinkCall{call})
-
-	case "RemoveContainer":
-		var in struct {
-			Name  string `json:"name"`
-			Force bool   `json:"force"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.RemoveContainer(VarlinkCall{call}, in.Name, in.Force)
-
-	case "DeleteStoppedContainers":
-		return s__.ioprojectatomicpodmanInterface.DeleteStoppedContainers(VarlinkCall{call})
-
-	case "PushImage":
-		var in struct {
-			Name      string `json:"name"`
-			Tag       string `json:"tag"`
-			Tlsverify bool   `json:"tlsverify"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.PushImage(VarlinkCall{call}, in.Name, in.Tag, in.Tlsverify)
-
-	case "ExportImage":
-		var in struct {
-			Name        string `json:"name"`
-			Destination string `json:"destination"`
-			Compress    bool   `json:"compress"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.ExportImage(VarlinkCall{call}, in.Name, in.Destination, in.Compress)
-
-	case "CreateFromContainer":
-		return s__.ioprojectatomicpodmanInterface.CreateFromContainer(VarlinkCall{call})
-
-	case "GetVersion":
-		return s__.ioprojectatomicpodmanInterface.GetVersion(VarlinkCall{call})
-
-	case "ListContainers":
-		return s__.ioprojectatomicpodmanInterface.ListContainers(VarlinkCall{call})
-
-	case "CreateContainer":
-		return s__.ioprojectatomicpodmanInterface.CreateContainer(VarlinkCall{call})
-
-	case "InspectContainer":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.InspectContainer(VarlinkCall{call}, in.Name)
-
-	case "StopContainer":
-		var in struct {
-			Name    string `json:"name"`
-			Timeout int64  `json:"timeout"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.StopContainer(VarlinkCall{call}, in.Name, in.Timeout)
-
-	case "UnpauseContainer":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.UnpauseContainer(VarlinkCall{call}, in.Name)
-
-	case "ExportContainer":
-		var in struct {
-			Name string `json:"name"`
-			Path string `json:"path"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.ExportContainer(VarlinkCall{call}, in.Name, in.Path)
-
-	case "RestartContainer":
-		var in struct {
-			Name    string `json:"name"`
-			Timeout int64  `json:"timeout"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.RestartContainer(VarlinkCall{call}, in.Name, in.Timeout)
-
-	case "HistoryImage":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.HistoryImage(VarlinkCall{call}, in.Name)
-
-	case "TagImage":
-		var in struct {
-			Name   string `json:"name"`
-			Tagged string `json:"tagged"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.TagImage(VarlinkCall{call}, in.Name, in.Tagged)
-
-	case "PauseContainer":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.PauseContainer(VarlinkCall{call}, in.Name)
-
-	case "WaitContainer":
-		var in struct {
-			Name string `json:"name"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.WaitContainer(VarlinkCall{call}, in.Name)
-
-	case "ListImages":
-		return s__.ioprojectatomicpodmanInterface.ListImages(VarlinkCall{call})
+		return s.ioprojectatomicpodmanInterface.ImportImage(VarlinkCall{call}, in.Source, in.Reference, in.Message, []string(in.Changes))
 
 	case "PullImage":
 		var in struct {
@@ -1696,20 +2222,15 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		if err != nil {
 			return call.ReplyInvalidParameter("parameters")
 		}
-		return s__.ioprojectatomicpodmanInterface.PullImage(VarlinkCall{call}, in.Name)
+		return s.ioprojectatomicpodmanInterface.PullImage(VarlinkCall{call}, in.Name)
 
-	case "ListContainerProcesses":
-		var in struct {
-			Name string   `json:"name"`
-			Opts []string `json:"opts"`
-		}
-		err := call.GetParameters(&in)
-		if err != nil {
-			return call.ReplyInvalidParameter("parameters")
-		}
-		return s__.ioprojectatomicpodmanInterface.ListContainerProcesses(VarlinkCall{call}, in.Name, []string(in.Opts))
+	case "ResizeContainerTty":
+		return s.ioprojectatomicpodmanInterface.ResizeContainerTty(VarlinkCall{call})
 
-	case "ListContainerChanges":
+	case "StartContainer":
+		return s.ioprojectatomicpodmanInterface.StartContainer(VarlinkCall{call})
+
+	case "UnpauseContainer":
 		var in struct {
 			Name string `json:"name"`
 		}
@@ -1717,13 +2238,16 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 		if err != nil {
 			return call.ReplyInvalidParameter("parameters")
 		}
-		return s__.ioprojectatomicpodmanInterface.ListContainerChanges(VarlinkCall{call}, in.Name)
-
-	case "StartContainer":
-		return s__.ioprojectatomicpodmanInterface.StartContainer(VarlinkCall{call})
+		return s.ioprojectatomicpodmanInterface.UnpauseContainer(VarlinkCall{call}, in.Name)
 
 	case "AttachToContainer":
-		return s__.ioprojectatomicpodmanInterface.AttachToContainer(VarlinkCall{call})
+		return s.ioprojectatomicpodmanInterface.AttachToContainer(VarlinkCall{call})
+
+	case "DeleteStoppedContainers":
+		return s.ioprojectatomicpodmanInterface.DeleteStoppedContainers(VarlinkCall{call})
+
+	case "ListImages":
+		return s.ioprojectatomicpodmanInterface.ListImages(VarlinkCall{call})
 
 	default:
 		return call.ReplyMethodNotFound(methodname)
@@ -1731,12 +2255,12 @@ func (s__ *VarlinkInterface) VarlinkDispatch(call varlink.Call, methodname strin
 }
 
 // Varlink interface name
-func (s__ *VarlinkInterface) VarlinkGetName() string {
+func (s *VarlinkInterface) VarlinkGetName() string {
 	return `io.projectatomic.podman`
 }
 
 // Varlink interface description
-func (s__ *VarlinkInterface) VarlinkGetDescription() string {
+func (s *VarlinkInterface) VarlinkGetDescription() string {
 	return `# Podman Service Interface
 interface io.projectatomic.podman
 
@@ -1756,6 +2280,12 @@ type NotImplemented (
 
 type StringResponse (
     message: string
+)
+# ContainerChanges describes the return struct for ListContainerChanges
+type ContainerChanges (
+   changed: []string,
+   added: []string,
+   deleted: []string
 )
 
 # ImageInList describes the structure that is returned in
@@ -1856,59 +2386,256 @@ type ContainerNameSpace (
     ipc: string
 )
 
-# System
+# Ping provides a response for developers to ensure their varlink setup is working.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.Ping
+# {
+#   "ping": {
+#     "message": "OK"
+#   }
+# }
+# ~~~
 method Ping() -> (ping: StringResponse)
+
+# GetVersion returns a Version structure describing the libpod setup on their
+# system.
 method GetVersion() -> (version: Version)
 
-# Containers
+
+# ListContainers returns a list of containers in no particular order.  There are
+# returned as an array of ListContainerData structs.  See also [GetContainer](#GetContainer).
 method ListContainers() -> (containers: []ListContainerData)
+
+# GetContainer takes a name or ID of a container and returns single ListContainerData
+# structure.  A [ContainerNotFound](#ContainerNotFound) error will be returned if the container cannot be found.
+# See also [ListContainers](ListContainers) and [InspectContainer](InspectContainer).
 method GetContainer(name: string) -> (container: ListContainerData)
+
+# This method has not been implemented yet.
 method CreateContainer() -> (notimplemented: NotImplemented)
+
+# InspectContainer data takes a name or ID of a container returns the inspection
+# data in string format.  You can then serialize the string into JSON.  A [ContainerNotFound](#ContainerNotFound)
+# error will be returned if the container cannot be found. See also [InspectImage](#InspectImage).
 method InspectContainer(name: string) -> (container: string)
-# TODO: Should this be made into a streaming response as opposed to a one off?
+
+# ListContainerProcesses takes a name or ID of a container and returns the processes
+# running inside the container as array of strings.  It will accept an array of string
+# arguements that represent ps options.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+# error will be returned.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.ListContainerProcesses '{"name": "135d71b9495f", "opts": []}'
+# {
+#   "container": [
+#     "  UID   PID  PPID  C STIME TTY          TIME CMD",
+#     "    0 21220 21210  0 09:05 pts/0    00:00:00 /bin/sh",
+#     "    0 21232 21220  0 09:05 pts/0    00:00:00 top",
+#     "    0 21284 21220  0 09:05 pts/0    00:00:00 vi /etc/hosts"
+#   ]
+# }
+# ~~~
 method ListContainerProcesses(name: string, opts: []string) -> (container: []string)
-# TODO: Should this be made into a streaming response as opposed to a one off?
+
+# GetContainerLogs takes a name or ID of a container and returns the logs of that container.
+# If the container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+# The container logs are returned as an array of strings.  GetContainerLogs will honor the streaming
+# capability of varlink if the client invokes it.
 method GetContainerLogs(name: string) -> (container: []string)
-method ListContainerChanges(name: string) -> (container: [string]string)
-# TODO: This should be made into a streaming response
+
+# ListContainerChanges takes a name or ID of a container and returns changes between the container and
+# its base image. It returns a struct of changed, deleted, and added path names. If the
+# container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+method ListContainerChanges(name: string) -> (container: ContainerChanges)
+
+# ExportContainer creates an image from a container.  It takes the name or ID of a container and a
+# path representing the target tarfile.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+# error will be returned.
+# The return value is the written tarfile.
 method ExportContainer(name: string, path: string) -> (tarfile: string)
+
+# GetContainerStats takes the name or ID of a container and returns a single ContainerStats structure which
+# contains attributes like memory and cpu usage.  If the container cannot be found, a
+# [ContainerNotFound](#ContainerNotFound)  error will be returned.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.GetContainerStats '{"name": "c33e4164f384"}'
+# {
+#   "container": {
+#     "block_input": 0,
+#     "block_output": 0,
+#     "cpu": 2.571123918839990154678e-08,
+#     "cpu_nano": 49037378,
+#     "id": "c33e4164f384aa9d979072a63319d66b74fd7a128be71fa68ede24f33ec6cfee",
+#     "mem_limit": 33080606720,
+#     "mem_perc": 2.166828456524753747370e-03,
+#     "mem_usage": 716800,
+#     "name": "competent_wozniak",
+#     "net_input": 768,
+#     "net_output": 5910,
+#     "pids": 1,
+#     "system_nano": 10000000
+#   }
+# }
+# ~~~
 method GetContainerStats(name: string) -> (container: ContainerStats)
+
+# This method has not be implemented yet.
 method ResizeContainerTty() -> (notimplemented: NotImplemented)
+
+# This method has not be implemented yet.
 method StartContainer() -> (notimplemented: NotImplemented)
+
+# StopContainer stops a container given a timeout.  It takes the name or ID of a container as well as a
+# timeout value.  The timeout value the time before a forceable stop to the container is applied.  It
+# returns the container ID once stopped. If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
+# error will be returned instead. See also [KillContainer](KillContainer).
+# #### Error
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.StopContainer '{"name": "135d71b9495f", "timeout": 5}'
+# {
+#   "container": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+# }
+# ~~~
 method StopContainer(name: string, timeout: int) -> (container: string)
+
+# RestartContainer will restart a running container given a container name or ID and timeout value. The timeout
+# value is the time before a forceable stop is used to stop the container.  If the container cannot be found by
+# name or ID, a [ContainerNotFound](#ContainerNotFound)  error will be returned; otherwise, the ID of the
+# container will be returned.
 method RestartContainer(name: string, timeout: int) -> (container: string)
+
+# KillContainer takes the name or ID of a container as well as a signal to be applied to the container.  Once the
+# container has been killed, the container's ID is returned.  If the container cannot be found, a
+# [ContainerNotFound](#ContainerNotFound) error is returned. See also [StopContainer](StopContainer).
 method KillContainer(name: string, signal: int) -> (container: string)
+
+# This method has not be implemented yet.
 method UpdateContainer() -> (notimplemented: NotImplemented)
+
+# This method has not be implemented yet.
 method RenameContainer() -> (notimplemented: NotImplemented)
+
+# PauseContainer takes the name or ID of container and pauses it.  If the container cannot be found,
+# a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
+# See also [UnpauseContainer](UnpauseContainer).
 method PauseContainer(name: string) -> (container: string)
+
+# UnpauseContainer takes the name or ID of container and unpauses a paused container.  If the container cannot be
+# found, a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
+# See also [PauseContainer](PauseContainer).
 method UnpauseContainer(name: string) -> (container: string)
+
+# This method has not be implemented yet.
 method AttachToContainer() -> (notimplemented: NotImplemented)
+
+# WaitContainer takes the name of ID of a container and waits until the container stops.  Upon stopping, the return
+# code of the container is returned. If the container container cannot be found by ID or name,
+# a [ContainerNotFound](#ContainerNotFound) error is returned.
 method WaitContainer(name: string) -> (exitcode: int)
+
+# RemoveContainer takes requires the name or ID of container as well a boolean representing whether a running
+# container can be stopped and removed.  Upon sucessful removal of the container, its ID is returned.  If the
+# container cannot be found by name or ID, an [ContainerNotFound](#ContainerNotFound) error will be returned.
+# #### Error
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.RemoveContainer '{"name": "62f4fd98cb57"}'
+# {
+#   "container": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
+# }
+# ~~~
 method RemoveContainer(name: string, force: bool) -> (container: string)
+
+# DeleteStoppedContainers will delete all containers that are not running. It will return a list the deleted
+# container IDs.  See also [RemoveContainer](RemoveContainer).
 method DeleteStoppedContainers() -> (containers: []string)
 
-# Images
+# ListImages returns an array of ImageInList structures which provide basic information about
+# an image currenly in storage.  See also [InspectImage](InspectImage).
 method ListImages() -> (images: []ImageInList)
+
+# This function is not implemented yet.
 method BuildImage() -> (notimplemented: NotImplemented)
+
+# This function is not implemented yet.
 method CreateImage() -> (notimplemented: NotImplemented)
+
+# InspectImage takes the name or ID of an image and returns a string respresentation of data associated with the
+#image.  You must serialize the string into JSON to use it further.  An [ImageNotFound](#ImageNotFound) error will
+# be returned if the image cannot be found.
 method InspectImage(name: string) -> (image: string)
+
+# HistoryImage takes the name or ID of an image and returns information about its history and layers.  The returned
+# history is in the form of an array of ImageHistory structures.  If the image cannot be found, an
+# [ImageNotFound](#ImageNotFound) error is returned.
 method HistoryImage(name: string) -> (history: []ImageHistory)
-method PushImage(name: string, tag: string, tlsverify: bool) -> ()
-method TagImage(name: string, tagged: string) -> ()
+
+# PushImage takes three input arguments: the name or ID of an image, the fully-qualified destination name of the image,
+# and a boolean as to whether tls-verify should be used.  It will return an [ImageNotFound](#ImageNotFound) error if
+# the image cannot be found in local storage; otherwise the ID of the image will be returned on success.
+method PushImage(name: string, tag: string, tlsverify: bool) -> (image: string)
+
+# TagImage takes the name or ID of an image in local storage as well as the desired tag name.  If the image cannot
+# be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
+method TagImage(name: string, tagged: string) -> (image: string)
+
+# RemoveImage takes the name or ID of an image as well as a booleon that determines if containers using that image
+# should be deleted.  If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned.  The
+# ID of the removed image is returned when complete.  See also [DeleteUnusedImages](DeleteUnusedImages).
+# #### Example
+# ~~~
+# varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.RemoveImage '{"name": "registry.fedoraproject.org/fedora", "force": true}'
+# {
+#   "image": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
+# }
+# ~~~
 method RemoveImage(name: string, force: bool) -> (image: string)
+
+# SearchImage takes the string of an image name and a limit of searches from each registries to be returned.  SearchImage
+# will then use a glob-like match to find the image you are searching for.  The images are returned in an array of
+# ImageSearch structures which contain information about the image as well as its fully-qualified name.
 method SearchImage(name: string, limit: int) -> (images: []ImageSearch)
+
+# DeleteUnusedImages deletes any images not associated with a container.  The IDs of the deleted images are returned
+# in a string array.
 method DeleteUnusedImages() -> (images: []string)
+
+# This method is not implemented.
 method CreateFromContainer() -> (notimplemented: NotImplemented)
+
+# ImportImage imports an image from a source (like tarball) into local storage.  The image can have additional
+# descriptions added to it using the message and changes options. See also [ExportImage](ExportImage).
 method ImportImage(source: string, reference: string, message: string, changes: []string) -> (image: string)
-method ExportImage(name: string, destination: string, compress: bool) -> ()
+
+# ExportImage takes the name or ID of an image and exports it to a destination like a tarball.  There is also
+# a booleon option to force compression.  Upon completion, the ID of the image is returned. If the image cannot
+# be found in local storage, an [ImageNotFound](#ImageNotFound) error will be returned. See also [ImportImage](ImportImage).
+method ExportImage(name: string, destination: string, compress: bool) -> (image: string)
+
+# PullImage pulls an image from a repository to local storage.  After the pull is successful, the ID of the image
+# is returned.
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/io.projectatomic.podman/io.projectatomic.podman.PullImage '{"name": "registry.fedoraproject.org/fedora"}'
+# {
+#   "id": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
+# }
+# ~~~
 method PullImage(name: string) -> (id: string)
 
 
-# Something failed
-error ActionFailed (reason: string)
+# ImageNotFound means the image could not be found by the provided name or ID in local storage.
 error ImageNotFound (name: string)
+
+# ContainerNotFound means the container could not be found by the provided name or ID in local storage.
 error ContainerNotFound (name: string)
+
+# ErrorOccurred is a generic error for an error that occurs during the execution.  The actual error message
+# is includes as part of the error's text.
 error ErrorOccurred (reason: string)
+
+# RuntimeErrors generally means a runtime could not be found or gotten.
 error RuntimeError (reason: string)
 `
 }

--- a/docs/generate.go
+++ b/docs/generate.go
@@ -1,0 +1,3 @@
+package docs
+
+//go:generate go run varlink/apidoc.go ../cmd/podman/varlink/io.projectatomic.podman.varlink ../API.md

--- a/docs/varlink/apidoc.go
+++ b/docs/varlink/apidoc.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/varlink/go/varlink/idl"
+)
+
+func readFileToString(path string) (string, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func exit(err error) {
+	fmt.Println(err.Error())
+	os.Exit(1)
+}
+
+func typeToString(input *idl.Type) string {
+	switch input.Kind {
+	case idl.TypeString:
+		return "string"
+	case idl.TypeBool:
+		return "bool"
+	case idl.TypeFloat:
+		return "float"
+	case idl.TypeArray:
+		result := input.ElementType.Alias
+		if result == "" {
+			return fmt.Sprintf("[]%s", typeToString(input.ElementType))
+		}
+		return result
+	case idl.TypeAlias:
+		return input.Alias
+	case idl.TypeMap:
+		return "map[string]"
+	case idl.TypeInt:
+		return "int"
+	}
+	return ""
+}
+
+func typeToLink(input string) string {
+	switch input {
+	case "string":
+		return "https://godoc.org/builtin#string"
+	case "int":
+		return "https://godoc.org/builtin#int"
+	case "bool":
+		return "https://godoc.org/builtin#bool"
+	case "float":
+		return "https://golang.org/src/builtin/builtin.go#L58"
+	default:
+		return fmt.Sprintf("#%s", input)
+	}
+}
+
+type funcArgs struct {
+	paramName string
+	paramKind string
+}
+type funcDescriber struct {
+	Name         string
+	inputParams  []funcArgs
+	returnParams []funcArgs
+	doc          string
+}
+
+type typeAttrs struct {
+	Name     string
+	AttrType string
+}
+type typeDescriber struct {
+	Name  string
+	doc   string
+	Attrs []typeAttrs
+}
+
+type err struct {
+	Name string
+	doc  string
+}
+
+// collects defined types in the idl
+func getTypes(tidl *idl.IDL) []typeDescriber {
+	var types []typeDescriber
+	for _, x := range tidl.Aliases {
+		i := typeDescriber{
+			Name: x.Name,
+			doc:  x.Doc,
+		}
+		ta := []typeAttrs{}
+		for _, y := range x.Type.Fields {
+			result := typeToString(y.Type)
+			ta = append(ta, typeAttrs{Name: y.Name, AttrType: result})
+		}
+		i.Attrs = ta
+		types = append(types, i)
+	}
+	return types
+}
+
+// collects defined methods in the idl
+func getMethods(midl *idl.IDL) []funcDescriber {
+	var methods []funcDescriber
+	for _, t := range midl.Methods {
+		m := funcDescriber{
+			Name: t.Name,
+			doc:  t.Doc,
+		}
+		fa := []funcArgs{}
+		fo := []funcArgs{}
+
+		for _, i := range t.In.Fields {
+			fa = append(fa, funcArgs{paramName: i.Name, paramKind: typeToString(i.Type)})
+
+		}
+		for _, f := range t.Out.Fields {
+			fo = append(fo, funcArgs{paramName: f.Name, paramKind: typeToString(f.Type)})
+		}
+		m.inputParams = fa
+		m.returnParams = fo
+		methods = append(methods, m)
+	}
+	return methods
+}
+
+// collects defined errors in the idl
+func getErrors(midl *idl.IDL) []err {
+	var errors []err
+	for _, e := range midl.Errors {
+		myError := err{
+			Name: e.Name,
+			doc:  e.Doc,
+		}
+		errors = append(errors, myError)
+	}
+	return errors
+}
+
+// generates the index for the top of the markdown page
+func generateIndex(methods []funcDescriber, types []typeDescriber, errors []err, b bytes.Buffer) bytes.Buffer {
+	for _, method := range methods {
+		var inArgs []string
+		var outArgs []string
+		for _, inArg := range method.inputParams {
+			inArgs = append(inArgs, fmt.Sprintf("%s: %s", inArg.paramName, inArg.paramKind))
+
+		}
+		for _, outArg := range method.returnParams {
+			outArgs = append(outArgs, fmt.Sprintf("%s", outArg.paramKind))
+
+		}
+		b.WriteString(fmt.Sprintf("\n[func %s(%s) %s](#%s)\n", method.Name, strings.Join(inArgs, ", "), strings.Join(outArgs, ", "), method.Name))
+	}
+	for _, t := range types {
+		b.WriteString(fmt.Sprintf("[type %s](#%s)\n\n", t.Name, t.Name))
+	}
+	for _, e := range errors {
+		b.WriteString(fmt.Sprintf("[error %s](#%s)\n\n", e.Name, e.Name))
+	}
+	return b
+}
+
+// performs the output for defined methods
+func generateFuncDescriptions(methods []funcDescriber, b bytes.Buffer) bytes.Buffer {
+	for _, method := range methods {
+		b.WriteString(fmt.Sprintf("### <a name=\"%s\"></a>func %s\n", method.Name, method.Name))
+		var inArgs []string
+		var outArgs []string
+		for _, inArg := range method.inputParams {
+			inArgs = append(inArgs, fmt.Sprintf("%s: [%s](%s)", inArg.paramName, inArg.paramKind, typeToLink(inArg.paramKind)))
+		}
+		for _, outArg := range method.returnParams {
+			outArgs = append(outArgs, fmt.Sprintf("[%s](%s)", outArg.paramKind, typeToLink(outArg.paramKind)))
+		}
+		b.WriteString(fmt.Sprintf("<div style=\"background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;\">\n\nmethod %s(%s) %s</div>", method.Name, strings.Join(inArgs, ", "), strings.Join(outArgs, ", ")))
+		b.WriteString("\n")
+		b.WriteString(method.doc)
+		b.WriteString("\n")
+	}
+	return b
+}
+
+// performs the output for defined types/structs
+func generateTypeDescriptions(types []typeDescriber, b bytes.Buffer) bytes.Buffer {
+	for _, t := range types {
+		b.WriteString(fmt.Sprintf("### <a name=\"%s\"></a>type %s\n", t.Name, t.Name))
+		b.WriteString(fmt.Sprintf("\n%s\n", t.doc))
+		for _, i := range t.Attrs {
+			b.WriteString(fmt.Sprintf("\n%s [%s](%s)\n", i.Name, i.AttrType, typeToLink(i.AttrType)))
+		}
+	}
+	return b
+}
+
+// performs the output for defined errors
+func generateErrorDescriptions(errors []err, b bytes.Buffer) bytes.Buffer {
+	for _, e := range errors {
+		b.WriteString(fmt.Sprintf("### <a name=\"%s\"></a>type %s\n", e.Name, e.Name))
+		b.WriteString(fmt.Sprintf("\n%s\n", e.doc))
+	}
+	return b
+}
+
+func main() {
+	args := os.Args
+	if len(args) < 2 {
+		exit(fmt.Errorf("you must provide an input and output path"))
+	}
+	varlinkFile := args[1]
+	mdFile := args[2]
+
+	varlinkInput, err := readFileToString(varlinkFile)
+	if err != nil {
+		exit(err)
+	}
+	varlinkInput = strings.TrimRight(varlinkInput, "\n")
+
+	// Run the idl parser
+	midl, err := idl.New(varlinkInput)
+	if err != nil {
+		exit(err)
+	}
+
+	// Collect up the info from the idl
+	methods := getMethods(midl)
+	types := getTypes(midl)
+	errors := getErrors(midl)
+
+	out := bytes.Buffer{}
+	out.WriteString("## Index\n")
+	out = generateIndex(methods, types, errors, out)
+	out.WriteString("## Methods\n")
+	out = generateFuncDescriptions(methods, out)
+	out.WriteString("## Types\n")
+	out = generateTypeDescriptions(types, out)
+	out.WriteString("## Errors\n")
+	out = generateErrorDescriptions(errors, out)
+	ioutil.WriteFile(mdFile, out.Bytes(), 0755)
+}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -140,7 +140,7 @@ func (i *LibpodAPI) PushImage(call ioprojectatomicpodman.VarlinkCall, name, tag 
 	if err := newImage.PushImage(getContext(), destname, "", "", "", nil, false, so, &dockerRegistryOptions); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	return call.ReplyPushImage()
+	return call.ReplyPushImage(newImage.ID())
 }
 
 // TagImage accepts an image name and tag as strings and tags an image in the local store.
@@ -156,7 +156,7 @@ func (i *LibpodAPI) TagImage(call ioprojectatomicpodman.VarlinkCall, name, tag s
 	if err := newImage.TagImage(tag); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	return call.ReplyTagImage()
+	return call.ReplyTagImage(newImage.ID())
 }
 
 // RemoveImage accepts a image name or ID as a string and force bool to determine if it should
@@ -275,7 +275,7 @@ func (i *LibpodAPI) ExportImage(call ioprojectatomicpodman.VarlinkCall, name, de
 	if err := newImage.PushImage(getContext(), destination, "", "", "", nil, compress, image.SigningOptions{}, &image.DockerRegistryOptions{}); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	return call.ReplyExportImage()
+	return call.ReplyExportImage(newImage.ID())
 }
 
 // PullImage pulls an image from a registry to the image store.

--- a/vendor/github.com/varlink/go/cmd/varlink-go-certification/main.go
+++ b/vendor/github.com/varlink/go/cmd/varlink-go-certification/main.go
@@ -1,0 +1,619 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification"
+	"github.com/varlink/go/varlink"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+func run_client(address string) {
+	c, err := varlink.NewConnection(address)
+	if err != nil {
+		fmt.Println("Failed to connect")
+		return
+	}
+	defer c.Close()
+
+	client_id, err := orgvarlinkcertification.Start().Call(c)
+	if err != nil {
+		fmt.Println("Start() failed")
+		return
+	}
+	fmt.Printf("Start: '%v'\n", client_id)
+
+	b1, err := orgvarlinkcertification.Test01().Call(c, client_id)
+	if err != nil {
+		fmt.Println("Test01() failed")
+		return
+	}
+	fmt.Printf("Test01: '%v'\n", b1)
+
+	i2, err := orgvarlinkcertification.Test02().Call(c, client_id, b1)
+	if err != nil {
+		fmt.Println("Test02() failed")
+		return
+	}
+	fmt.Printf("Test02: '%v'\n", i2)
+
+	f3, err := orgvarlinkcertification.Test03().Call(c, client_id, i2)
+	if err != nil {
+		fmt.Println("Test03() failed")
+		return
+	}
+	fmt.Printf("Test03: '%v'\n", f3)
+
+	s4, err := orgvarlinkcertification.Test04().Call(c, client_id, f3)
+	if err != nil {
+		fmt.Println("Test04() failed")
+		return
+	}
+	fmt.Printf("Test04: '%v'\n", s4)
+
+	b5, i5, f5, s5, err := orgvarlinkcertification.Test05().Call(c, client_id, s4)
+	if err != nil {
+		fmt.Println("Test05() failed")
+		return
+	}
+	fmt.Printf("Test05: '%v'\n", b5)
+
+	o6, err := orgvarlinkcertification.Test06().Call(c, client_id, b5, i5, f5, s5)
+	if err != nil {
+		fmt.Println("Test06() failed")
+		return
+	}
+	fmt.Printf("Test06: '%v'\n", o6)
+
+	m7, err := orgvarlinkcertification.Test07().Call(c, client_id, o6)
+	if err != nil {
+		fmt.Println("Test07() failed")
+		return
+	}
+	fmt.Printf("Test07: '%v'\n", m7)
+
+	m8, err := orgvarlinkcertification.Test08().Call(c, client_id, m7)
+	if err != nil {
+		fmt.Println("Test08() failed")
+		return
+	}
+	fmt.Printf("Test08: '%v'\n", m8)
+
+	t9, err := orgvarlinkcertification.Test09().Call(c, client_id, m8)
+	if err != nil {
+		fmt.Println("Test09() failed")
+		return
+	}
+	fmt.Printf("Test09: '%v'\n", t9)
+
+	receive10, err := orgvarlinkcertification.Test10().Send(c, varlink.More, client_id, t9)
+	if err != nil {
+		fmt.Println("Test10() failed")
+		return
+	}
+
+	fmt.Println("Test10() Send:")
+	var a10 []string
+	for {
+		s10, flags10, err := receive10()
+		if err != nil {
+			fmt.Println("Test10() receive failed")
+			return
+		}
+		a10 = append(a10, s10)
+		fmt.Printf("  Receive: '%v'\n", s10)
+
+		if flags10&varlink.Continues == 0 {
+			break
+		}
+	}
+	fmt.Printf("Test10: '%v'\n", a10)
+
+	_, err = orgvarlinkcertification.Test11().Send(c, varlink.Oneway, client_id, a10)
+	if err != nil {
+		fmt.Println("Test11() failed")
+		return
+	}
+	fmt.Println("Test11: ''")
+
+	end, err := orgvarlinkcertification.End().Call(c, client_id)
+	if err != nil {
+		fmt.Println("End() failed")
+		return
+	}
+	fmt.Printf("End: '%v'\n", end)
+}
+
+// Service
+type client struct {
+	id   string
+	time time.Time
+}
+
+type test struct {
+	orgvarlinkcertification.VarlinkInterface
+	mutex   sync.Mutex
+	clients map[string]*client
+}
+
+func (t *test) Client(id string) *client {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return t.clients[id]
+}
+
+func (t *test) NewClient() *client {
+	id128 := make([]byte, 16)
+	io.ReadFull(rand.Reader, id128)
+	id128[8] = id128[8]&^0xc0 | 0x80
+	id128[6] = id128[6]&^0xf0 | 0x40
+	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", id128[0:4], id128[4:6], id128[6:8], id128[8:10], id128[10:])
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// Garbage-collect old clients
+	for key, client := range t.clients {
+		if time.Since(client.time).Minutes() > 1 {
+			delete(t.clients, key)
+		}
+	}
+
+	if len(t.clients) > 100 {
+		return nil
+	}
+
+	c := client{
+		id:   uuid,
+		time: time.Now(),
+	}
+	t.clients[uuid] = &c
+
+	return &c
+}
+
+func (t *test) RemoveClient(id string) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	delete(t.clients, id)
+}
+
+func (t *test) Start(c orgvarlinkcertification.VarlinkCall) error {
+	return c.ReplyStart(t.NewClient().id)
+}
+
+func (t *test) Test01(c orgvarlinkcertification.VarlinkCall, client_id_ string) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	return c.ReplyTest01(true)
+}
+
+func (t *test) Test02(c orgvarlinkcertification.VarlinkCall, client_id_ string, bool_ bool) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if !bool_ {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	return c.ReplyTest02(1)
+}
+
+func (t *test) Test03(c orgvarlinkcertification.VarlinkCall, client_id_ string, int_ int64) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if int_ != 1 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	return c.ReplyTest03(1.0)
+}
+
+func (t *test) Test04(c orgvarlinkcertification.VarlinkCall, client_id_ string, float_ float64) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if float_ != 1.0 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	return c.ReplyTest04("ping")
+}
+func (t *test) Test05(c orgvarlinkcertification.VarlinkCall, client_id_ string, string_ string) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if string_ != "ping" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	return c.ReplyTest05(false, 2, math.Pi, "a lot of string")
+}
+
+func (t *test) Test06(c orgvarlinkcertification.VarlinkCall, client_id_ string, bool_ bool, int_ int64, float_ float64, string_ string) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if bool_ {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if int_ != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if float_ != math.Pi {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if string_ != "a lot of string" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	s := struct {
+		Bool   bool
+		Int    int64
+		Float  float64
+		String string
+	}{
+		Bool:   false,
+		Int:    2,
+		Float:  math.Pi,
+		String: "a lot of string",
+	}
+	return c.ReplyTest06(s)
+}
+
+func (t *test) Test07(c orgvarlinkcertification.VarlinkCall, client_id_ string, struct_ struct {
+	Bool   bool
+	Int    int64
+	Float  float64
+	String string
+}) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if struct_.Bool {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if struct_.Int != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if struct_.Float != math.Pi {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if struct_.String != "a lot of string" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	m := map[string]string{
+		"bar": "Bar",
+		"foo": "Foo",
+	}
+	return c.ReplyTest07(m)
+}
+
+func (t *test) Test08(c orgvarlinkcertification.VarlinkCall, client_id_ string, map_ map[string]string) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if len(map_) != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if map_["bar"] != "Bar" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if map_["foo"] != "Foo" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	m := map[string]struct{}{
+		"one":   {},
+		"two":   {},
+		"three": {},
+	}
+	return c.ReplyTest08(m)
+}
+
+func (t *test) Test09(c orgvarlinkcertification.VarlinkCall, client_id_ string, set_ map[string]struct{}) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if len(set_) != 3 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	_, ok := set_["one"]
+	if !ok {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	_, ok = set_["two"]
+	if !ok {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	_, ok = set_["three"]
+	if !ok {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	m := orgvarlinkcertification.MyType{
+		Object: json.RawMessage(`{"method": "org.varlink.certification.Test09", "parameters": {"map": {"foo": "Foo", "bar": "Bar"}}}`),
+		Enum:   "two",
+		Struct: struct {
+			First  int64  `json:"first"`
+			Second string `json:"second"`
+		}{First: 1, Second: "2"},
+		Array:                 []string{"one", "two", "three"},
+		Dictionary:            map[string]string{"foo": "Foo", "bar": "Bar"},
+		Stringset:             map[string]struct{}{"one": {}, "two": {}, "three": {}},
+		Nullable:              nil,
+		Nullable_array_struct: nil,
+		Interface: orgvarlinkcertification.Interface{
+			Foo: &[]*map[string]string{
+				nil,
+				&map[string]string{"Foo": "foo", "Bar": "bar"},
+				nil,
+				&map[string]string{"one": "foo", "two": "bar"},
+			},
+			Anon: struct {
+				Foo bool `json:"foo"`
+				Bar bool `json:"bar"`
+			}{Foo: true, Bar: false},
+		},
+	}
+	return c.ReplyTest09(m)
+}
+
+func (t *test) Test10(c orgvarlinkcertification.VarlinkCall, client_id_ string, mytype_ orgvarlinkcertification.MyType) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	var o struct {
+		Method     string `json:"method"`
+		Parameters struct {
+			Map map[string]string `json:"map"`
+		} `json:"parameters"`
+	}
+	err := json.Unmarshal(mytype_.Object, &o)
+	if err != nil {
+		return err
+	}
+
+	if o.Method != "org.varlink.certification.Test09" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if len(o.Parameters.Map) != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if o.Parameters.Map["bar"] != "Bar" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if o.Parameters.Map["foo"] != "Foo" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Enum != "two" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Struct.First != 1 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Struct.Second != "2" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if len(mytype_.Array) != 3 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Array[0] != "one" && mytype_.Array[1] != "two" && mytype_.Array[2] != "three" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if len(mytype_.Dictionary) != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Dictionary["bar"] != "Bar" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Dictionary["foo"] != "Foo" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if len(mytype_.Stringset) != 3 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	_, ok := mytype_.Stringset["one"]
+	if !ok {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	_, ok = mytype_.Stringset["two"]
+	if !ok {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	_, ok = mytype_.Stringset["three"]
+	if !ok {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Nullable != nil {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Nullable_array_struct != nil {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	i := *mytype_.Interface.Foo
+	if len(i) != 4 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if i[0] != nil {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if len(*i[1]) != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if (*i[1])["Foo"] != "foo" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if (*i[1])["Bar"] != "bar" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if i[2] != nil {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if len(*i[3]) != 2 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if (*i[3])["one"] != "foo" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if (*i[3])["two"] != "bar" {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if !mytype_.Interface.Anon.Foo {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if mytype_.Interface.Anon.Bar {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if !c.WantsMore() {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	for i := 1; i <= 10; i++ {
+		c.Continues = i < 10
+		err := c.ReplyTest10("Reply number " + strconv.Itoa(i))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *test) Test11(c orgvarlinkcertification.VarlinkCall, client_id_ string, last_more_replies_ []string) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	if len(last_more_replies_) != 10 {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	if !c.IsOneway() {
+		return c.ReplyCertificationError(nil, nil)
+	}
+
+	for i := 1; i <= 10; i++ {
+		if last_more_replies_[i] != "Reply number "+strconv.Itoa(i) {
+			return c.ReplyCertificationError(nil, nil)
+		}
+	}
+
+	return c.ReplyTest11()
+}
+
+func (t *test) End(c orgvarlinkcertification.VarlinkCall, client_id_ string) error {
+	if t.Client(client_id_) == nil {
+		return c.ReplyClientIdError()
+	}
+
+	t.RemoveClient(client_id_)
+	return c.ReplyEnd(true)
+}
+
+func run_server(address string) {
+	t := test{
+		clients: make(map[string]*client),
+	}
+
+	s, err := varlink.NewService(
+		"Varlink",
+		"Certification",
+		"1",
+		"https://github.com/varlink/go",
+	)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	s.RegisterInterface(orgvarlinkcertification.VarlinkNew(&t))
+	err = s.Listen(address, 0)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	var address string
+	var client bool
+
+	flag.StringVar(&address, "varlink", "", "Varlink address")
+	flag.BoolVar(&client, "client", false, "Run as client")
+	flag.Parse()
+
+	if address == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if client {
+		run_client(address)
+		return
+	}
+
+	run_server(address)
+}

--- a/vendor/github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification/generate.go
+++ b/vendor/github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification/generate.go
@@ -1,0 +1,3 @@
+package orgvarlinkcertification
+
+//go:generate go run ../../varlink-go-interface-generator/main.go org.varlink.certification.varlink

--- a/vendor/github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification/org.varlink.certification.varlink
+++ b/vendor/github.com/varlink/go/cmd/varlink-go-certification/orgvarlinkcertification/org.varlink.certification.varlink
@@ -1,0 +1,89 @@
+# Interface to test varlink implementations against.
+# First you write a varlink client calling:
+# Start, Test01, Test02, …, Test09, End
+# The return value of the previous call should be the argument of the next call.
+# Then you test this client against well known servers like python or rust from
+# https://github.com/varlink/
+#
+# Next you write a varlink server providing the same service as the well known ones.
+# Now run your client against it and run well known clients like python or rust
+# from https://github.com/varlink/ against your server. If all works out, then
+# your new language bindings should be varlink certified.
+interface org.varlink.certification
+
+type Interface (
+  foo: ?[]?[string](foo, bar, baz),
+  anon: (foo: bool, bar: bool)
+)
+
+type MyType (
+  object: object,
+  enum: (one, two, three),
+  struct: (first: int, second: string),
+  array: []string,
+  dictionary: [string]string,
+  stringset: [string](),
+  nullable: ?string,
+  nullable_array_struct: ?[](first: int, second: string),
+  interface: Interface
+)
+
+method Start() -> (client_id: string)
+
+method Test01(client_id: string) -> (bool: bool)
+
+method Test02(client_id: string, bool: bool) -> (int: int)
+
+method Test03(client_id: string, int: int) -> (float: float)
+
+method Test04(client_id: string, float: float) -> (string: string)
+
+method Test05(client_id: string, string: string) -> (
+  bool: bool,
+  int: int,
+  float: float,
+  string: string
+)
+
+method Test06(
+  client_id: string,
+  bool: bool,
+  int: int,
+  float: float,
+  string: string
+) -> (
+  struct: (
+    bool: bool,
+    int: int,
+    float: float,
+    string: string
+  )
+)
+
+method Test07(
+  client_id: string,
+  struct: (
+    bool: bool,
+    int: int,
+    float: float,
+    string: string
+  )
+) -> (map: [string]string)
+
+method Test08(client_id: string, map: [string]string) -> (set: [string]())
+
+method Test09(client_id: string, set: [string]()) -> (mytype: MyType)
+
+# returns more than one reply with "continues"
+method Test10(client_id: string, mytype: MyType) -> (string: string)
+
+method Test11(
+  client_id: string,
+  last_more_replies: []string
+) -> ()
+
+method End(client_id: string) -> (all_ok: bool)
+
+error ClientIdError ()
+
+error CertificationError (wants: object, got: object)

--- a/vendor/github.com/varlink/go/varlink/call.go
+++ b/vendor/github.com/varlink/go/varlink/call.go
@@ -21,9 +21,9 @@ func (c *Call) WantsMore() bool {
 	return c.in.More
 }
 
-// IsOneShot indicate that the calling client does not expect a reply.
-func (c *Call) IsOneShot() bool {
-	return c.in.OneShot
+// IsOneway indicate that the calling client does not expect a reply.
+func (c *Call) IsOneway() bool {
+	return c.in.Oneway
 }
 
 // GetParameters retrieves the method call parameters.
@@ -35,7 +35,7 @@ func (c *Call) GetParameters(p interface{}) error {
 }
 
 func (c *Call) sendMessage(r *serviceReply) error {
-	if c.in.OneShot {
+	if c.in.Oneway {
 		return nil
 	}
 

--- a/vendor/github.com/varlink/go/varlink/idl/idl.go
+++ b/vendor/github.com/varlink/go/varlink/idl/idl.go
@@ -58,6 +58,7 @@ type Method struct {
 // Error represents an error defined in the interface description.
 type Error struct {
 	Name string
+	Doc  string
 	Type *Type
 }
 
@@ -393,6 +394,7 @@ func (p *parser) readError(idl *IDL) (*Error, error) {
 	e := &Error{}
 
 	p.advance()
+	e.Doc = p.lastComment.String()
 	e.Name = p.readTypeName()
 	if e.Name == "" {
 		return nil, fmt.Errorf("missing error name")

--- a/vendor/github.com/varlink/go/varlink/service.go
+++ b/vendor/github.com/varlink/go/varlink/service.go
@@ -23,7 +23,7 @@ type serviceCall struct {
 	Method     string           `json:"method"`
 	Parameters *json.RawMessage `json:"parameters,omitempty"`
 	More       bool             `json:"more,omitempty"`
-	OneShot    bool             `json:"oneshot,omitempty"`
+	Oneway     bool             `json:"oneway,omitempty"`
 }
 
 type serviceReply struct {

--- a/vendor/github.com/varlink/go/varlink/varlink_test.go
+++ b/vendor/github.com/varlink/go/varlink/varlink_test.go
@@ -140,7 +140,7 @@ func (s *VarlinkInterface) VarlinkDispatch(call Call, methodname string) error {
 		if !call.WantsMore() {
 			return fmt.Errorf("More flag not passed")
 		}
-		if call.IsOneShot() {
+		if call.IsOneway() {
 			return fmt.Errorf("OneShot flag set")
 		}
 		call.Continues = true


### PR DESCRIPTION
Using varlink's idl parser, we generate API documentation for the podman
API relying on the .varlink file as the source.

Signed-off-by: baude <bbaude@redhat.com>