### PR TITLE
bash completion: remove shebang

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 __podman_previous_extglob_setting=$(shopt -p extglob)


### PR DESCRIPTION
Remove the bash completion's shebang, which isn't required as the file
is only meant to be sourced.  rpmlint was complaining about that.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>