### PR TITLE
Fix varlink remove image force

### DIFF
--- a/API.md
+++ b/API.md
@@ -78,6 +78,7 @@ in the [API.md](https://github.com/projectatomic/libpod/blob/master/API.md) file
 [func UpdateContainer() NotImplemented](#UpdateContainer)
 
 [func WaitContainer(name: string) int](#WaitContainer)
+
 [type ContainerChanges](#ContainerChanges)
 
 [type ContainerMount](#ContainerMount)

--- a/docs/varlink/apidoc.go
+++ b/docs/varlink/apidoc.go
@@ -184,6 +184,7 @@ func generateIndex(methods []funcDescriber, types []typeDescriber, errors []err,
 		}
 		b.WriteString(fmt.Sprintf("\n[func %s(%s) %s](#%s)\n", method.Name, strings.Join(inArgs, ", "), strings.Join(outArgs, ", "), method.Name))
 	}
+	b.WriteString("\n")
 	for _, t := range types {
 		b.WriteString(fmt.Sprintf("[type %s](#%s)\n\n", t.Name, t.Name))
 	}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -170,10 +170,11 @@ func (i *LibpodAPI) RemoveImage(call ioprojectatomicpodman.VarlinkCall, name str
 	if err != nil {
 		return call.ReplyImageNotFound(name)
 	}
-	if err := newImage.Remove(force); err != nil {
+	imageID, err := runtime.RemoveImage(newImage, force)
+	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	return call.ReplyRemoveImage(newImage.ID())
+	return call.ReplyRemoveImage(imageID)
 }
 
 // SearchImage searches all registries configured in /etc/containers/registries.conf for an image


### PR DESCRIPTION
Fixes a bug where the force bool was being ignored when deleting images
via the varlink interface.

Also, minor fix to the docs to add a line break between methods and types in
the doc index.

Signed-off-by: baude <bbaude@redhat.com>