### PR TITLE
Make references to the Process part of Spec conditional

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -84,9 +84,13 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	importBuilder.SetCmd(c.config.Command)
 
 	// Env
-	for _, e := range c.config.Spec.Process.Env {
-		splitEnv := strings.Split(e, "=")
-		importBuilder.SetEnv(splitEnv[0], splitEnv[1])
+	// TODO - this includes all the default environment vars as well
+	// Should we store the ENV we actually want in the spec separately?
+	if c.config.Spec.Process != nil {
+		for _, e := range c.config.Spec.Process.Env {
+			splitEnv := strings.Split(e, "=")
+			importBuilder.SetEnv(splitEnv[0], splitEnv[1])
+		}
 	}
 	// Expose ports
 	for _, p := range c.config.PortMappings {

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -13,7 +13,11 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 	runtimeInfo := c.state
 	spec := c.config.Spec
 
-	args := config.Spec.Process.Args
+	// Process is allowed to be nil in the spec
+	args := []string{}
+	if config.Spec.Process != nil {
+		args = config.Spec.Process.Args
+	}
 	var path string
 	if len(args) > 0 {
 		path = args[0]


### PR DESCRIPTION
The OCI runtime spec does not require Process to be passed (IE, it can be nil). Make most of our references to it conditional on it existing.

More work is needed to untangle it in `oci.go`, particularly around Exec. Given exec is going to be rewritten anyways, though, I'm not terribly worried.