### PR TITLE
Set Entrypoint from image only if not already set

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -242,8 +242,10 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	}
 
 	// Set the default Entrypoint and Command
-	c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
-	if len(c.config.Command) == 0 {
+	if c.config.Entrypoint == nil {
+		c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
+	}
+	if c.config.Command == nil {
 		c.config.Command = containerInfo.Config.Config.Cmd
 	}
 


### PR DESCRIPTION
Follow-on to #823 to make Entrypoint not override what is set by the user as well

Also changes the compare logic to use `== nil` instead of `len(...) == 0` - I think it's valid to set a 0-length entrypoint/command to clear what will be set in the image.