### PR TITLE
Catch does not exist error

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -423,7 +423,7 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container) error {
 
 	out, err := exec.Command(r.path, "state", ctr.ID()).CombinedOutput()
 	if err != nil {
-		if strings.HasSuffix(string(out), "does not exist") {
+		if strings.Contains(string(out), "does not exist") {
 			ctr.removeConmonFiles()
 			ctr.state.State = ContainerStateConfigured
 			return nil


### PR DESCRIPTION
There was a new line at the end of does not exist
which was causing this to fail.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>