### PR TITLE
Fix handling of command in images

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -243,7 +243,9 @@ func (c *Container) setupStorage(ctx context.Context) error {
 
 	// Set the default Entrypoint and Command
 	c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
-	c.config.Command = containerInfo.Config.Config.Cmd
+	if len(c.config.Command) == 0 {
+		c.config.Command = containerInfo.Config.Config.Cmd
+	}
 
 	artifacts := filepath.Join(c.config.StaticDir, artifactsDir)
 	if err := os.MkdirAll(artifacts, 0755); err != nil {


### PR DESCRIPTION
Currently we are dropping the command entry from the create
line and using the image Cmd.  This change will only use the
image Cmd if the user did not specify a Cmd.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>