### PR TITLE
python podman create and start

### DIFF
--- a/contrib/python/test/test_runner.sh
+++ b/contrib/python/test/test_runner.sh
@@ -40,7 +40,7 @@ fi
 export PATH=../../bin:$PATH
 
 function showlog {
-  [ -s "$1" ] && (echo $1 =====; cat "$1")
+  [ -s "$1" ] && (echo $1 =====; cat "$1"; echo)
 }
 
 # Need a location to store the podman socket
@@ -109,8 +109,9 @@ else
 fi
 
 set +x
-pkill podman
+pkill -9 podman
 pkill -9 conmon
 
+showlog /tmp/test_runner.output
 showlog /tmp/alpine.log
 showlog /tmp/busybox.log

--- a/pkg/varlinkapi/containers_create.go
+++ b/pkg/varlinkapi/containers_create.go
@@ -41,7 +41,7 @@ func (i *LibpodAPI) CreateContainer(call ioprojectatomicpodman.VarlinkCall, conf
 
 	newImage, err := runtime.ImageRuntime().New(ctx, config.Image, rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{}, false, false)
 	if err != nil {
-		return err
+		return call.ReplyErrorOccurred(err.Error())
 	}
 	data, err := newImage.Inspect(ctx)
 


### PR DESCRIPTION
- Added alias 'container()' to image model for CreateContainer()
- Fixed return in containers_create.go to wrap error in varlink
  exception
- Added a wait time to container.kill(), number of seconds to wait
  for the container to change state
- Refactored cached_property() to use system libraries
- Refactored tests to speed up performance

Signed-off-by: Jhon Honce <jhonce@redhat.com>