### PR TITLE
Makefile: Add stderr redirect to HAS_PYTHON3 definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh)
 PYTHON ?= /usr/bin/python3
-HAS_PYTHON3 := $(shell command -v python3)
+HAS_PYTHON3 := $(shell command -v python3 2>/dev/null)
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d


### PR DESCRIPTION
For two reasons:

* When a system is missing `python3`, we don't need to spam them with "Command not found" in their stderr.

* Without the redirect, GNU Make (at least version 4.2.1) is overly clever and tries to invoke the command itself, [not realizing that it's a shell builtin][1]:

    ```console
    $ make --version
    GNU Make 4.2.1
    Built for aarch64-unknown-linux-gnu
    Copyright (C) 1988-2016 Free Software Foundation, Inc.
    License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
    This is free software: you are free to change and redistribute it.
    There is NO WARRANTY, to the extent permitted by law.
    $ cat Makefile
    PYTHON3_A := $(shell command -v python3)
    PYTHON3_B := $(shell command -v python3 2>/dev/null)

    test:
            @echo "SHELL: '$(SHELL)'"
            @echo "PYTHON3_A: '$(PYTHON3_A)'"
            @echo "PYTHON3_B: '$(PYTHON3_B)'"
    $ make
    make: command: Command not found
    SHELL: '/bin/sh'
    PYTHON3_A: ''
    PYTHON3_B: '/usr/bin/python3'
    ```

    By adding the redirect we actually hit the shell and can successfully invoke `command`.

[1]: https://stackoverflow.com/a/17550243