### PR TITLE
Add --all flag even though it is a noop so scripts will work

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -54,8 +54,20 @@ func (a imagesSorted) Less(i, j int) bool { return a[i].CreatedTime.After(a[j].C
 var (
 	imagesFlags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "quiet, q",
-			Usage: "display only image IDs",
+			Name:  "all, a",
+			Usage: "Show all images (default hides intermediate images)",
+		},
+		cli.BoolFlag{
+			Name:  "digests",
+			Usage: "show digests",
+		},
+		cli.StringSliceFlag{
+			Name:  "filter, f",
+			Usage: "filter output based on conditions provided (default [])",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Change the output format to JSON or a Go template",
 		},
 		cli.BoolFlag{
 			Name:  "noheading, n",
@@ -66,16 +78,8 @@ var (
 			Usage: "do not truncate output",
 		},
 		cli.BoolFlag{
-			Name:  "digests",
-			Usage: "show digests",
-		},
-		cli.StringFlag{
-			Name:  "format",
-			Usage: "Change the output format to JSON or a Go template",
-		},
-		cli.StringSliceFlag{
-			Name:  "filter, f",
-			Usage: "filter output based on conditions provided (default [])",
+			Name:  "quiet, q",
+			Usage: "display only image IDs",
 		},
 	}
 

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -889,16 +889,20 @@ _podman_info() {
 
 _podman_images() {
     local boolean_options="
-     --help
-     -h
-     --quiet
-     -q
-     --noheading
-     -n
-     --no-trunc
+     -a
+     --all
      --digests
-     --filter
+     --digests
      -f
+     --filter
+     -h
+     --help
+     --no-trunc
+     --notruncate
+     -n
+     --noheading
+     -q
+     --quiet
      "
     local options_with_args="
     --format

--- a/docs/podman-images.1.md
+++ b/docs/podman-images.1.md
@@ -11,6 +11,10 @@ Displays locally stored images, their names, and their IDs.
 
 ## OPTIONS
 
+**--all, -a**
+
+Show all images (by default filter out the intermediate image layers). The default is false. (This is a NOOP until podman build supports caching.)
+
 **--digests**
 
 Show image digests


### PR DESCRIPTION
Until podman build supports caching, their are no intermediary builds,
but people might still use scripts that use the --all option.
Adding this will not hurt anything and could fix scripts.

Also fixed sorting issues in options handling of images

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>