### PR TITLE
Returning joining namespace error should not be fatal

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -461,10 +461,12 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 
 			// Open the new network namespace
 			ns, err := joinNetNS(netNSPath)
-			if err != nil {
-				return errors.Wrapf(err, "error joining network namespace for container %s", ctr.ID())
+			if err == nil {
+				newState.NetNS = ns
+			} else {
+				logrus.Errorf("error joining network namespace for container %s", ctr.ID())
+				ctr.valid = false
 			}
-			newState.NetNS = ns
 		}
 	} else {
 		// The container no longer has a network namespace

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -165,9 +165,11 @@ func (r *Runtime) RemoveContainer(ctx context.Context, c *Container, force bool)
 // Locks the container, but does not lock the runtime
 func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool) error {
 	if !c.valid {
-		// Container probably already removed
-		// Or was never in the runtime to begin with
-		return nil
+		if ok, _ := r.HasContainer(c.ID()); !ok {
+			// Container probably already removed
+			// Or was never in the runtime to begin with
+			return nil
+		}
 	}
 
 	// We need to lock the pod before we lock the container


### PR DESCRIPTION
I got my database state in a bad way by killing a hanging container.

It did not setup the network namespace correctly

listing/remove bad containers becomes impossible.

podman run alpine/nginx
^c
got me in this state.

I got into a state in the database where
podman ps -a
was returning errors and I could not get out of it,  Makeing joining the network
namespace a non fatal error fixes the issue.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>