### PR TITLE
troubleshooting: Add console syntax highlighting

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -12,13 +12,16 @@ it is likely that the `/etc/containers/registries.conf` file is either not insta
 misconfigured.
 
 #### Symptom
-```
-sudo podman build -f Dockerfile
+
+```console
+$ sudo podman build -f Dockerfile
 STEP 1: FROM alpine
 error building: error creating build container: no such image "alpine" in registry: image not known
 ```
+
 or
-```
+
+```console
 $ sudo podman pull fedora
 error pulling image "fedora": unable to pull fedora: error getting default registries to try: Near line 9 (last key parsed ''): Bare keys cannot contain ':'.
 ```
@@ -37,8 +40,9 @@ tls verification is turned on by default.  If authentication is not used with
 those commands, this error can occur.
 
 #### Symptom
-```
-podman push alpine docker://localhost:5000/myalpine:latest
+
+```console
+$ sudo podman push alpine docker://localhost:5000/myalpine:latest
 Getting image source signatures
 Get https://localhost:5000/v2/: http: server gave HTTP response to HTTPS client
 ```


### PR DESCRIPTION
These blocks include both shell input and command output.  [GitHub uses Linuguist][1] for syntax highlighting.  Linguist [defines a ShellSession language][2] to highlight those, although I prefer the shorter `console` alias.

This commit also makes this file more consistent about including the leading `$` prompt and `sudo`.

I'd also be fine using the traditional `#` prompt for privileged users instead of `$ sudo`, to be less opinionated about *how* the user acquires the privileges (via sudo or otherwise).  Linguist's shell-session grammar is [from Atom][3], and that grammar [recognizes any of `>$#%` as the final prompt character][4].  But I've left this facet alone for now.

CC @TomSweeneyRedHat, since you wrote #793.

[1]: https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
[2]: https://github.com/github/linguist/blob/v6.1.0/lib/linguist/languages.yml#L4362-L4373
[3]: https://github.com/github/linguist/blame/v6.1.0/vendor/README.md#L335
[4]: https://github.com/atom/language-shellscript/blob/v0.26.3/grammars/shell-session.cson#L22