### PR TITLE
libpod: Execute poststop hooks locally

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -37,6 +37,7 @@ var (
 
 // saveCmd saves the image to either docker-archive or oci
 func rmCmd(c *cli.Context) error {
+	ctx := getContext()
 	if err := validateFlags(c, rmFlags); err != nil {
 		return err
 	}
@@ -81,7 +82,7 @@ func rmCmd(c *cli.Context) error {
 		}
 	}
 	for _, container := range delContainers {
-		err = runtime.RemoveContainer(container, c.Bool("force"))
+		err = runtime.RemoveContainer(ctx, container, c.Bool("force"))
 		if err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -35,6 +35,7 @@ var (
 )
 
 func rmiCmd(c *cli.Context) error {
+	ctx := getContext()
 	if err := validateFlags(c, rmiFlags); err != nil {
 		return err
 	}
@@ -76,7 +77,7 @@ func rmiCmd(c *cli.Context) error {
 		return errors.Errorf("no valid images to delete")
 	}
 	for _, img := range imagesToDelete {
-		msg, err := runtime.RemoveImage(img, c.Bool("force"))
+		msg, err := runtime.RemoveImage(ctx, img, c.Bool("force"))
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUsedByContainer {
 				fmt.Printf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\n", img.ID())

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -225,7 +225,7 @@ func runCmd(c *cli.Context) error {
 	}
 
 	if createConfig.Rm {
-		return runtime.RemoveContainer(ctr, true)
+		return runtime.RemoveContainer(ctx, ctr, true)
 	}
 
 	if err := ctr.Cleanup(); err != nil {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -166,6 +166,10 @@ type containerState struct {
 	// UserNSRoot is the directory used as root for the container when using
 	// user namespaces.
 	UserNSRoot string `json:"userNSRoot,omitempty"`
+
+	// ExtensionStageHooks holds hooks which will be executed by libpod
+	// and not delegated to the OCI runtime.
+	ExtensionStageHooks map[string][]spec.Hook `json:"extensionStageHooks,omitempty"`
 }
 
 // ExecSession contains information on an active exec session

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -1,0 +1,80 @@
+package libpod
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// hookPath is the path to an example hook executable.
+var hookPath string
+
+func TestPostDeleteHooks(t *testing.T) {
+	ctx := context.Background()
+	dir, err := ioutil.TempDir("", "libpod_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	statePath := filepath.Join(dir, "state")
+	copyPath := filepath.Join(dir, "copy")
+	c := Container{
+		config: &ContainerConfig{
+			ID: "123abc",
+			Spec: &rspec.Spec{
+				Annotations: map[string]string{
+					"a": "b",
+				},
+			},
+			StaticDir: dir, // not the bundle, but good enough for this test
+		},
+		state: &containerState{
+			ExtensionStageHooks: map[string][]rspec.Hook{
+				"poststop": {
+					rspec.Hook{
+						Path: hookPath,
+						Args: []string{"sh", "-c", fmt.Sprintf("cat >%s", statePath)},
+					},
+					rspec.Hook{
+						Path: "/does/not/exist",
+					},
+					rspec.Hook{
+						Path: hookPath,
+						Args: []string{"sh", "-c", fmt.Sprintf("cp %s %s", statePath, copyPath)},
+					},
+				},
+			},
+		},
+	}
+	err = c.postDeleteHooks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stateRegexp := "{\"ociVersion\":\"1\\.0\\.0\",\"id\":\"123abc\",\"status\":\"stopped\",\"bundle\":\"/tmp/libpod_test_[0-9]*\",\"annotations\":{\"a\":\"b\"}}"
+	for _, path := range []string{statePath, copyPath} {
+		t.Run(path, func(t *testing.T) {
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Regexp(t, stateRegexp, string(content))
+		})
+	}
+}
+
+func init() {
+	if runtime.GOOS != "windows" {
+		hookPath = "/bin/sh"
+	} else {
+		panic("we need a reliable executable path on Windows")
+	}
+}

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -75,7 +75,7 @@ type CopyOptions struct {
 
 // RemoveImage deletes an image from local storage
 // Images being used by running containers can only be removed if force=true
-func (r *Runtime) RemoveImage(image *image.Image, force bool) (string, error) {
+func (r *Runtime) RemoveImage(ctx context.Context, image *image.Image, force bool) (string, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -97,7 +97,7 @@ func (r *Runtime) RemoveImage(image *image.Image, force bool) (string, error) {
 	if len(imageCtrs) > 0 && len(image.Names()) <= 1 {
 		if force {
 			for _, ctr := range imageCtrs {
-				if err := r.removeContainer(ctr, true); err != nil {
+				if err := r.removeContainer(ctx, ctr, true); err != nil {
 					return "", errors.Wrapf(err, "error removing image %s: container %s using image could not be removed", image.ID(), ctr.ID())
 				}
 			}

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -409,6 +409,7 @@ func (i *LibpodAPI) WaitContainer(call ioprojectatomicpodman.VarlinkCall, name s
 
 // RemoveContainer ...
 func (i *LibpodAPI) RemoveContainer(call ioprojectatomicpodman.VarlinkCall, name string, force bool) error {
+	ctx := getContext()
 	runtime, err := libpodruntime.GetRuntime(i.Cli)
 	if err != nil {
 		return call.ReplyRuntimeError(err.Error())
@@ -417,7 +418,7 @@ func (i *LibpodAPI) RemoveContainer(call ioprojectatomicpodman.VarlinkCall, name
 	if err != nil {
 		return call.ReplyContainerNotFound(name)
 	}
-	if err := runtime.RemoveContainer(ctr, force); err != nil {
+	if err := runtime.RemoveContainer(ctx, ctr, force); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
 	return call.ReplyRemoveContainer(ctr.ID())
@@ -426,6 +427,7 @@ func (i *LibpodAPI) RemoveContainer(call ioprojectatomicpodman.VarlinkCall, name
 
 // DeleteStoppedContainers ...
 func (i *LibpodAPI) DeleteStoppedContainers(call ioprojectatomicpodman.VarlinkCall) error {
+	ctx := getContext()
 	var deletedContainers []string
 	runtime, err := libpodruntime.GetRuntime(i.Cli)
 	if err != nil {
@@ -441,7 +443,7 @@ func (i *LibpodAPI) DeleteStoppedContainers(call ioprojectatomicpodman.VarlinkCa
 			return call.ReplyErrorOccurred(err.Error())
 		}
 		if state != libpod.ContainerStateRunning {
-			if err := runtime.RemoveContainer(ctr, false); err != nil {
+			if err := runtime.RemoveContainer(ctx, ctr, false); err != nil {
 				return call.ReplyErrorOccurred(err.Error())
 			}
 			deletedContainers = append(deletedContainers, ctr.ID())

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -360,6 +360,7 @@ func (i *LibpodAPI) TagImage(call ioprojectatomicpodman.VarlinkCall, name, tag s
 // RemoveImage accepts a image name or ID as a string and force bool to determine if it should
 // remove the image even if being used by stopped containers
 func (i *LibpodAPI) RemoveImage(call ioprojectatomicpodman.VarlinkCall, name string, force bool) error {
+	ctx := getContext()
 	runtime, err := libpodruntime.GetRuntime(i.Cli)
 	if err != nil {
 		return call.ReplyRuntimeError(err.Error())
@@ -368,7 +369,7 @@ func (i *LibpodAPI) RemoveImage(call ioprojectatomicpodman.VarlinkCall, name str
 	if err != nil {
 		return call.ReplyImageNotFound(name)
 	}
-	imageID, err := runtime.RemoveImage(newImage, force)
+	imageID, err := runtime.RemoveImage(ctx, newImage, force)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}


### PR DESCRIPTION
Builds on #857, review that first.

Execute the poststop hooks ourselves instead of delegating to the runtime, since [some runtimes do not seem to handle these reliably][1].

This may be enough for #730, but I'm not sure.

Also, while the `hooks` package is well-covered by unit tests and this pull requests adds unit tests for `Container.postDeleteHooks`, we don't seem to have integration tests exercising the whole system.  fdcf633a (#155) added [a hook test][2], but its `fileutils.CopyFile` call has no error checking and (as far as I can see) no source `hooks.json` to copy.  I expect we want to patch up that test, but I'm leaving it to follow-up (or parallel) work.

[1]: https://github.com/projectatomic/libpod/issues/730#issuecomment-392959938
[2]: https://github.com/projectatomic/libpod/blame/824ea4da338891aff122f08f8f97b4d08b1a1e95/test/e2e/run_test.go#L250-L261