### PR TITLE
improve podman commit documentation and error messages

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -80,7 +80,7 @@ func commitCmd(c *cli.Context) error {
 	case "oci":
 		mimeType = buildah.OCIv1ImageManifest
 		if c.IsSet("message") {
-			return errors.Errorf("messages cannot be added to the OCIv1 image format.")
+			return errors.Errorf("messages are only compatible with the docker image format (-f docker)")
 		}
 	case "docker":
 		mimeType = buildah.Dockerv2ImageManifest

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -29,12 +29,16 @@ Apply the following possible instructions to the created image:
 **CMD** | **ENTRYPOINT** | **ENV** | **EXPOSE** | **LABEL** | **STOPSIGNAL** | **USER** | **VOLUME** | **WORKDIR**
 Can be set multiple times
 
+**--format, -f**
+Set the format of the image manifest and metadata.  The currently supported formats are _oci_ and _docker_.  If
+not specifically set, the default format used is _oci_.
+
 **--iidfile** *ImageIDfile*
 
 Write the image ID to the file.
 
 **--message, -m**
-Set commit message for committed image
+Set commit message for committed image.  The message field is not supported in _oci_ format.
 
 **--pause, -p**
 Pause the container when creating an image


### PR DESCRIPTION
document --format|-f in the commit man page.  also, improve the error
message when user tries to use -m with the oci image format.

Resolves: 765

Signed-off-by: baude <bbaude@redhat.com>