### PR TITLE
vendor.conf: Bump containerd/cgroups to 77e62851

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,7 @@ github.com/Microsoft/hcsshim 43f9725307998e09f2e3816c2c0c36dc98f0c982
 github.com/blang/semver v3.5.0
 github.com/boltdb/bolt master
 github.com/buger/goterm 2f8dfbc7dbbff5dd1d391ed91482c24df243b2d3
-github.com/containerd/cgroups 7a5fdd8330119dc70d850260db8f3594d89d6943
+github.com/containerd/cgroups 77e628511d924b13a77cebdc73b757a47f6d751b
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.4.0
 github.com/containernetworking/plugins master


### PR DESCRIPTION
`vendor.conf` has been pinned at containerd/cgroups@7a5fdd83 (Merge pull request \#26 from onorua/error-ignore-example, 2017-08-24) since libpod forked from CRI-O with a031b83a (Initial checkin from CRI-O repo, 2017-11-01).  The content in `vendor/github.com/containerd/cgroups` was bumped to containerd/cgroups@77e62851 (Use /proc/diskstats to get device names, 2018-01-31) in ae89dc28 (Update containerd/cgroups repo fix perf issue, 2018-02-01, #284), but ae89dc28 forgot to update `vendor.conf`.  With this commit:

```console
$ vndr github.com/containerd/cgroups
```

no longer changes anything under `vendor/github.com/containerd/cgroups`.

Spun off from #747.