### PR TITLE
Add pod CGroups

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -623,6 +623,7 @@ func (s *BoltState) Pod(id string) (*Pod, error) {
 
 	pod := new(Pod)
 	pod.config = new(PodConfig)
+	pod.state = new(podState)
 
 	db, err := s.getDBCon()
 	if err != nil {
@@ -657,6 +658,7 @@ func (s *BoltState) LookupPod(idOrName string) (*Pod, error) {
 
 	pod := new(Pod)
 	pod.config = new(PodConfig)
+	pod.state = new(podState)
 
 	db, err := s.getDBCon()
 	if err != nil {
@@ -957,9 +959,14 @@ func (s *BoltState) AddPod(pod *Pod) error {
 	podID := []byte(pod.ID())
 	podName := []byte(pod.Name())
 
-	podJSON, err := json.Marshal(pod.config)
+	podConfigJSON, err := json.Marshal(pod.config)
 	if err != nil {
-		return errors.Wrapf(err, "error marshalling pod %s JSON", pod.ID())
+		return errors.Wrapf(err, "error marshalling pod %s config to JSON", pod.ID())
+	}
+
+	podStateJSON, err := json.Marshal(pod.state)
+	if err != nil {
+		return errors.Wrapf(err, "error marshalling pod %s state to JSON", pod.ID())
 	}
 
 	db, err := s.getDBCon()
@@ -1011,8 +1018,12 @@ func (s *BoltState) AddPod(pod *Pod) error {
 			return errors.Wrapf(err, "error creating bucket for pod %s containers", pod.ID())
 		}
 
-		if err := newPod.Put(configKey, podJSON); err != nil {
+		if err := newPod.Put(configKey, podConfigJSON); err != nil {
 			return errors.Wrapf(err, "error storing pod %s configuration in DB", pod.ID())
+		}
+
+		if err := newPod.Put(stateKey, podStateJSON); err != nil {
+			return errors.Wrapf(err, "error storing pod %s state JSON in DB", pod.ID())
 		}
 
 		// Add us to the ID and names buckets
@@ -1296,6 +1307,108 @@ func (s *BoltState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	return err
 }
 
+// UpdatePod updates a pod's state from the database
+func (s *BoltState) UpdatePod(pod *Pod) error {
+	if !s.valid {
+		return ErrDBClosed
+	}
+
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	newState := new(podState)
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	podID := []byte(pod.ID())
+
+	err = db.View(func(tx *bolt.Tx) error {
+		podBkt, err := getPodBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		podDB := podBkt.Bucket(podID)
+		if podDB == nil {
+			pod.valid = false
+			return errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in database", pod.ID())
+		}
+
+		// Get the pod state JSON
+		podStateBytes := podDB.Get(stateKey)
+		if podStateBytes == nil {
+			return errors.Wrapf(ErrInternal, "pod %s is missing state key in DB", pod.ID())
+		}
+
+		if err := json.Unmarshal(podStateBytes, newState); err != nil {
+			return errors.Wrapf(err, "error unmarshalling pod %s state JSON", pod.ID())
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	pod.state = newState
+
+	return nil
+}
+
+// SavePod saves a pod's state to the database
+func (s *BoltState) SavePod(pod *Pod) error {
+	if !s.valid {
+		return ErrDBClosed
+	}
+
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	stateJSON, err := json.Marshal(pod.state)
+	if err != nil {
+		return errors.Wrapf(err, "error marshalling pod %s state to JSON", pod.ID())
+	}
+
+	db, err := s.getDBCon()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	podID := []byte(pod.ID())
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		podBkt, err := getPodBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		podDB := podBkt.Bucket(podID)
+		if podDB == nil {
+			pod.valid = false
+			return errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in database", pod.ID())
+		}
+
+		// Set the pod state JSON
+		if err := podDB.Put(stateKey, stateJSON); err != nil {
+			return errors.Wrapf(err, "error updating pod %s state in database", pod.ID())
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // AllPods returns all pods present in the state
 func (s *BoltState) AllPods() ([]*Pod, error) {
 	if !s.valid {
@@ -1331,6 +1444,7 @@ func (s *BoltState) AllPods() ([]*Pod, error) {
 
 			pod := new(Pod)
 			pod.config = new(PodConfig)
+			pod.state = new(podState)
 
 			pods = append(pods, pod)
 

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -256,13 +256,22 @@ func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error
 		return errors.Wrapf(ErrNoSuchPod, "pod with ID %s not found", string(id))
 	}
 
-	podBytes := podDB.Get(configKey)
-	if podBytes == nil {
+	podConfigBytes := podDB.Get(configKey)
+	if podConfigBytes == nil {
 		return errors.Wrapf(ErrInternal, "pod %s is missing configuration key in DB", string(id))
 	}
 
-	if err := json.Unmarshal(podBytes, pod.config); err != nil {
-		return errors.Wrapf(err, "error unmarshalling pod %s from DB", string(id))
+	if err := json.Unmarshal(podConfigBytes, pod.config); err != nil {
+		return errors.Wrapf(err, "error unmarshalling pod %s config from DB", string(id))
+	}
+
+	podStateBytes := podDB.Get(stateKey)
+	if podStateBytes == nil {
+		return errors.Wrapf(ErrInternal, "pod %s is missing state key in DB", string(id))
+	}
+
+	if err := json.Unmarshal(podStateBytes, pod.state); err != nil {
+		return errors.Wrapf(err, "error unmarshalling pod %s state from DB", string(id))
 	}
 
 	// Get the lock

--- a/libpod/common_test.go
+++ b/libpod/common_test.go
@@ -94,9 +94,13 @@ func getTestContainer(id, name, locksDir string) (*Container, error) {
 func getTestPod(id, name, locksDir string) (*Pod, error) {
 	pod := &Pod{
 		config: &PodConfig{
-			ID:     id,
-			Name:   name,
-			Labels: map[string]string{"a": "b", "c": "d"},
+			ID:           id,
+			Name:         name,
+			Labels:       map[string]string{"a": "b", "c": "d"},
+			CgroupParent: "/hello/world/cgroup/parent",
+		},
+		state: &podState{
+			CgroupPath: "/path/to/cgroups/hello/",
 		},
 		valid: true,
 	}
@@ -179,4 +183,24 @@ func testContainersEqual(t *testing.T, a, b *Container) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, aState, bState)
+}
+
+// Test if pods are equal
+func testPodsEqual(t *testing.T, a, b *Pod) {
+	if a == nil && b == nil {
+		return
+	}
+
+	assert.NotNil(t, a)
+	assert.NotNil(t, b)
+
+	assert.NotNil(t, a.config)
+	assert.NotNil(t, b.config)
+	assert.NotNil(t, a.state)
+	assert.NotNil(t, b.state)
+
+	assert.Equal(t, a.valid, b.valid)
+
+	assert.EqualValues(t, a.config, b.config)
+	assert.EqualValues(t, a.state, b.state)
 }

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -604,6 +604,36 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	return nil
 }
 
+// UpdatePod updates a pod in the state
+// This is a no-op as there is no backing store
+func (s *InMemoryState) UpdatePod(pod *Pod) error {
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	if _, ok := s.pods[pod.ID()]; !ok {
+		pod.valid = false
+		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+	}
+
+	return nil
+}
+
+// SavePod updates a pod in the state
+// This is a no-op at there is no backing store
+func (s *InMemoryState) SavePod(pod *Pod) error {
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	if _, ok := s.pods[pod.ID()]; !ok {
+		pod.valid = false
+		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+	}
+
+	return nil
+}
+
 // AllPods retrieves all pods currently in the state
 func (s *InMemoryState) AllPods() ([]*Pod, error) {
 	pods := make([]*Pod, 0, len(s.pods))

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -944,3 +944,32 @@ func WithPodLabels(labels map[string]string) PodCreateOption {
 		return nil
 	}
 }
+
+// WithPodCgroupParent sets the Cgroup Parent of the pod.
+func WithPodCgroupParent(path string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+
+		pod.config.CgroupParent = path
+
+		return nil
+	}
+}
+
+// WithPodCgroups tells containers in this pod to use the cgroup created for
+// this pod.
+// This can still be overridden at the container level by explicitly specifying
+// a CGroup parent.
+func WithPodCgroups() PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+
+		pod.config.UsePodCgroup = true
+
+		return nil
+	}
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -15,6 +15,7 @@ import (
 // ffjson: skip
 type Pod struct {
 	config *PodConfig
+	state  *podState
 
 	valid   bool
 	runtime *Runtime
@@ -23,9 +24,19 @@ type Pod struct {
 
 // PodConfig represents a pod's static configuration
 type PodConfig struct {
-	ID     string            `json:"id"`
-	Name   string            `json:"name"`
-	Labels map[string]string `json:""`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+
+	// Labels contains labels applied to the pod
+	Labels map[string]string `json:"labels"`
+	// CgroupParent contains the pod's CGroup parent
+	CgroupParent string `json:"cgroupParent"`
+}
+
+// podState represents a pod's state
+type podState struct {
+	// CgroupPath is the path to the pod's CGroup
+	CgroupPath string
 }
 
 // ID retrieves the pod's ID
@@ -48,12 +59,18 @@ func (p *Pod) Labels() map[string]string {
 	return labels
 }
 
+// CgroupParent returns the pod's CGroup parent
+func (p *Pod) CgroupParent() string {
+	return p.config.CgroupParent
+}
+
 // Creates a new, empty pod
 func newPod(lockDir string, runtime *Runtime) (*Pod, error) {
 	pod := new(Pod)
 	pod.config = new(PodConfig)
 	pod.config.ID = stringid.GenerateNonCryptoID()
 	pod.config.Labels = make(map[string]string)
+	pod.state = new(podState)
 	pod.runtime = runtime
 
 	// Path our lock file will reside at

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -524,13 +524,22 @@ func (r *Runtime) refresh(alivePath string) error {
 	}
 
 	// Next refresh the state of all containers to recreate dirs and
-	// namespaces
+	// namespaces, and all the pods to recreate cgroups
 	ctrs, err := r.state.AllContainers()
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving all containers from state")
 	}
+	pods, err := r.state.AllPods()
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving all pods from state")
+	}
 	for _, ctr := range ctrs {
 		if err := ctr.refresh(); err != nil {
+			return err
+		}
+	}
+	for _, pod := range pods {
+		if err := pod.refresh(); err != nil {
 			return err
 		}
 	}

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -2,9 +2,12 @@ package libpod
 
 import (
 	"path"
+	"path/filepath"
 	"strings"
 
+	"github.com/containerd/cgroups"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Contains the public Runtime API for pods
@@ -56,11 +59,20 @@ func (r *Runtime) NewPod(options ...PodCreateOption) (*Pod, error) {
 		} else if strings.HasSuffix(path.Base(pod.config.CgroupParent), ".slice") {
 			return nil, errors.Wrapf(ErrInvalidArg, "systemd slice received as cgroup parent when using cgroupfs")
 		}
+		// Creating CGroup path is currently a NOOP until proper systemd
+		// cgroup management is merged
 	case SystemdCgroupsManager:
 		if pod.config.CgroupParent == "" {
 			pod.config.CgroupParent = SystemdDefaultCgroupParent
 		} else if len(pod.config.CgroupParent) < 6 || !strings.HasSuffix(path.Base(pod.config.CgroupParent), ".slice") {
 			return nil, errors.Wrapf(ErrInvalidArg, "did not receive systemd slice as cgroup parent when using systemd to manage cgroups")
+		}
+		// If we are set to use pod cgroups, set the cgroup parent that
+		// all containers in the pod will share
+		// No need to create it with cgroupfs - the first container to
+		// launch should do it for us
+		if pod.config.UsePodCgroup {
+			pod.state.CgroupPath = filepath.Join(pod.config.CgroupParent, pod.ID())
 		}
 	default:
 		return nil, errors.Wrapf(ErrInvalidArg, "unsupported CGroup manager: %s - cannot validate cgroup parent", r.config.CgroupManager)
@@ -209,6 +221,29 @@ func (r *Runtime) RemovePod(p *Pod, removeCtrs, force bool) error {
 	// Mark containers invalid
 	for _, ctr := range ctrs {
 		ctr.valid = false
+	}
+
+	// Remove pod cgroup, if present
+	if p.state.CgroupPath != "" {
+		switch p.runtime.config.CgroupManager {
+		case SystemdCgroupsManager:
+			// NOOP for now, until proper systemd cgroup management
+			// is implemented
+		case CgroupfsCgroupsManager:
+			// Delete the cgroupfs cgroup
+			logrus.Debugf("Removing pod cgroup %s", p.state.CgroupPath)
+
+			cgroup, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(p.state.CgroupPath))
+			if err != nil && err != cgroups.ErrCgroupDeleted {
+				return err
+			} else if err == nil {
+				if err := cgroup.Delete(); err != nil {
+					return err
+				}
+			}
+		default:
+			return errors.Wrapf(ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.CgroupManager)
+		}
 	}
 
 	// Remove pod from state

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -66,6 +66,10 @@ type State interface {
 	// RemoveContainerFromPod removes a container from an existing pod
 	// The container will also be removed from the state
 	RemoveContainerFromPod(pod *Pod, ctr *Container) error
+	// UpdatePod updates a pod's state from the database
+	UpdatePod(pod *Pod) error
+	// SavePod saves a pod's state to the database
+	SavePod(pod *Pod) error
 	// Retrieves all pods presently in state
 	AllPods() ([]*Pod, error)
 }


### PR DESCRIPTION
Add the ability for pods to have their own CGroups that containers can use as their CGroup parent.

Presently only works with cgroupfs, systemd cgroups are coming in a later patch.