### PR TITLE
tidy up the copr spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh)
 PYTHON ?= /usr/bin/python3
+HAS_PYTHON3 := $(shell command -v python3)
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
@@ -95,7 +96,9 @@ podman: .gopathok API.md cmd/podman/varlink/ioprojectatomicpodman.go
 	$(GO) build -i -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o bin/$@ $(PROJECT)/cmd/podman
 
 python-podman:
+ifdef HAS_PYTHON3
 	$(MAKE) -C contrib/python python-podman
+endif
 
 clean:
 	rm -rf \
@@ -108,7 +111,9 @@ clean:
 		test/copyimg/copyimg \
 		test/testdata/redis-image \
 		$(MANPAGES)
-	$(MAKE) -C contrib/python clean
+ifdef HAS_PYTHON3
+		$(MAKE) -C contrib/python clean
+endif
 	find . -name \*~ -delete
 	find . -name \#\* -delete
 

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -23,6 +23,12 @@
 # Generate unit-test rpm
 %global with_unit_test 0
 
+%if 0%{?fedora} >= 28
+%bcond_without varlink
+%else
+%bcond_with varlink
+%endif
+
 %if 0%{?with_debug}
 %global _find_debuginfo_dwz_opts %{nil}
 %global _dwz_low_mem_die_limit 0
@@ -187,7 +193,7 @@ Provides: bundled(golang(gopkg.in/yaml.v2)) = v2
 libpod provides a library for applications looking to use
 the Container Pod concept popularized by Kubernetes.
 
-%if 0%{?fedora} >= 28
+%if %{with varlink}
 %package -n python3-%{name}
 Version: 0.1.0
 BuildArch: noarch
@@ -199,7 +205,7 @@ Summary: Python 3 bindings for %{name}
 
 %description -n python3-%{name}
 This package contains Python 3 bindings for %{name}.
-%endif
+%endif # varlink
 
 %if 0%{?with_devel}
 %package -n libpod-devel
@@ -374,23 +380,24 @@ export BUILDTAGS="selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_ta
 
 GOPATH=$GOPATH BUILDTAGS=$BUILDTAGS %gobuild -o bin/%{name} %{import_path}/cmd/%{name}
 BUILDTAGS=$BUILDTAGS make binaries docs
-%if 0%{?fedora} >= 28
+
+%if %{with varlink}
 #untar contents for python-podman
 pushd contrib/python/dist
 tar zxf %{name}*.tar.gz
 popd
-%endif
+%endif #varlink
 
 %install
 install -dp %{buildroot}%{_unitdir}
 %make_install PREFIX=%{buildroot}%{_prefix} install install.completions
 
-%if 0%{?fedora} >= 28
+%if %{with varlink}
 #install python-podman
 pushd contrib/python
 %{__python3} setup.py install --root %{buildroot}
 popd
-%endif
+%endif #varlink
 
 # source codes for building projects
 %if 0%{?with_devel}
@@ -471,13 +478,13 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %{_unitdir}/io.%{project}.%{name}.socket
 %{_tmpfilesdir}/%{name}.conf
 
-%if 0%{?fedora} >= 28
+%if %{with varlink}
 %files -n python3-%{name}
 %license LICENSE
 %doc README.md CONTRIBUTING.md install.md code-of-conduct.md transfer.md
 %dir %{python3_sitelib}
 %{python3_sitelib}/*
-%endif
+%endif #varlink
 
 %if 0%{?with_devel}
 %files -n libpod-devel -f devel.file-list


### PR DESCRIPTION
on os's (like centos) where python3 might not be installed, do not attempt to build
the python3 varlink client.  varlink python is only supported on python3.

also, change the conditions for f28 to match the fedora official specs.

Signed-off-by: baude <bbaude@redhat.com>