### PR TITLE
add go generate varlink to copr spec

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -383,6 +383,7 @@ ln -s vendor src
 export GOPATH=$(pwd)/_build:$(pwd):$(pwd):%{gopath}
 export BUILDTAGS="selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) $(hack/libdm_tag.sh) containers_image_ostree_stub"
 
+GOPATH=$GOPATH go generate ./cmd/podman/varlink/...
 GOPATH=$GOPATH BUILDTAGS=$BUILDTAGS %gobuild -o bin/%{name} %{import_path}/cmd/%{name}
 BUILDTAGS=$BUILDTAGS make binaries docs
 


### PR DESCRIPTION
Now that we make the varlink .go file on the fly, we need to have the
spec call go generate on it to build properly.

Signed-off-by: baude <bbaude@redhat.com>