### PR TITLE
libpod: fix panic when using -t and the process fails to start

### DIFF
--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -17,7 +17,6 @@ import (
 // Attach to a container
 func attachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool) error {
 	resize := make(chan remotecommand.TerminalSize)
-	defer close(resize)
 
 	haveTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 
@@ -26,7 +25,12 @@ func attachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys
 	if haveTerminal && ctr.Spec().Process.Terminal {
 		logrus.Debugf("Handling terminal attach")
 
-		resizeTty(resize)
+		resizeTerminate := make(chan interface{})
+		defer func() {
+			resizeTerminate <- true
+			close(resizeTerminate)
+		}()
+		resizeTty(resize, resizeTerminate)
 
 		oldTermState, err := term.SaveState(os.Stdin.Fd())
 		if err != nil {
@@ -69,7 +73,6 @@ func attachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys
 // Start and attach to a container
 func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool) error {
 	resize := make(chan remotecommand.TerminalSize)
-	defer close(resize)
 
 	haveTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 
@@ -78,7 +81,12 @@ func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detac
 	if haveTerminal && ctr.Spec().Process.Terminal {
 		logrus.Debugf("Handling terminal attach")
 
-		resizeTty(resize)
+		resizeTerminate := make(chan interface{})
+		defer func() {
+			resizeTerminate <- true
+			close(resizeTerminate)
+		}()
+		resizeTty(resize, resizeTerminate)
 
 		oldTermState, err := term.SaveState(os.Stdin.Fd())
 		if err != nil {
@@ -133,7 +141,7 @@ func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detac
 }
 
 // Helper for prepareAttach - set up a goroutine to generate terminal resize events
-func resizeTty(resize chan remotecommand.TerminalSize) {
+func resizeTty(resize chan remotecommand.TerminalSize, resizeTerminate chan interface{}) {
 	sigchan := make(chan os.Signal, 1)
 	gosignal.Notify(sigchan, signal.SIGWINCH)
 	sendUpdate := func() {
@@ -152,8 +160,14 @@ func resizeTty(resize chan remotecommand.TerminalSize) {
 		// Update the terminal size immediately without waiting
 		// for a SIGWINCH to get the correct initial size.
 		sendUpdate()
-		for range sigchan {
-			sendUpdate()
+		for {
+			select {
+			case <-resizeTerminate:
+				return
+
+			case <-sigchan:
+				sendUpdate()
+			}
 		}
 	}()
 }


### PR DESCRIPTION
We were closing resize both on the receiver and the sender side.
This was racy as the sender might have written to a closed channel.
If the container could not be created, the attach exited
immediately causing the channel to be closed before the write from
resizeTty.

Change the logic to close only from the senderSide and add another
channel to notify the resizeTty goroutine when the container exited.

Closes: https://github.com/projectatomic/libpod/issues/785

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>