### PR TITLE
hack/release.sh: No longer need to bump setup.py

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,12 +21,6 @@ write_go_version()
 	sed -i "s/^\(const Version = \"\).*/\1${LOCAL_VERSION}\"/" version/version.go
 }
 
-write_python_version()
-{
-	LOCAL_VERSION="$1"
-	sed -i "s/^\( *version='*\).*/\1${LOCAL_VERSION}'/" contrib/python/setup.py
-}
-
 write_spec_version()
 {
 	LOCAL_VERSION="$1"
@@ -51,7 +45,6 @@ write_changelog()
 release_commit()
 {
 	write_go_version "${VERSION}" &&
-	write_python_version "${VERSION}" &&
 	write_changelog &&
 	git commit -asm "Bump to v${VERSION}"
 }
@@ -59,7 +52,6 @@ release_commit()
 dev_version_commit()
 {
 	write_go_version "${NEXT_VERSION}-dev" &&
-	write_python_version "${NEXT_VERSION}" &&
 	write_spec_version "${VERSION}" &&
 	git commit -asm "Bump to v${NEXT_VERSION}-dev"
 }

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -45,6 +45,7 @@ write_changelog()
 release_commit()
 {
 	write_go_version "${VERSION}" &&
+	write_spec_version "${VERSION}" &&
 	write_changelog &&
 	git commit -asm "Bump to v${VERSION}"
 }
@@ -52,7 +53,7 @@ release_commit()
 dev_version_commit()
 {
 	write_go_version "${NEXT_VERSION}-dev" &&
-	write_spec_version "${VERSION}" &&
+	write_spec_version "${NEXT_VERSION}" &&
 	git commit -asm "Bump to v${NEXT_VERSION}-dev"
 }
 


### PR DESCRIPTION
Since #807, `setup.py` has been pulling this from a `PODMAN_VERSION` environment variable (which can be set in spec files), and there's no need for us to bump it as part of our releases.

Also fix the spec version bump in `dev_version_commit`.  Bump it to the next version (without a `-dev` suffix), based on the precedent set by 70672652 (#834). Previously I had `VERSION` there, which was a copy/paste error.

I've also added an explicit `write_spec_version` to `release_commit`.  That *should* be a no-op, with the spec version having already been set by the previous release's `dev_version_commit`.  But better to be safe than to cut a release with the wrong version number in the spec file (e.g. maybe we guessed `NEXT_VERSION` wrong during the last release).

cc @mheon, @jwhonce.