### PR TITLE
Update .gitignore for Varlink code and gopathok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 .nfs*
 .ropeproject
 __pycache__
+/cmd/podman/varlink/ioprojectatomicpodman.go
+.gopathok


### PR DESCRIPTION
Make sure we don't check generated files into the repo by adding them to the gitignore