### PR TITLE
varlink build fixes

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,7 +5,7 @@ in the [API.md](https://github.com/projectatomic/libpod/blob/master/API.md) file
 
 [func AttachToContainer() NotImplemented](#AttachToContainer)
 
-[func BuildImage(build: BuildInfo) []string](#BuildImage)
+[func BuildImage(build: BuildInfo) BuildResponse](#BuildImage)
 
 [func Commit(name: string, image_name: string, changes: []string, author: string, message: string, pause: bool) string](#Commit)
 
@@ -87,6 +87,8 @@ in the [API.md](https://github.com/projectatomic/libpod/blob/master/API.md) file
 
 [type BuildInfo](#BuildInfo)
 
+[type BuildResponse](#BuildResponse)
+
 [type ContainerChanges](#ContainerChanges)
 
 [type ContainerMount](#ContainerMount)
@@ -148,10 +150,10 @@ This method has not be implemented yet.
 ### <a name="BuildImage"></a>func BuildImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method BuildImage(build: [BuildInfo](#BuildInfo)) [[]string](#[]string)</div>
+method BuildImage(build: [BuildInfo](#BuildInfo)) [BuildResponse](#BuildResponse)</div>
 BuildImage takes a [BuildInfo](#BuildInfo) structure and builds an image.  At a minimum, you must provide the
-'dockerfile' and 'tags' options in the BuildInfo structure.  Upon a successful build, it will
-return the ID of the container.
+'dockerfile' and 'tags' options in the BuildInfo structure. It will return a [BuildResponse](#BuildResponse) structure
+that contains the build logs and resulting image ID.
 ### <a name="Commit"></a>func Commit
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -557,6 +559,13 @@ annotations [[]string](#[]string)
 build_args [map[string]](#map[string])
 
 image_format [string](https://godoc.org/builtin#string)
+### <a name="BuildResponse"></a>type BuildResponse
+
+BuildResponse is used to describe the responses for building images
+
+logs [[]string](#[]string)
+
+id [string](https://godoc.org/builtin#string)
 ### <a name="ContainerChanges"></a>type ContainerChanges
 
 ContainerChanges describes the return struct for ListContainerChanges

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah"
 	"github.com/projectatomic/buildah/imagebuildah"
 	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
@@ -30,6 +32,8 @@ var (
 func buildCmd(c *cli.Context) error {
 	// The following was taken directly from projectatomic/buildah/cmd/bud.go
 	// TODO Find a away to vendor more of this in rather than copy from bud
+
+	var namespace []buildah.NamespaceOption
 	output := ""
 	tags := []string{}
 	if c.IsSet("tag") || c.IsSet("t") {
@@ -151,6 +155,13 @@ func buildCmd(c *cli.Context) error {
 		return err
 	}
 
+	hostNetwork := buildah.NamespaceOption{
+		Name: specs.NetworkNamespace,
+		Host: true,
+	}
+
+	namespace = append(namespace, hostNetwork)
+
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:      contextDir,
 		PullPolicy:            pullPolicy,
@@ -170,6 +181,7 @@ func buildCmd(c *cli.Context) error {
 		Squash:                c.Bool("squash"),
 		Labels:                c.StringSlice("label"),
 		Annotations:           c.StringSlice("annotation"),
+		NamespaceOptions:      namespace,
 	}
 
 	if !c.Bool("quiet") {

--- a/cmd/podman/varlink/io.projectatomic.podman.varlink
+++ b/cmd/podman/varlink/io.projectatomic.podman.varlink
@@ -320,6 +320,12 @@ type BuildInfo (
     image_format: string
 )
 
+# BuildResponse is used to describe the responses for building images
+type BuildResponse (
+    logs: []string,
+    id: string
+)
+
 # Ping provides a response for developers to ensure their varlink setup is working.
 # #### Example
 # ~~~
@@ -525,9 +531,9 @@ method ListImages() -> (images: []ImageInList)
 method GetImage(name: string) -> (image: ImageInList)
 
 # BuildImage takes a [BuildInfo](#BuildInfo) structure and builds an image.  At a minimum, you must provide the
-# 'dockerfile' and 'tags' options in the BuildInfo structure.  Upon a successful build, it will
-# return the ID of the container.
-method BuildImage(build: BuildInfo) -> (image: []string)
+# 'dockerfile' and 'tags' options in the BuildInfo structure. It will return a [BuildResponse](#BuildResponse) structure
+# that contains the build logs and resulting image ID.
+method BuildImage(build: BuildInfo) -> (image: BuildResponse)
 
 # This function is not implemented yet.
 method CreateImage() -> (notimplemented: NotImplemented)


### PR DESCRIPTION
the varlink build was not working as designed and required some touch-ups:

* return a struct that includes logs and the new image ID
* pass namespaceoption so that networking in buildah works

Signed-off-by: baude <bbaude@redhat.com>