### PR TITLE
hooks/1.0.0: Fix 'annotation' -> 'annotations' in JSON

### DIFF
--- a/pkg/hooks/1.0.0/when.go
+++ b/pkg/hooks/1.0.0/when.go
@@ -10,7 +10,7 @@ import (
 // When holds hook-injection conditions.
 type When struct {
 	Always        *bool             `json:"always,omitempty"`
-	Annotations   map[string]string `json:"annotation,omitempty"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
 	Commands      []string          `json:"commands,omitempty"`
 	HasBindMounts *bool             `json:"hasBindMounts,omitempty"`
 

--- a/pkg/hooks/1.0.0/when_test.go
+++ b/pkg/hooks/1.0.0/when_test.go
@@ -218,7 +218,7 @@ func TestHasBindMountsAndCommands(t *testing.T) {
 			match:         true,
 		},
 		{
-			name:          "both, and",
+			name:          "both, or",
 			command:       "/bin/sh",
 			hasBindMounts: true,
 			or:            true,

--- a/pkg/hooks/docs/oci-hooks.5.md
+++ b/pkg/hooks/docs/oci-hooks.5.md
@@ -119,6 +119,7 @@ The following example injects `nvidia-container-runtime-hook prestart` with part
 ```console
 $ cat /etc/containers/oci/hooks.d/nvidia.json
 {
+  "version": "1.0.0",
   "hook": {
     "path": "/usr/sbin/nvidia-container-runtime-hook",
     "args": ["nvidia-container-runtime-hook", "prestart"],
@@ -129,7 +130,7 @@ $ cat /etc/containers/oci/hooks.d/nvidia.json
   },
   "when": {
     "annotations": {
-      "^com\.example\.department$": ".*fluid-dynamics$"
+      "^com\\.example\\.department$": ".*fluid-dynamics$"
     }
   },
   "stages": ["prestart"]

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -10,6 +10,7 @@ import (
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	current "github.com/projectatomic/libpod/pkg/hooks/1.0.0"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 )
@@ -112,6 +113,7 @@ func (m *Manager) Hooks(config *rspec.Spec, annotations map[string]string, hasBi
 			return extensionStageHooks, errors.Wrapf(err, "matching hook %q", namedHook.name)
 		}
 		if match {
+			logrus.Debugf("hook %s matched; adding to stages %v", namedHook.name, namedHook.hook.Stages)
 			if config.Hooks == nil {
 				config.Hooks = &rspec.Hooks{}
 			}
@@ -134,6 +136,8 @@ func (m *Manager) Hooks(config *rspec.Spec, annotations map[string]string, hasBi
 					}
 				}
 			}
+		} else {
+			logrus.Debugf("hook %s did not match", namedHook.name)
 		}
 	}
 

--- a/pkg/hooks/read.go
+++ b/pkg/hooks/read.go
@@ -67,13 +67,16 @@ func ReadDir(path string, extensionStages []string, hooks map[string]*current.Ho
 	}
 
 	for _, file := range files {
-		hook, err := Read(filepath.Join(path, file.Name()), extensionStages)
+		filePath := filepath.Join(path, file.Name())
+		hook, err := Read(filePath, extensionStages)
 		if err != nil {
 			if err == ErrNoJSONSuffix {
 				continue
 			}
 			if os.IsNotExist(err) {
-				continue
+				if err2, ok := err.(*os.PathError); ok && err2.Path == filePath {
+					continue
+				}
 			}
 			return err
 		}

--- a/pkg/hooks/read.go
+++ b/pkg/hooks/read.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	current "github.com/projectatomic/libpod/pkg/hooks/1.0.0"
+	"github.com/sirupsen/logrus"
 )
 
 type reader func(content []byte) (*current.Hook, error)
@@ -61,6 +62,7 @@ func read(content []byte) (hook *current.Hook, err error) {
 // ReadDir reads hook JSON files from a directory into the given map,
 // clobbering any previous entries with the same filenames.
 func ReadDir(path string, extensionStages []string, hooks map[string]*current.Hook) error {
+	logrus.Debugf("reading hooks from %s", path)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return err
@@ -81,6 +83,7 @@ func ReadDir(path string, extensionStages []string, hooks map[string]*current.Ho
 			return err
 		}
 		hooks[file.Name()] = hook
+		logrus.Debugf("added hook %s", filePath)
 	}
 	return nil
 }

--- a/pkg/hooks/read_test.go
+++ b/pkg/hooks/read_test.go
@@ -191,3 +191,24 @@ func TestBadDir(t *testing.T) {
 	}
 	assert.Regexp(t, "^parsing hook \"[^\"]*a.json\": unrecognized hook version: \"-1\"$", err.Error())
 }
+
+func TestHookExecutableDoesNotExit(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hooks-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	jsonPath := filepath.Join(dir, "hook.json")
+	err = ioutil.WriteFile(jsonPath, []byte("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"/does/not/exist\"}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := map[string]*current.Hook{}
+	err = ReadDir(dir, []string{}, hooks)
+	if err == nil {
+		t.Fatal("unexpected success")
+	}
+	assert.Regexp(t, "^stat /does/not/exist: no such file or directory$", err.Error())
+}


### PR DESCRIPTION
This typo from 68eb128f (#686) was causing any `annotations` entries in hook JSON to be silently ignored.

This PR also fixes a number of other issues:

* `ReadDir` was silently ignoring missing hook executables.  Now it bubbles those up.
* The hooks package didn't have any logging for the initial load (behind `New(...)`) or injection (behind `Hooks(...)`).  Now it has logging.
* The 1.0.0 Nvidia example was missing a `version` and appropriate escaping for backslashes (#884).  Now these are fixed.
* One of the `When.Match` tests had a copy/pasted "both, and" name that should have been "both, or".  Now it is "both, or".