### PR TITLE
Remove stop on error from Docker install switch in baseline tests

### DIFF
--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -28,7 +28,6 @@ done
 if [ "$installdocker" -eq 1 ]
 then
     echo "Script will install and then deinstall Docker."
-    set -eu
 fi
 
 if [ "$showerror" -eq 1 ]


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Remove the "stop on error" command from the switch that turns Docker install/deinstall on.  If there was an error the script would stop when it should have continued.  This "stop on error" command is in the following if statement where the user can toggle that functionality on/off.  

This script is only run "by hand" it is not part of the CI tests.