### PR TITLE
podman push should honor registries.conf

### DIFF
--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -80,6 +80,7 @@ func pushCmd(c *cli.Context) error {
 	var (
 		registryCreds *types.DockerAuthConfig
 		destName      string
+		forceSecure   bool
 	)
 
 	args := c.Args()
@@ -143,6 +144,10 @@ func pushCmd(c *cli.Context) error {
 		}
 	}
 
+	if c.IsSet("tls-verify") {
+		forceSecure = c.Bool("tls-verify")
+	}
+
 	dockerRegistryOptions := image.DockerRegistryOptions{
 		DockerRegistryCreds:         registryCreds,
 		DockerCertPath:              certPath,
@@ -160,5 +165,5 @@ func pushCmd(c *cli.Context) error {
 	}
 
 	//return runtime.PushImage(srcName, destName, options)
-	return newImage.PushImage(getContext(), destName, manifestType, c.String("authfile"), c.String("signature-policy"), writer, c.Bool("compress"), so, &dockerRegistryOptions)
+	return newImage.PushImage(getContext(), destName, manifestType, c.String("authfile"), c.String("signature-policy"), writer, c.Bool("compress"), so, &dockerRegistryOptions, forceSecure)
 }

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -121,7 +121,7 @@ func saveCmd(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := newImage.PushImage(getContext(), dest, manifestType, "", "", writer, c.Bool("compress"), libpodImage.SigningOptions{}, &libpodImage.DockerRegistryOptions{}); err != nil {
+		if err := newImage.PushImage(getContext(), dest, manifestType, "", "", writer, c.Bool("compress"), libpodImage.SigningOptions{}, &libpodImage.DockerRegistryOptions{}, false); err != nil {
 			if err2 := os.Remove(output); err2 != nil {
 				logrus.Errorf("error deleting %q: %v", output, err)
 			}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -137,7 +137,7 @@ func (i *LibpodAPI) PushImage(call ioprojectatomicpodman.VarlinkCall, name, tag 
 
 	so := image.SigningOptions{}
 
-	if err := newImage.PushImage(getContext(), destname, "", "", "", nil, false, so, &dockerRegistryOptions); err != nil {
+	if err := newImage.PushImage(getContext(), destname, "", "", "", nil, false, so, &dockerRegistryOptions, false); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
 	return call.ReplyPushImage(newImage.ID())
@@ -272,7 +272,7 @@ func (i *LibpodAPI) ExportImage(call ioprojectatomicpodman.VarlinkCall, name, de
 	if err != nil {
 		return call.ReplyImageNotFound(name)
 	}
-	if err := newImage.PushImage(getContext(), destination, "", "", "", nil, compress, image.SigningOptions{}, &image.DockerRegistryOptions{}); err != nil {
+	if err := newImage.PushImage(getContext(), destination, "", "", "", nil, compress, image.SigningOptions{}, &image.DockerRegistryOptions{}, false); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
 	return call.ReplyExportImage(newImage.ID())


### PR DESCRIPTION
Like podman pull, when you push an image, podman should check
if the registry is listed as insecure and if so, it should
--tls-verify=false unless the user overrides this.

Signed-off-by: baude <bbaude@redhat.com>