### PR TITLE
hooks: Fix monitoring of multiple directories

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -1,4 +1,4 @@
-// Package hooks implements CRI-O's hook handling.
+// Package hooks implements hook configuration and handling for CRI-O and libpod.
 package hooks
 
 import (

--- a/pkg/hooks/monitor_test.go
+++ b/pkg/hooks/monitor_test.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func TestMonitorGood(t *testing.T) {
+func TestMonitorOneDirGood(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	dir, err := ioutil.TempDir("", "hooks-test-")
 	if err != nil {
@@ -92,7 +92,7 @@ func TestMonitorGood(t *testing.T) {
 	})
 
 	t.Run("bad-addition", func(t *testing.T) {
-		err = ioutil.WriteFile(jsonPath, []byte("{\"version\": \"-1\"]}"), 0644)
+		err = ioutil.WriteFile(jsonPath, []byte("{\"version\": \"-1\"}"), 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -111,6 +111,197 @@ func TestMonitorGood(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	})
+
+	cancel()
+	err = <-sync
+	assert.Equal(t, context.Canceled, err)
+}
+
+func TestMonitorTwoDirGood(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	primaryDir, err := ioutil.TempDir("", "hooks-test-primary-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(primaryDir)
+
+	fallbackDir, err := ioutil.TempDir("", "hooks-test-fallback-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(fallbackDir)
+
+	lang, err := language.Parse("und-u-va-posix")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := New(ctx, []string{fallbackDir, primaryDir}, []string{}, lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sync := make(chan error, 2)
+	go manager.Monitor(ctx, sync)
+	err = <-sync
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fallbackPath := filepath.Join(fallbackDir, "a.json")
+	fallbackJSON := []byte(fmt.Sprintf("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\"}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}", path))
+	fallbackInjected := &rspec.Hooks{
+		Prestart: []rspec.Hook{
+			{
+				Path: path,
+			},
+		},
+	}
+
+	t.Run("good-fallback-addition", func(t *testing.T) {
+		err = ioutil.WriteFile(fallbackPath, fallbackJSON, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, fallbackInjected, config.Hooks)
+	})
+
+	primaryPath := filepath.Join(primaryDir, "a.json")
+	primaryJSON := []byte(fmt.Sprintf("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\", \"timeout\": 1}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}", path))
+	one := 1
+	primaryInjected := &rspec.Hooks{
+		Prestart: []rspec.Hook{
+			{
+				Path:    path,
+				Timeout: &one,
+			},
+		},
+	}
+
+	t.Run("good-primary-override", func(t *testing.T) {
+		err = ioutil.WriteFile(primaryPath, primaryJSON, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, primaryInjected, config.Hooks)
+	})
+
+	t.Run("good-fallback-removal", func(t *testing.T) {
+		err = os.Remove(fallbackPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, primaryInjected, config.Hooks) // masked by primary
+	})
+
+	t.Run("good-fallback-restore", func(t *testing.T) {
+		err = ioutil.WriteFile(fallbackPath, fallbackJSON, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, primaryInjected, config.Hooks) // masked by primary
+	})
+
+	t.Run("bad-primary-addition", func(t *testing.T) {
+		err = ioutil.WriteFile(primaryPath, []byte("{\"version\": \"-1\"}"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		expected := config.Hooks
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, expected, config.Hooks)
+	})
+
+	t.Run("good-primary-removal", func(t *testing.T) {
+		err = os.Remove(primaryPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, fallbackInjected, config.Hooks)
+	})
+
+	t.Run("good-non-json-addition", func(t *testing.T) {
+		err = ioutil.WriteFile(filepath.Join(fallbackDir, "README"), []byte("Hello"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, fallbackInjected, config.Hooks)
+	})
+
+	t.Run("good-fallback-removal", func(t *testing.T) {
+		err = os.Remove(fallbackPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		expected := config.Hooks
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, expected, config.Hooks)
 	})
 
 	cancel()


### PR DESCRIPTION
This isn't an issue with podman, which will only ever use one directory.  But CRI-O generally uses two directories, and we want to make sure that changes to the fallback directory are not clobbering hooks configured in the override directory (kubernetes-incubator/cri-o#1470).

I've split the handling into a single-directory block and a multiple-directory block so we don't waste time polling the filesystem for single-directory removals.

I'm using the single-directory block for the the zero-directory case as well.  Managers with zero directories should not be receiving fsnotify events, so I don't think it really matters which block handles them.  If we want to handle this case robustly (because we're concerned about something in the hook package adjusted the private .directories property on the fly?), then we'll probably want to add an explicit zero-directory block in future work.