### PR TITLE
docs: fix contrib/cni broken link

### DIFF
--- a/cni/README.md
+++ b/cni/README.md
@@ -1,0 +1,15 @@
+## `cni` ##
+
+There are a wide variety of different [CNI][cni] network configurations. This
+directory just contains an example configuration that can be used as the
+basis for your own configuration.
+
+To use this configuration, place it in `/etc/cni/net.d` (or the directory
+specified by `cni_config_dir` in your `libpod.conf`).
+
+In addition, you need to install the [CNI plugins][cni] necessary into
+`/opt/cni/bin` (or the directory specified by `cni_plugin_dir`). The
+two plugins necessary for the example CNI configurations are `portmap` and
+`bridge`.
+
+[cni]: https://github.com/containernetworking/plugins

--- a/install.md
+++ b/install.md
@@ -12,10 +12,9 @@ The latest version of `conmon` is expected to be installed on the system. Conmon
 
 #### Setup CNI networking
 
-A proper description of setting up CNI networking is given in the
-[`contrib/cni` README](contrib/cni/README.md). But the gist is that you need to
-have some basic network configurations enabled and CNI plugins installed on
-your system.
+A proper description of setting up CNI networking is given in the [`cni` README](cni/README.md).
+But the gist is that you need to have some basic network configurations enabled and
+CNI plugins installed on your system.
 
 ### Build and Run Dependencies
 


### PR DESCRIPTION
This change updates the install.md documentation to reference the new
cni directory location. This change also restores the previously
deleted README.md with updated instructions.

Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>