### PR TITLE
hooks: Allow local control of OCI stages via extensionStages

### DIFF
--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -54,7 +54,7 @@ func TestGoodNew(t *testing.T) {
 	}
 
 	config := &rspec.Spec{}
-	extensionStages, err := manager.Hooks(config, map[string]string{}, false)
+	extensionStageHooks, err := manager.Hooks(config, map[string]string{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,8 +91,8 @@ func TestGoodNew(t *testing.T) {
 		},
 	}, config.Hooks)
 
-	var nilExtensionStages map[string][]rspec.Hook
-	assert.Equal(t, nilExtensionStages, extensionStages)
+	var nilExtensionStageHooks map[string][]rspec.Hook
+	assert.Equal(t, nilExtensionStageHooks, extensionStageHooks)
 }
 
 func TestBadNew(t *testing.T) {
@@ -142,14 +142,14 @@ func TestBrokenMatch(t *testing.T) {
 			Args: []string{"/bin/sh"},
 		},
 	}
-	extensionStages, err := manager.Hooks(config, map[string]string{}, false)
+	extensionStageHooks, err := manager.Hooks(config, map[string]string{}, false)
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
 	assert.Regexp(t, "^matching hook \"a\\.json\": command: error parsing regexp: .*", err.Error())
 
-	var nilExtensionStages map[string][]rspec.Hook
-	assert.Equal(t, nilExtensionStages, extensionStages)
+	var nilExtensionStageHooks map[string][]rspec.Hook
+	assert.Equal(t, nilExtensionStageHooks, extensionStageHooks)
 }
 
 func TestInvalidStage(t *testing.T) {
@@ -168,14 +168,14 @@ func TestInvalidStage(t *testing.T) {
 			},
 		},
 	}
-	extensionStages, err := manager.Hooks(&rspec.Spec{}, map[string]string{}, false)
+	extensionStageHooks, err := manager.Hooks(&rspec.Spec{}, map[string]string{}, false)
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
 	assert.Regexp(t, "^hook \"a\\.json\": unknown stage \"does-not-exist\"$", err.Error())
 
-	var nilExtensionStages map[string][]rspec.Hook
-	assert.Equal(t, nilExtensionStages, extensionStages)
+	var nilExtensionStageHooks map[string][]rspec.Hook
+	assert.Equal(t, nilExtensionStageHooks, extensionStageHooks)
 }
 
 func TestExtensionStage(t *testing.T) {
@@ -197,7 +197,7 @@ func TestExtensionStage(t *testing.T) {
 	}
 
 	config := &rspec.Spec{}
-	extensionStages, err := manager.Hooks(config, map[string]string{}, false)
+	extensionStageHooks, err := manager.Hooks(config, map[string]string{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestExtensionStage(t *testing.T) {
 				Path: "/a/b/c",
 			},
 		},
-	}, extensionStages)
+	}, extensionStageHooks)
 }
 
 func init() {

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -190,10 +190,10 @@ func TestExtensionStage(t *testing.T) {
 				When: current.When{
 					Always: &always,
 				},
-				Stages: []string{"prestart", "a", "b"},
+				Stages: []string{"prestart", "poststop", "a", "b"},
 			},
 		},
-		extensionStages: []string{"a", "b", "c"},
+		extensionStages: []string{"poststop", "a", "b", "c"},
 	}
 
 	config := &rspec.Spec{}
@@ -211,6 +211,11 @@ func TestExtensionStage(t *testing.T) {
 	}, config.Hooks)
 
 	assert.Equal(t, map[string][]rspec.Hook{
+		"poststop": {
+			{
+				Path: "/a/b/c",
+			},
+		},
 		"a": {
 			{
 				Path: "/a/b/c",


### PR DESCRIPTION
This allows callers to avoid delegating to OCI runtimes for cases where they feel that the runtime hook handling is unreliable (e.g. see [here][1] and the following few comments).  If/when this lands, I'll work up a PR that sets `poststop` as an extension stage in `libpod/container_internal.go` and then invokes those hooks after deletion.

CC @mheon.

[1]: https://github.com/projectatomic/libpod/issues/730#issuecomment-392959938