### PR TITLE
Add OnBuild support for podman build

### DIFF
--- a/API.md
+++ b/API.md
@@ -153,7 +153,7 @@ method Commit(name: [string](https://godoc.org/builtin#string), image_name: [str
 Commit, creates an image from an existing container. It requires the name or
 ID of the container as well as the resulting image name.  Optionally, you can define an author and message
 to be added to the resulting image.  You can also define changes to the resulting image for the following
-attributes: _CMD, ENTRYPOINT, ENV, EXPOSE, LABEL, STOPSIGNAL, USER, VOLUME, and WORKDIR_.  To pause the
+attributes: _CMD, ENTRYPOINT, ENV, EXPOSE, LABEL, ONBUILD, STOPSIGNAL, USER, VOLUME, and WORKDIR_.  To pause the
 container while it is being committed, pass a _true_ bool for the pause argument.  If the container cannot
 be found by the ID or name provided, a (ContainerNotFound)[#ContainerNotFound] error will be returned; otherwise,
 the resulting image's ID will be returned as a string.

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -19,7 +19,7 @@ var (
 	commitFlags = []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "change, c",
-			Usage: "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR",
+			Usage: fmt.Sprintf("Apply the following possible instructions to the created image (default []): %s", strings.Join(libpod.ChangeCmds, " | ")),
 		},
 		cli.StringFlag{
 			Name:  "format, f",
@@ -92,7 +92,7 @@ func commitCmd(c *cli.Context) error {
 	if c.IsSet("change") {
 		for _, change := range c.StringSlice("change") {
 			splitChange := strings.Split(strings.ToUpper(change), "=")
-			if !util.StringInSlice(splitChange[0], []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}) {
+			if !util.StringInSlice(splitChange[0], libpod.ChangeCmds) {
 				return errors.Errorf("invalid syntax for --change ", change)
 			}
 		}

--- a/cmd/podman/varlink/io.projectatomic.podman.varlink
+++ b/cmd/podman/varlink/io.projectatomic.podman.varlink
@@ -531,7 +531,7 @@ method DeleteUnusedImages() -> (images: []string)
 # Commit, creates an image from an existing container. It requires the name or
 # ID of the container as well as the resulting image name.  Optionally, you can define an author and message
 # to be added to the resulting image.  You can also define changes to the resulting image for the following
-# attributes: _CMD, ENTRYPOINT, ENV, EXPOSE, LABEL, STOPSIGNAL, USER, VOLUME, and WORKDIR_.  To pause the
+# attributes: _CMD, ENTRYPOINT, ENV, EXPOSE, LABEL, ONBUILD, STOPSIGNAL, USER, VOLUME, and WORKDIR_.  To pause the
 # container while it is being committed, pass a _true_ bool for the pause argument.  If the container cannot
 # be found by the ID or name provided, a (ContainerNotFound)[#ContainerNotFound] error will be returned; otherwise,
 # the resulting image's ID will be returned as a string.

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -24,7 +24,9 @@ Set the author for the committed image
 
 **--change, -c**
 Apply the following possible instructions to the created image:
-**CMD** | **ENTRYPOINT** | **ENV** | **EXPOSE** | **LABEL** | **STOPSIGNAL** | **USER** | **VOLUME** | **WORKDIR**
+**CMD** | **ENTRYPOINT** | **ENV** | **EXPOSE** | **LABEL** | **ONBUILD** | **STOPSIGNAL** | **USER** | **VOLUME** | **WORKDIR**
+
+
 Can be set multiple times
 
 **--format, -f**

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -24,6 +24,9 @@ type ContainerCommitOptions struct {
 	Changes []string
 }
 
+// ChangeCmds is the list of valid Changes commands to passed to the Commit call
+var ChangeCmds = []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}
+
 // Commit commits the changes between a container and its image, creating a new
 // image
 func (c *Container) Commit(ctx context.Context, destImage string, options ContainerCommitOptions) (*image.Image, error) {
@@ -138,6 +141,8 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 				isLabelCleared = true
 			}
 			importBuilder.SetLabel(splitChange[1], splitChange[2])
+		case "ONBUILD":
+			importBuilder.SetOnBuild(splitChange[1])
 		case "STOPSIGNAL":
 			// No Set StopSignal
 		case "USER":

--- a/vendor.conf
+++ b/vendor.conf
@@ -88,7 +88,7 @@ k8s.io/kube-openapi 275e2ce91dec4c05a4094a7b1daee5560b555ac9 https://github.com/
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kubernetes/utils
 github.com/mrunalp/fileutils master
 github.com/varlink/go master
-github.com/projectatomic/buildah 25f4e8ec639044bff4ab393188d083782f07b61c
+github.com/projectatomic/buildah b66e8531456e2986ffc409f591c9005813589a34
 github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master

--- a/vendor/github.com/projectatomic/buildah/commit.go
+++ b/vendor/github.com/projectatomic/buildah/commit.go
@@ -52,6 +52,9 @@ type CommitOptions struct {
 	// Squash tells the builder to produce an image with a single layer
 	// instead of with possibly more than one layer.
 	Squash bool
+
+	// OnBuild is a list of commands to be run by images based on this image
+	OnBuild []string
 }
 
 // PushOptions can be used to alter how an image is copied somewhere.

--- a/vendor/github.com/projectatomic/buildah/config.go
+++ b/vendor/github.com/projectatomic/buildah/config.go
@@ -331,6 +331,24 @@ func (b *Builder) SetUser(spec string) {
 	b.Docker.Config.User = spec
 }
 
+// OnBuild returns the OnBuild value from the container.
+func (b *Builder) OnBuild() []string {
+	return copyStringSlice(b.Docker.Config.OnBuild)
+}
+
+// ClearOnBuild removes all values from the OnBuild structure
+func (b *Builder) ClearOnBuild() {
+	b.Docker.Config.OnBuild = []string{}
+}
+
+// SetOnBuild sets a trigger instruction to be executed when the image is used
+// as the base of another image.
+// Note: this setting is not present in the OCIv1 image format, so it is
+// discarded when writing images using OCIv1 formats.
+func (b *Builder) SetOnBuild(onBuild string) {
+	b.Docker.Config.OnBuild = append(b.Docker.Config.OnBuild, onBuild)
+}
+
 // WorkDir returns the default working directory for running commands in the
 // container, or in a container built using an image built from this container.
 func (b *Builder) WorkDir() string {
@@ -348,7 +366,7 @@ func (b *Builder) SetWorkDir(there string) {
 // Shell returns the default shell for running commands in the
 // container, or in a container built using an image built from this container.
 func (b *Builder) Shell() []string {
-	return b.Docker.Config.Shell
+	return copyStringSlice(b.Docker.Config.Shell)
 }
 
 // SetShell sets the default shell for running
@@ -357,7 +375,7 @@ func (b *Builder) Shell() []string {
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetShell(shell []string) {
-	b.Docker.Config.Shell = shell
+	b.Docker.Config.Shell = copyStringSlice(shell)
 }
 
 // Env returns a list of key-value pairs to be set when running commands in the

--- a/vendor/github.com/projectatomic/buildah/imagebuildah/chroot_symlink.go
+++ b/vendor/github.com/projectatomic/buildah/imagebuildah/chroot_symlink.go
@@ -37,7 +37,7 @@ func resolveChrootedSymlinks() {
 		os.Exit(1)
 	}
 
-	// Our second paramter is the path name to evaluate for symbolic links
+	// Our second parameter is the path name to evaluate for symbolic links
 	symLink, err := getSymbolicLink(flag.Arg(0), flag.Arg(1))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error getting symbolic links: %v\n", err)

--- a/vendor/github.com/projectatomic/buildah/pkg/cli/common.go
+++ b/vendor/github.com/projectatomic/buildah/pkg/cli/common.go
@@ -152,6 +152,10 @@ var (
 			Name:  "squash",
 			Usage: "Squash newly built layers into a single new layer. Buildah does not currently support caching so this is a NOOP.",
 		},
+		cli.BoolTFlag{
+			Name:  "stream",
+			Usage: "There is no daemon in use, so this command is a NOOP.",
+		},
 		cli.StringSliceFlag{
 			Name:  "tag, t",
 			Usage: "tagged `name` to apply to the built image",


### PR DESCRIPTION
Only supported for docker formated images. OCI Does not support this flag.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>