### PR TITLE
[WIP] Use Version from spec file in setup.py

### DIFF
--- a/contrib/python/setup.py
+++ b/contrib/python/setup.py
@@ -11,9 +11,10 @@ with open(os.path.join(root, 'README.md')) as me:
 with open(os.path.join(root, 'requirements.txt')) as r:
     requirements = r.read().splitlines()
 
+
 setup(
     name='podman',
-    version='0.1.0',
+    version=os.environ.get('PODMAN_VERSION', '0.0.0'),
     description='A client for communicating with a Podman server',
     long_description=readme,
     author='Jhon Honce',

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -189,7 +189,6 @@ the Container Pod concept popularized by Kubernetes.
 
 %if 0%{?fedora} >= 28
 %package -n python3-%{name}
-Version: 0.1.0
 BuildArch: noarch
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
@@ -371,6 +370,7 @@ popd
 ln -s vendor src
 export GOPATH=$(pwd)/_build:$(pwd):$(pwd):%{gopath}
 export BUILDTAGS="selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) $(hack/libdm_tag.sh) containers_image_ostree_stub"
+export PODMAN_VERSION=%{version}
 
 GOPATH=$GOPATH BUILDTAGS=$BUILDTAGS %gobuild -o bin/%{name} %{import_path}/cmd/%{name}
 BUILDTAGS=$BUILDTAGS make binaries docs


### PR DESCRIPTION
- If envvar PODMAN_VERSION not set use default version of 0.0.0

Signed-off-by: Jhon Honce <jhonce@redhat.com>