### PR TITLE
hooks/exec: Allow successful reaps for 0s post-kill timeouts

### DIFF
--- a/pkg/hooks/exec/exec_test.go
+++ b/pkg/hooks/exec/exec_test.go
@@ -207,7 +207,7 @@ func TestRunKillTimeout(t *testing.T) {
 	}
 	hookErr, err := Run(ctx, hook, []byte("{}"), nil, nil, time.Duration(0))
 	assert.Equal(t, context.DeadlineExceeded, err)
-	assert.Regexp(t, "^failed to reap process within 0s of the kill signal$", hookErr)
+	assert.Regexp(t, "^(failed to reap process within 0s of the kill signal|signal: killed)$", hookErr)
 }
 
 func init() {


### PR DESCRIPTION
I'd been getting the failed-to-reap errors locally when working up #857, but on an unrelated pull-request [the FAH27 suite successfully reaped that hook][1]:

```
--- FAIL: TestRunKillTimeout (0.50s)
	assertions.go:226:

	Error Trace:	exec_test.go:210

	Error:      	Expect "signal: killed" to match "^failed to reap process within 0s of the kill signal$"
FAIL
```

The successful-reap cases limit our coverage, but I don't think that's a big enough problem to be worth repeated polling or similar until we do get the failed-to-reap error.

[1]: https://s3.amazonaws.com/aos-ci/ghprb/projectatomic/libpod/96c1535fdc11b2de24421863d7ad5d3b94338b37.0.1527811547665239762/output.log