### PR TITLE
hooks/1.0.0: Error on empty process.args instead of panicking

### DIFF
--- a/pkg/hooks/1.0.0/when.go
+++ b/pkg/hooks/1.0.0/when.go
@@ -75,6 +75,9 @@ func (when *When) Match(config *rspec.Spec, annotations map[string]string, hasBi
 	}
 
 	if config.Process != nil {
+		if len(config.Process.Args) == 0 {
+			return false, errors.New("process.args must have at least one entry")
+		}
 		command := config.Process.Args[0]
 		for _, cmdPattern := range when.Commands {
 			match, err := regexp.MatchString(cmdPattern, command)


### PR DESCRIPTION
[The `process` property is optional][1], which this package already handled appropriately, although I've added a new test here to guard against regressions.

[The `process.args` entry is required when `process` is set][2], and it's also [required to contain at least one entry][3].  The previous implementation here assumed that would always be satisfied, and panicked on empty `process.args` (reported by @baude).  With this commit, we avoid the panic and instead return an error message explaining why the input was invalid.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/config.md#L145
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/config.md#L157
[3]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/config.md#L158