### PR TITLE
Add disable-content-trust flag info to man page for build

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -131,6 +131,12 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--disable-content-trust**
+
+This is a Docker specific option to disable image verification to a Docker 
+registry and is not supported by Buildah.  This flag is a NOOP and provided
+soley for scripting compatibility.
+
 **--file, -f** *Dockerfile*
 
 Specifies a Dockerfile which contains instructions for building the image,


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

The disable-content-trust flag to build as it's just been added to `buildah bud`.