### PR TITLE
Support pulling Dockerfile from http

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -6,21 +6,18 @@
 podman-build - Build a container image using a Dockerfile.
 
 ## SYNOPSIS
-**podman** **build** [*options* [...]] [**context**]
+**podman** **build** [*options* [...]] **context**
 
 ## DESCRIPTION
-**podman build** Builds an image using instructions from one or more Dockerfiles and a specified
-build context directory.  The build context directory can be specified as the
-**http** or **https** URL of an archive which will be retrieved and extracted
-to a temporary location.  This command passes the parameters entered in by the user to the
-**buildah bud** command https://github.com/projectatomic/buildah/blob/master/docs/buildah-bud.md
-to do the actual building.
+**podman build** Builds an image using instructions from one or more Dockerfiles and a specified build context directory.
 
-**podman [GLOBAL OPTIONS]**
+The build context directory can be specified as the http(s) URL of an archive, git repository or Dockerfile.
 
-**podman build [GLOBAL OPTIONS]**
+When the URL is an archive, the contents of the URL is downloaded to a temporary location and extracted before execution.
 
-**podman build [OPTIONS] NAME[:TAG|@DIGEST]**
+When the URL is an Dockerfile, the Dockerfile is downloaded to a temporary location.
+
+When a Git repository is set as the URL, the repository is cloned locally and then set as the context.
 
 ## OPTIONS
 
@@ -143,7 +140,7 @@ Write the image ID to the file.
 
 **--isolation** [Not Supported]
 
-Buildah is not currently supported on Windows, and does not have a daemon.
+Podman is not currently supported on Windows, and does not have a daemon.
 If you want to override the container isolation you can choose a different
 OCI Runtime, using the --runtime flag.
 
@@ -238,7 +235,7 @@ Ulimit options
    * [`[r]shared`|`[r]slave`|`[r]private`]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
-must be an absolute path as well. podman bind-mounts the `HOST-DIR` to the
+must be an absolute path as well. Podman bind-mounts the `HOST-DIR` to the
 path you specify. For example, if you supply the `/foo` value, podman creates a bind-mount.
 
 You can specify multiple  **-v** options to mount one or more mounts to a
@@ -294,6 +291,8 @@ mount can be changed directly. For instance if `/` is the source mount for
 
 ## EXAMPLES
 
+### Build an image using local Dockerfiles
+
 podman build .
 
 podman build -f Dockerfile.simple .
@@ -317,6 +316,21 @@ podman build --memory 40m --cpu-period 10000 --cpu-quota 50000 --ulimit nofile=1
 podman build --security-opt label=level:s0:c100,c200 --cgroup-parent /path/to/cgroup/parent -t imageName .
 
 podman build --volume /home/test:/myvol:ro,Z -t imageName .
+
+### Building an image using a URL
+
+  This will clone the specified GitHub repository from the URL and use it as context. The Dockerfile at the root of the repository is used as Dockerfile. This only works if the GitHub repository is a dedicated repository.
+
+ `podman build github.com/scollier/purpletest`
+
+  Note: You can set an arbitrary Git repository via the git:// scheme.
+
+### Building an image using a URL to a tarball'ed context
+  Podman will fetch the tarball archive, decompress it and use its contents as the build context.  The Dockerfile at the root of the archive and the rest of the archive will get used as the context of the build. If you pass an -f PATH/Dockerfile option as well, the system will look for that file inside the contents of the tarball.
+
+ `podman build -f dev/Dockerfile https://10.10.10.1/podman/context.tar.gz`
+
+  Note: supported compression formats are `xz`, `bzip2`, `gzip` and `identity` (no compression).
 
 ## SEE ALSO
 podman(1), buildah(1)

--- a/vendor.conf
+++ b/vendor.conf
@@ -88,7 +88,7 @@ k8s.io/kube-openapi 275e2ce91dec4c05a4094a7b1daee5560b555ac9 https://github.com/
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kubernetes/utils
 github.com/mrunalp/fileutils master
 github.com/varlink/go master
-github.com/projectatomic/buildah master
+github.com/projectatomic/buildah 3e320b9ae4c3f4c9db8e7295b2dc7e114cca38c2
 github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master

--- a/vendor/github.com/projectatomic/buildah/buildah.go
+++ b/vendor/github.com/projectatomic/buildah/buildah.go
@@ -22,7 +22,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "0.16"
+	Version = "1.0"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/vendor/github.com/projectatomic/buildah/pkg/cli/common.go
+++ b/vendor/github.com/projectatomic/buildah/pkg/cli/common.go
@@ -20,6 +20,10 @@ var (
 			Usage: "`argument=value` to supply to the builder",
 		},
 		cli.StringFlag{
+			Name:  "cache-from",
+			Usage: "Images to utilise as potential cache sources. Buildah does not currently support caching so this is a NOOP.",
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
@@ -37,6 +41,10 @@ var (
 			Name:  "file, f",
 			Usage: "`pathname or URL` of a Dockerfile",
 		},
+		cli.BoolFlag{
+			Name:  "force-rm",
+			Usage: "Always remove intermediate containers after a build. Buildah does not currently support caching so this is a NOOP.",
+		},
 		cli.StringFlag{
 			Name:  "format",
 			Usage: "`format` of the built image's manifest and metadata",
@@ -44,6 +52,10 @@ var (
 		cli.StringFlag{
 			Name:  "iidfile",
 			Usage: "Write the image ID to the file",
+		},
+		cli.BoolFlag{
+			Name:  "no-cache",
+			Usage: "Do not use caching for the container build. Buildah does not currently support caching so this is a NOOP.",
 		},
 		cli.BoolTFlag{
 			Name:  "pull",
@@ -59,7 +71,7 @@ var (
 		},
 		cli.BoolFlag{
 			Name:  "rm",
-			Usage: "Remove intermediate containers after a successful build.  Buildah does not currently support cacheing so this is a NOOP.",
+			Usage: "Remove intermediate containers after a successful build. Buildah does not currently support caching so this is a NOOP.",
 		},
 		cli.StringFlag{
 			Name:  "runtime",
@@ -76,7 +88,7 @@ var (
 		},
 		cli.BoolFlag{
 			Name:  "squash",
-			Usage: "Squash newly built layers into a single new layer. Buildah does not currently support cacheing so this is a NOOP.",
+			Usage: "Squash newly built layers into a single new layer. Buildah does not currently support caching so this is a NOOP.",
 		},
 		cli.StringSliceFlag{
 			Name:  "tag, t",
@@ -106,7 +118,7 @@ var (
 			Usage: "limit the CPU CFS (Completely Fair Scheduler) quota",
 		},
 		cli.Uint64Flag{
-			Name:  "cpu-shares",
+			Name:  "cpu-shares, c",
 			Usage: "CPU shares (relative weight)",
 		},
 		cli.StringFlag{

--- a/vendor/github.com/projectatomic/buildah/pkg/parse/parse.go
+++ b/vendor/github.com/projectatomic/buildah/pkg/parse/parse.go
@@ -180,9 +180,9 @@ func validateVolumeOpts(option string) error {
 				return errors.Errorf("invalid options %q, can only specify 1 'z' or 'Z' option", option)
 			}
 			foundLabelChange++
-		case "private", "rprivate", "shared", "rshared", "slave", "rslave":
+		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
 			if foundRootPropagation > 1 {
-				return errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private' or '[r]slave' option", option)
+				return errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private', '[r]slave' or '[r]unbindable' option", option)
 			}
 			foundRootPropagation++
 		default:

--- a/vendor/github.com/projectatomic/buildah/run.go
+++ b/vendor/github.com/projectatomic/buildah/run.go
@@ -326,15 +326,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if len(command) > 0 {
 		g.SetProcessArgs(command)
 	} else {
-		cmd := b.Cmd()
-		if len(options.Cmd) > 0 {
-			cmd = options.Cmd
-		}
-		entrypoint := b.Entrypoint()
-		if len(options.Entrypoint) > 0 {
-			entrypoint = options.Entrypoint
-		}
-		g.SetProcessArgs(append(entrypoint, cmd...))
+		g.SetProcessArgs(nil)
 	}
 	if options.WorkingDir != "" {
 		g.SetProcessCwd(options.WorkingDir)


### PR DESCRIPTION
Currently podman build http://remote.com/Dockerfile does not work.
podman always treats this file as an Archive.

Vendoring in the latest buildah code fixes this issue.  Also updated
the man pages to better explain the syntax.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>