### PR TITLE
Rework systemd cgroups to keep Conmon and Container in same hierarchy

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -127,9 +127,9 @@ func runCmd(c *cli.Context) error {
 	logrus.Debugf("New container created %q", ctr.ID())
 
 	if logrus.GetLevel() == logrus.DebugLevel {
-		cgroupPath, err := ctr.CGroupPath()
+		cgroupPath, err := ctr.CgroupPath()
 		if err == nil {
-			logrus.Debugf("container %q has CgroupParent %q", ctr.ID(), cgroupPath)
+			logrus.Debugf("container %q has CgroupPath %q", ctr.ID(), cgroupPath)
 		}
 	}
 

--- a/libpod.conf
+++ b/libpod.conf
@@ -30,7 +30,7 @@ conmon_env_vars = [
 ]
 
 # CGroup Manager - valid values are "systemd" and "cgroupfs"
-cgroup_manager = "cgroupfs"
+cgroup_manager = "systemd"
 
 # Directory for persistent libpod files (database, etc)
 # By default, this will be configured relative to where containers/storage

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -852,13 +852,51 @@ func (c *Container) NamespacePath(ns LinuxNS) (string, error) {
 	return fmt.Sprintf("/proc/%d/ns/%s", c.state.PID, ns.String()), nil
 }
 
-// CGroupPath returns a cgroups "path" for a given container.
-func (c *Container) CGroupPath() (string, error) {
+// CgroupBasePath returns the base CGroup path for a container
+// This CGroup contains both the container and conmon, each in separate child
+// cgroups
+func (c *Container) CgroupBasePath() (string, error) {
 	switch c.runtime.config.CgroupManager {
 	case CgroupfsCgroupsManager:
-		return filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-%s", c.ID()), "ctr"), nil
+		return filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-%s", c.ID())), nil
 	case SystemdCgroupsManager:
-		return filepath.Join(c.config.CgroupParent, createUnitName("libpod", c.ID())), nil
+		return filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-%s.slice", c.ID())), nil
+	default:
+		return "", errors.Wrapf(ErrInvalidArg, "unsupported CGroup manager %s in use", c.runtime.config.CgroupManager)
+	}
+}
+
+// CgroupConmonPath returns the path for the container's Conmon cgroup
+// The conmon cgroup is guaranteed to be a child of CgroupBasePath
+func (c *Container) CgroupConmonPath() (string, error) {
+	baseCgroup, err := c.CgroupBasePath()
+	if err != nil {
+		return "", err
+	}
+
+	switch c.runtime.config.CgroupManager {
+	case CgroupfsCgroupsManager:
+		return filepath.Join(baseCgroup, "conmon"), nil
+	case SystemdCgroupsManager:
+		return filepath.Join(baseCgroup, "conmon.scope"), nil
+	default:
+		return "", errors.Wrapf(ErrInvalidArg, "unsupported CGroup manager %s in use", c.runtime.config.CgroupManager)
+	}
+}
+
+// CgroupPath returns the path to the container's cgroup
+// The container cgroup is guaranteed to be a child of CgroupBasePath
+func (c *Container) CgroupPath() (string, error) {
+	baseCgroup, err := c.CgroupBasePath()
+	if err != nil {
+		return "", err
+	}
+
+	switch c.runtime.config.CgroupManager {
+	case CgroupfsCgroupsManager:
+		return filepath.Join(baseCgroup, "ctr"), nil
+	case SystemdCgroupsManager:
+		return filepath.Join(baseCgroup, fmt.Sprintf("libpod-%s.scope", c.ID())), nil
 	default:
 		return "", errors.Wrapf(ErrInvalidArg, "unsupported CGroup manager %s in use", c.runtime.config.CgroupManager)
 	}

--- a/libpod/container_top.go
+++ b/libpod/container_top.go
@@ -27,7 +27,7 @@ func (c *Container) GetContainerPids() ([]string, error) {
 // Gets the pids for a container without locking.  should only be called from a func where
 // locking has already been established.
 func (c *Container) getContainerPids() ([]string, error) {
-	cgroupPath, err := c.CGroupPath()
+	cgroupPath, err := c.CgroupPath()
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -118,11 +118,6 @@ func newPipe() (parent *os.File, child *os.File, err error) {
 	return os.NewFile(uintptr(fds[1]), "parent"), os.NewFile(uintptr(fds[0]), "child"), nil
 }
 
-// Create systemd unit name for cgroup scopes
-func createUnitName(prefix string, name string) string {
-	return fmt.Sprintf("%s-%s.scope", prefix, name)
-}
-
 // Wait for a container which has been sent a signal to stop
 func waitContainerStop(ctr *Container, timeout time.Duration) error {
 	done := make(chan struct{})
@@ -189,10 +184,10 @@ func waitPidsStop(pids []int, timeout time.Duration) error {
 // CreateContainer creates a container in the OCI runtime
 // TODO terminal support for container
 // Presently just ignoring conmon opts related to it
-func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string) (err error) {
+func (r *OCIRuntime) createContainer(ctr *Container) (err error) {
 	if ctr.state.UserNSRoot == "" {
 		// no need of an intermediate mount ns
-		return r.createOCIContainer(ctr, cgroupParent)
+		return r.createOCIContainer(ctr)
 	}
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -229,14 +224,14 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string) (err e
 		if err != nil {
 			return
 		}
-		err = r.createOCIContainer(ctr, cgroupParent)
+		err = r.createOCIContainer(ctr)
 	}()
 	wg.Wait()
 
 	return err
 }
 
-func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string) (err error) {
+func (r *OCIRuntime) createOCIContainer(ctr *Container) (err error) {
 	var stderrBuf bytes.Buffer
 
 	parentPipe, childPipe, err := newPipe()
@@ -321,22 +316,29 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string) (er
 
 	// Move conmon to specified cgroup
 	if r.cgroupManager == SystemdCgroupsManager {
-		unitName := createUnitName("libpod-conmon", ctr.ID())
-
-		logrus.Infof("Running conmon under slice %s and unitName %s", cgroupParent, unitName)
-		if err = utils.RunUnderSystemdScope(cmd.Process.Pid, cgroupParent, unitName); err != nil {
-			logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
+		unitName := "conmon.scope"
+		baseCgroup, err := ctr.CgroupBasePath()
+		if err != nil {
+			logrus.Errorf("Error retrieving base CGroup for container %s: %v", ctr.ID(), err)
+		} else {
+			logrus.Infof("Running conmon under slice %s and unitName %s", baseCgroup, unitName)
+			if err = utils.RunUnderSystemdScope(cmd.Process.Pid, baseCgroup, unitName); err != nil {
+				logrus.Warnf("Failed to add conmon to systemd cgroup: %v", err)
+			}
 		}
 	} else {
-		cgroupPath := filepath.Join(ctr.config.CgroupParent, fmt.Sprintf("libpod-%s", ctr.ID()), "conmon")
-		control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cgroupPath), &spec.LinuxResources{})
+		cgroupPath, err := ctr.CgroupConmonPath()
 		if err != nil {
-			logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+			logrus.Warnf("Error retrieving conmon CGroup for container %s: %v", ctr.ID(), err)
 		} else {
-			// we need to remove this defer and delete the cgroup once conmon exits
-			// maybe need a conmon monitor?
-			if err := control.Add(cgroups.Process{Pid: cmd.Process.Pid}); err != nil {
-				logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+			logrus.Infof("Running conmon in CGroup %s", cgroupPath)
+			control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cgroupPath), &spec.LinuxResources{})
+			if err != nil {
+				logrus.Warnf("Failed to retrieve conmon cgroup for container %s: %v", ctr.ID(), err)
+			} else {
+				if err := control.Add(cgroups.Process{Pid: cmd.Process.Pid}); err != nil {
+					logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+				}
 			}
 		}
 	}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -136,7 +136,7 @@ func (p *Pod) refresh() error {
 	}
 
 	if p.config.UsePodCgroup {
-		if err :=  p.makePodCgroup(); err != nil {
+		if err := p.makePodCgroup(); err != nil {
 			return err
 		}
 	}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -134,23 +135,54 @@ func (p *Pod) refresh() error {
 		return ErrPodRemoved
 	}
 
-	// We need to recreate the pod's cgroup
 	if p.config.UsePodCgroup {
-		switch p.runtime.config.CgroupManager {
-		case SystemdCgroupsManager:
-			// NOOP for now, until proper systemd cgroup management
-			// is implemented
-		case CgroupfsCgroupsManager:
-			p.state.CgroupPath = filepath.Join(p.config.CgroupParent, p.ID())
-
-			logrus.Debugf("setting pod cgroup to %s", p.state.CgroupPath)
-		default:
-			return errors.Wrapf(ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.CgroupManager)
+		if err :=  p.makePodCgroup(); err != nil {
+			return err
 		}
 	}
 
-	// Save changes
 	return p.save()
+}
+
+// Make a pod's cgroup
+func (p *Pod) makePodCgroup() error {
+	switch p.runtime.config.CgroupManager {
+	case SystemdCgroupsManager:
+		p.state.CgroupPath = filepath.Join(p.config.CgroupParent, fmt.Sprintf("libpod-%s", p.ID()))
+		if err := createSystemdCgroup(p.state.CgroupPath); err != nil {
+			return err
+		}
+	case CgroupfsCgroupsManager:
+		p.state.CgroupPath = filepath.Join(p.config.CgroupParent, p.ID())
+	default:
+		return errors.Wrapf(ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.CgroupManager)
+	}
+
+	logrus.Debugf("Setting pod cgroup to %s", p.state.CgroupPath)
+
+	return nil
+}
+
+// Remove a pod's cgroup
+func (p *Pod) removePodCgroup() error {
+	logrus.Debugf("Removing pod cgroup %s", p.state.CgroupPath)
+
+	switch p.runtime.config.CgroupManager {
+	case SystemdCgroupsManager:
+		if err := deleteSystemdCgroup(p.state.CgroupPath); err != nil {
+			return errors.Wrapf(err, "error removing pod %s cgroup", p.ID())
+		}
+	case CgroupfsCgroupsManager:
+		if err := deleteCgroupfsCgroup(p.state.CgroupPath); err != nil {
+			return errors.Wrapf(err, "error removing pod %s cgroup", p.ID())
+		}
+	default:
+		return errors.Wrapf(ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.CgroupManager)
+	}
+
+	p.state.CgroupPath = ""
+
+	return nil
 }
 
 // Start starts all containers within a pod

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -160,7 +160,7 @@ var (
 		ConmonEnvVars: []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		},
-		CgroupManager: CgroupfsCgroupsManager,
+		CgroupManager: SystemdCgroupsManager,
 		HooksDir:      hooks.DefaultDir,
 		StaticDir:     filepath.Join(storage.DefaultStoreOptions.GraphRoot, "libpod"),
 		TmpDir:        "/var/run/libpod",

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -43,7 +43,7 @@ func (c *Container) GetContainerStats(previousStats *ContainerStats) (*Container
 		return stats, nil
 	}
 
-	cgroupPath, err := c.CGroupPath()
+	cgroupPath, err := c.CgroupPath()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Have systemd create a slice for each container, and place conmon and the container itself under that slice. This keeps conmon and the container in the same hierarchy, and allows them to be killed together if need be.

Also sets systemd to be the default cgroup manager for libpod containers.