### PR TITLE
Propegate exit code on Exec calls

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime/pprof"
+	"syscall"
 
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/pkg/errors"
@@ -175,6 +177,12 @@ func main() {
 		if debug {
 			logrus.Errorf(err.Error())
 		} else {
+			// Retrieve the exit error from the exec call, if it exists
+			if ee, ok := err.(*exec.ExitError); ok {
+				if status, ok := ee.Sys().(syscall.WaitStatus); ok {
+					exitCode = status.ExitStatus()
+				}
+			}
 			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	} else {

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -86,5 +86,14 @@ var _ = Describe("Podman exec", func() {
 		os.Unsetenv("FOO")
 
 	})
+	It("podman exec exit code", func() {
+		setup := podmanTest.RunTopContainer("test1")
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"exec", "test1", "sh", "-c", "exit 100"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(100))
+	})
 
 })


### PR DESCRIPTION
Signed-off-by: haircommander <pehunt@redhat.com>

Fixes: #402 

Returns Error code from a failed exec call to users terminal for debugging