### PR TITLE
If user specifies UIDMapSlice without GIDMapSlice, set them equal

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -136,6 +136,13 @@ func ParseIDMapping(UIDMapSlice, GIDMapSlice []string, subUIDMap, subGIDMap stri
 	if subUIDMap == "" && subGIDMap != "" {
 		subUIDMap = subGIDMap
 	}
+	if len(GIDMapSlice) == 0 && len(UIDMapSlice) != 0 {
+		GIDMapSlice = UIDMapSlice
+	}
+	if len(UIDMapSlice) == 0 && len(GIDMapSlice) != 0 {
+		UIDMapSlice = GIDMapSlice
+	}
+
 	parseTriple := func(spec []string) (container, host, size int, err error) {
 		cid, err := strconv.ParseUint(spec[0], 10, 32)
 		if err != nil {


### PR DESCRIPTION
We need to map slices set for both UID and GID maps to be equivalent if
not specified by user.  Currently if you do not specify both the containers
are not running.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>