### PR TITLE
Add pointers for Integration Tests to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+![PODMAN logo](logo/podman-logo-source.svg)
 # Contributing to Libpod
 
 We'd love to have you join the community! Below summarizes the processes
@@ -109,6 +110,17 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
+
+### Integration Tests
+
+Our primary means of performing integration testing for libpod is with the
+[Ginkgo](https://github.com/onsi/ginkgo) BDD testing framework. This allows
+us to use native Golang to perform our tests and there is a strong affiliation
+between Ginkgo and the Go test framework.  Adequate test cases are expected to
+be provided with PRs.
+
+For details on how to run the tests for Podman in your test environment, see the
+Integration Tests [README.md](test/README.md).
 
 ## Communications
 

--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -163,7 +163,11 @@ To remove the httpd container:
 $ sudo podman rm --latest
 ```
 You can verify the deletion of the container by running *podman ps -a*.
+
+## Integration Tests
+For more information on how to setup and run the integration tests in your environment, checkout the Integration Tests [README.md](../../test/README.md)
+
 ## More information
 
-For more information on Podman and its subcommands, checkout the asciiart demos on the [README](https://github.com/projectatomic/libpod#commands)
+For more information on Podman and its subcommands, checkout the asciiart demos on the [README.md](../../README.md#commands)
 page.

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,5 @@
-# Integration testing
+![PODMAN logo](../logo/podman-logo-source.svg)
+# Integration Tests
 
 Our primary means of performing integration testing for libpod is with the
 [Ginkgo](https://github.com/onsi/ginkgo) BDD testing framework. This allows


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

MOAR SELKIES!  Plus I've made the Integration Test README more visible adding pointers to it in  a few places and changed pointers to some links to relative pointers versus a fully qualified url.