### PR TITLE
 Test to make sure we are getting proper exit codes on podman run

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -465,4 +465,15 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(125))
 	})
 
+	It("podman run exit code on failure to exec", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "/etc"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(126))
+	})
+
+	It("podman run error on exec", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "sh", "-c", "exit 100"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(100))
+	})
 })


### PR DESCRIPTION
podman run command screws up we should get 125
podman run command succeeds but command in container fails to exec 126
podman run command succeeds but command exits with non 0 exit code

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>