### PR TITLE
fix segfault for podman push

### DIFF
--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -84,10 +84,10 @@ func pushCmd(c *cli.Context) error {
 	)
 
 	args := c.Args()
-	srcName := args[0]
 	if len(args) == 0 || len(args) > 2 {
 		return errors.New("podman push requires at least one image name, and optionally a second to specify a different destination name")
 	}
+	srcName := args[0]
 	switch len(args) {
 	case 1:
 		destName = args[0]


### PR DESCRIPTION
When no args were provided to podman push, podman segfaults.  Quick fix to avoid the condition
that triggers the segf.

Signed-off-by: baude <bbaude@redhat.com>