### PR TITLE
do not allow port related args to be used with --network=container:

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -435,6 +435,13 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		networkMode = c.String("net")
 	}
 
+	// Make sure if network is set to container namespace, port binding is not also being asked for
+	if strings.HasPrefix(networkMode, "container") {
+		if len(c.StringSlice("publish")) > 0 || c.Bool("publish-all") {
+			return nil, errors.Errorf("cannot set port bindings on an existing container network namespace")
+		}
+	}
+
 	// Verify the additional hosts are in correct format
 	for _, host := range c.StringSlice("add-host") {
 		if _, err := validateExtraHost(host); err != nil {


### PR DESCRIPTION
we cannot set additional ports on an existing container namespace, so we should
not allow --network=container with publish or publish-all.

Resolves: #845

Signed-off-by: baude <bbaude@redhat.com>