### PR TITLE
support for rootless containers with an external rootfs

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -322,6 +322,10 @@ var createFlags = []cli.Flag{
 		Name:  "rm",
 		Usage: "Remove container (and pod if created) after exit",
 	},
+	cli.BoolFlag{
+		Name:  "rootfs",
+		Usage: "The first argument is not an image but the rootfs to the exploded container",
+	},
 	cli.StringSliceFlag{
 		Name:  "security-opt",
 		Usage: "Security Options (default [])",

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containers/storage"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/go-connections/nat"
@@ -81,7 +80,10 @@ func createCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	storageOpts := storage.DefaultStoreOptions
+	storageOpts, err := libpodruntime.GetDefaultStoreOptions()
+	if err != nil {
+		return err
+	}
 	storageOpts.UIDMap = mappings.UIDMap
 	storageOpts.GIDMap = mappings.GIDMap
 

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -41,6 +41,9 @@ func GetRuntimeWithStorageOpts(c *cli.Context, storageOpts *storage.StoreOptions
 	if c.GlobalIsSet("conmon") {
 		options = append(options, libpod.WithConmonPath(c.GlobalString("conmon")))
 	}
+	if c.GlobalIsSet("tmpdir") {
+		options = append(options, libpod.WithTmpDir(c.GlobalString("tmpdir")))
+	}
 
 	if c.GlobalIsSet("cgroup-manager") {
 		options = append(options, libpod.WithCgroupManager(c.GlobalString("cgroup-manager")))

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -154,6 +154,10 @@ func main() {
 			Usage: "path to the root directory in which data, including images, is stored",
 		},
 		cli.StringFlag{
+			Name:  "tmpdir",
+			Usage: "path to the tmp directory",
+		},
+		cli.StringFlag{
 			Name:  "runroot",
 			Usage: "path to the 'run directory' where all state information is stored",
 		},

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
 	"github.com/projectatomic/libpod/libpod"
@@ -54,7 +53,10 @@ func runCmd(c *cli.Context) error {
 		}
 	}
 
-	storageOpts := storage.DefaultStoreOptions
+	storageOpts, err := libpodruntime.GetDefaultStoreOptions()
+	if err != nil {
+		return err
+	}
 	mappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidmap"), c.String("subgidmap"))
 	if err != nil {
 		return err

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1431,6 +1431,7 @@ _podman_container_run() {
 		--pids-limit
 		--publish -p
 		--runtime
+		--rootfs
 		--security-opt
 		--shm-size
 		--stop-signal

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -470,6 +470,13 @@ its root filesystem mounted as read only prohibiting any writes.
 
 Automatically remove the container when it exits. The default is *false*.
 
+**--rootfs**
+
+If specified, the first argument refers to an exploded container on the file system.
+
+This is useful to run a container without requiring any image management, the rootfs
+of the container is assumed to be managed externally.
+
 **--security-opt**=[]
 
 Security Options

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -491,6 +491,13 @@ its root filesystem mounted as read only prohibiting any writes.
 
 Automatically remove the container when it exits. The default is *false*.
 
+**--rootfs**
+
+If specified, the first argument refers to an exploded container on the file system.
+
+This is useful to run a container without requiring any image management, the rootfs
+of the container is assumed to be managed externally.
+
 **--security-opt**=[]
 
 Security Options

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -197,6 +197,8 @@ type ContainerConfig struct {
 	// Information on the image used for the root filesystem/
 	RootfsImageID   string `json:"rootfsImageID,omitempty"`
 	RootfsImageName string `json:"rootfsImageName,omitempty"`
+	// Rootfs to use for the container, this conflicts with RootfsImageID
+	Rootfs string `json:"rootfs,omitempty"`
 	// Whether to mount volumes specified in the image.
 	ImageVolumes bool `json:"imageVolumes"`
 	// Src path to be mounted on /dev/shm in container.

--- a/libpod/container_attach.go
+++ b/libpod/container_attach.go
@@ -85,7 +85,7 @@ func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSi
 
 	conn, err := net.DialUnix("unixpacket", nil, &net.UnixAddr{Name: c.AttachSocketPath(), Net: "unixpacket"})
 	if err != nil {
-		return errors.Wrapf(err, "failed to connect to container's attach socket: %v")
+		return errors.Wrapf(err, "failed to connect to container's attach socket: %v", c.AttachSocketPath())
 	}
 	defer conn.Close()
 

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -34,6 +34,10 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 		isEnvCleared, isLabelCleared, isExposeCleared, isVolumeCleared bool
 	)
 
+	if c.config.Rootfs != "" {
+		return nil, errors.Errorf("cannot commit a container that uses an exploded rootfs")
+	}
+
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -70,6 +70,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		},
 		ImageID:         config.RootfsImageID,
 		ImageName:       config.RootfsImageName,
+		Rootfs:          config.Rootfs,
 		ResolvConfPath:  resolvPath,
 		HostnamePath:    hostnamePath,
 		HostsPath:       hostsPath,

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -512,6 +512,9 @@ func (c *Container) completeNetworkSetup() error {
 	if !c.config.PostConfigureNetNS {
 		return nil
 	}
+	if os.Getuid() != 0 {
+		return nil
+	}
 	if err := c.syncContainer(); err != nil {
 		return err
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -225,8 +225,12 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		return errors.Wrapf(ErrInvalidArg, "must provide image ID and image name to use an image")
 	}
 
-	options := storage.ContainerOptions{IDMappingOptions: c.config.IDMappings}
-	containerInfo, err := c.runtime.storageService.CreateContainerStorage(ctx, c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, c.config.MountLabel, &options)
+	var options *storage.ContainerOptions
+	if c.config.Rootfs == "" {
+		options = &storage.ContainerOptions{c.config.IDMappings}
+
+	}
+	containerInfo, err := c.runtime.storageService.CreateContainerStorage(ctx, c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, c.config.MountLabel, options)
 	if err != nil {
 		return errors.Wrapf(err, "error creating container storage")
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1173,8 +1173,10 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	var err error
-	if c.state.ExtensionStageHooks, err = c.setupOCIHooks(ctx, &g); err != nil {
-		return nil, errors.Wrapf(err, "error setting up OCI Hooks")
+	if os.Getuid() == 0 {
+		if c.state.ExtensionStageHooks, err = c.setupOCIHooks(ctx, &g); err != nil {
+			return nil, errors.Wrapf(err, "error setting up OCI Hooks")
+		}
 	}
 	// Bind builtin image volumes
 	if c.config.Rootfs == "" && c.config.ImageVolumes {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1296,7 +1296,9 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		g.AddProcessEnv("container", "libpod")
 	}
 
-	if c.runtime.config.CgroupManager == SystemdCgroupsManager {
+	if os.Getuid() != 0 {
+		g.SetLinuxCgroupsPath("")
+	} else if c.runtime.config.CgroupManager == SystemdCgroupsManager {
 		// When runc is set to use Systemd as a cgroup manager, it
 		// expects cgroups to be passed as follows:
 		// slice:prefix:name

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -302,6 +302,7 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string) (er
 	// 0, 1 and 2 are stdin, stdout and stderr
 	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("_OCI_STARTPIPE=%d", 4))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", os.Getenv("XDG_RUNTIME_DIR")))
 	if notify, ok := os.LookupEnv("NOTIFY_SOCKET"); ok {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("NOTIFY_SOCKET=%s", notify))
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -349,23 +349,25 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string) (er
 	childStartPipe.Close()
 
 	// Move conmon to specified cgroup
-	if r.cgroupManager == SystemdCgroupsManager {
-		unitName := createUnitName("libpod-conmon", ctr.ID())
+	if os.Getuid() == 0 {
+		if r.cgroupManager == SystemdCgroupsManager {
+			unitName := createUnitName("libpod-conmon", ctr.ID())
 
-		logrus.Infof("Running conmon under slice %s and unitName %s", cgroupParent, unitName)
-		if err = utils.RunUnderSystemdScope(cmd.Process.Pid, cgroupParent, unitName); err != nil {
-			logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
-		}
-	} else {
-		cgroupPath := filepath.Join(ctr.config.CgroupParent, fmt.Sprintf("libpod-%s", ctr.ID()), "conmon")
-		control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cgroupPath), &spec.LinuxResources{})
-		if err != nil {
-			logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+			logrus.Infof("Running conmon under slice %s and unitName %s", cgroupParent, unitName)
+			if err = utils.RunUnderSystemdScope(cmd.Process.Pid, cgroupParent, unitName); err != nil {
+				logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
+			}
 		} else {
-			// we need to remove this defer and delete the cgroup once conmon exits
-			// maybe need a conmon monitor?
-			if err := control.Add(cgroups.Process{Pid: cmd.Process.Pid}); err != nil {
+			cgroupPath := filepath.Join(ctr.config.CgroupParent, fmt.Sprintf("libpod-%s", ctr.ID()), "conmon")
+			control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cgroupPath), &spec.LinuxResources{})
+			if err != nil {
 				logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+			} else {
+				// we need to remove this defer and delete the cgroup once conmon exits
+				// maybe need a conmon monitor?
+				if err := control.Add(cgroups.Process{Pid: cmd.Process.Pid}); err != nil {
+					logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+				}
 			}
 		}
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -183,7 +183,9 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 
 	configPath := ConfigPath
 	foundConfig := true
-	if _, err := os.Stat(OverrideConfigPath); err == nil {
+	if os.Getuid() != 0 {
+		foundConfig = false
+	} else if _, err := os.Stat(OverrideConfigPath); err == nil {
 		// Use the override configuration path
 		configPath = OverrideConfigPath
 	} else if _, err := os.Stat(ConfigPath); err != nil {

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -148,6 +148,7 @@ type ContainerInspectData struct {
 	State           *ContainerInspectState `json:"State"`
 	ImageID         string                 `json:"Image"`
 	ImageName       string                 `json:"ImageName"`
+	Rootfs          string                 `json:"Rootfs"`
 	ResolvConfPath  string                 `json:"ResolvConfPath"`
 	HostnamePath    string                 `json:"HostnamePath"`
 	HostsPath       string                 `json:"HostsPath"`

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -130,6 +130,7 @@ type CreateConfig struct {
 	ApparmorProfile    string               //SecurityOpts
 	SeccompProfilePath string               //SecurityOpts
 	SecurityOpts       []string
+	Rootfs             string
 }
 
 func u32Ptr(i int64) *uint32     { u := uint32(i); return &u }

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -360,7 +360,11 @@ func (c *CreateConfig) GetContainerCreateOptions() ([]libpod.CtrCreateOption, er
 	// does not have one
 	options = append(options, libpod.WithEntrypoint(c.Entrypoint))
 
-	if c.NetMode.IsContainer() {
+	if os.Getuid() != 0 {
+		if !c.NetMode.IsHost() && !c.NetMode.IsNone() {
+			options = append(options, libpod.WithNetNS(portBindings, true))
+		}
+	} else if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())
 		if err != nil {
 			return nil, errors.Wrapf(err, "container %q not found", c.NetMode.ConnectedContainer())

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,6 +1,7 @@
 package createconfig
 
 import (
+	"os"
 	"strings"
 
 	"github.com/docker/docker/daemon/caps"
@@ -43,6 +44,16 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
 		}
 		g.AddMount(sysMnt)
+	}
+	if os.Getuid() != 0 {
+		g.RemoveMount("/dev/pts")
+		devPts := spec.Mount{
+			Destination: "/dev/pts",
+			Type:        "devpts",
+			Source:      "devpts",
+			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"},
+		}
+		g.AddMount(devPts)
 	}
 
 	if addCgroup {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -153,7 +153,6 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		}
 	}
 
-
 	for _, uidmap := range config.IDMappings.UIDMap {
 		g.AddLinuxUIDMapping(uint32(uidmap.HostID), uint32(uidmap.ContainerID), uint32(uidmap.Size))
 	}
@@ -286,30 +285,6 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			configSpec.Linux.Resources.BlockIO = blkio
 		}
 	}
-
-	/*
-			//Annotations
-				Resources: &configSpec.LinuxResources{
-					BlockIO: &blkio,
-					//HugepageLimits:
-					Network: &configSpec.LinuxNetwork{
-					// ClassID *uint32
-					// Priorites []LinuxInterfacePriority
-					},
-				},
-				//CgroupsPath:
-				//Namespaces: []LinuxNamespace
-				// DefaultAction:
-				// Architectures
-				// Syscalls:
-				},
-				// RootfsPropagation
-				// MaskedPaths
-				// ReadonlyPaths:
-				// IntelRdt
-			},
-		}
-	*/
 
 	// If we cannot add resources be sure everything is cleared out
 	if !canAddResources {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -141,6 +142,12 @@ func ParseIDMapping(UIDMapSlice, GIDMapSlice []string, subUIDMap, subGIDMap stri
 	}
 	if len(UIDMapSlice) == 0 && len(GIDMapSlice) != 0 {
 		UIDMapSlice = GIDMapSlice
+	}
+	if len(UIDMapSlice) == 0 && subUIDMap == "" && os.Getuid() != 0 {
+		UIDMapSlice = []string{fmt.Sprintf("0:%d:1", os.Getuid())}
+	}
+	if len(GIDMapSlice) == 0 && subGIDMap == "" && os.Getuid() != 0 {
+		GIDMapSlice = []string{fmt.Sprintf("0:%d:1", os.Getgid())}
 	}
 
 	parseTriple := func(spec []string) (container, host, size int, err error) {

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -1,0 +1,97 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman rootless", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+	})
+
+	It("podman rootless rootfs", func() {
+		// Check if we can create an user namespace
+		err := exec.Command("unshare", "-r", "echo", "hello").Run()
+		if err != nil {
+			Skip("User namespaces not supported.")
+		}
+
+		setup := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid := setup.OutputToString()
+
+		mount := podmanTest.Podman([]string{"mount", cid})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+		mountPath := mount.OutputToString()
+
+		chownFunc := func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			return os.Lchown(p, 1000, 1000)
+		}
+
+		err = filepath.Walk(tempdir, chownFunc)
+		if err != nil {
+			fmt.Printf("cannot chown the directory: %q\n", err)
+			os.Exit(1)
+		}
+
+		runRootless := func(mountPath string) {
+			tempdir, err := CreateTempDirInTempDir()
+			Expect(err).To(BeNil())
+			podmanTest := PodmanCreate(tempdir)
+			err = filepath.Walk(tempdir, chownFunc)
+			Expect(err).To(BeNil())
+
+			xdgRuntimeDir, err := ioutil.TempDir("/run", "")
+			Expect(err).To(BeNil())
+			defer os.RemoveAll(xdgRuntimeDir)
+			err = filepath.Walk(xdgRuntimeDir, chownFunc)
+			Expect(err).To(BeNil())
+
+			home, err := CreateTempDirInTempDir()
+			Expect(err).To(BeNil())
+			err = filepath.Walk(xdgRuntimeDir, chownFunc)
+			Expect(err).To(BeNil())
+
+			env := os.Environ()
+			env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
+			env = append(env, fmt.Sprintf("HOME=%s", home))
+			cmd := podmanTest.PodmanAsUser([]string{"run", "--rootfs", mountPath, "echo", "hello"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
+			Expect(cmd.ExitCode()).To(Equal(0))
+		}
+
+		runRootless(mountPath)
+
+		umount := podmanTest.Podman([]string{"umount", cid})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
+	})
+})


### PR DESCRIPTION
This is a hacky and PoC attempt at having rootless containers in podman.  A proper implementation will take much more work than this PR (biggest issue, containers/storage must handle rootless access and management for the images, most likely we will need some changes in containers/image as well).  In any case we would be able to use only the vfs backend storage until overlayfs can be used by a not privileged user.

Given these limitations, the current implementation expects an exploded container rootfs.  My tests were limited to run a container and see it appears in `podman ps`.

The last patch must land in containers/storage, I've added it here so that the PR can be used.

```console
$ bin/podman run -v /tmp:/tmp --rootfs /path/to/an/exploded/container/rootfs sh -c "echo it works > /tmp/out"; cat /tmp/out
it works
$ bin/podman run -v /tmp:/tmp --rootfs /path/to/an/exploded/container/rootfs cat /proc/self/uid_map
         0       1000          1
```

