### PR TITLE
vendor.conf: Pin containernetworking/plugins to 1fb94a42

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@ github.com/buger/goterm 2f8dfbc7dbbff5dd1d391ed91482c24df243b2d3
 github.com/containerd/cgroups 77e628511d924b13a77cebdc73b757a47f6d751b
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.6.0
-github.com/containernetworking/plugins master
+github.com/containernetworking/plugins 1fb94a4222eafc6f948eacdca9c9f2158b427e53
 github.com/containers/image 88423e35d5f11939b0db4fb8f2939fc04adf2463
 github.com/containers/storage e454acf9874d6c399ccb87d03fc4dcbe8c1a4cc6
 github.com/coreos/go-systemd v14


### PR DESCRIPTION
containernetworking/plugins@a0eac8d7 (pkg/ns: remove namespace creation, 2018-03-16) removed `NewNS`, which we use in `libpod/networking.go`.  Pinning to the previous commit, containernetworking/plugins@1fb94a42 (Merge pull request \#96 from DennisDenuto/denuto/master, 2018-03-14), allows us to run `vndr` without breaking our build.  This is a short term fix; moving forward we'll want to either drop this dependency or catch up with the new upstream API.

The upstream package seems to have been fairly stable in the meantime, because even with the new pinned version, a `vndr` re-vendor generates no changes:

```console
$ vndr github.com/containernetworking/plugins
```

Spun off from #747.