### PR TITLE
podman search --tls-verify option

### DIFF
--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -1,19 +1,22 @@
 package main
 
 import (
-	"context"
-	"reflect"
-	"strconv"
-	"strings"
+	"fmt"
 
+	"context"
 	"github.com/containers/image/docker"
+	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/formats"
 	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
 	"github.com/projectatomic/libpod/libpod/common"
 	sysreg "github.com/projectatomic/libpod/pkg/registries"
+	"github.com/projectatomic/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 const (
@@ -23,6 +26,18 @@ const (
 
 var (
 	searchFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
+		cli.StringFlag{
+			Name:  "cert-dir",
+			Usage: "`pathname` of a directory containing TLS certificates and keys",
+		},
+		cli.StringFlag{
+			Name:  "creds",
+			Usage: "`credentials` (USERNAME:PASSWORD) to use for authenticating to a registry",
+		},
 		cli.StringSliceFlag{
 			Name:  "filter, f",
 			Usage: "filter output based on conditions provided (default [])",
@@ -42,6 +57,14 @@ var (
 		cli.StringSliceFlag{
 			Name:  "registry",
 			Usage: "specific registry to search",
+		},
+		cli.StringFlag{
+			Name:  "signature-policy",
+			Usage: "`pathname` of signature policy file (not usually used)",
+		},
+		cli.BoolTFlag{
+			Name:  "tls-verify",
+			Usage: "require HTTPS and verify certificates when contacting registries (default: true)",
 		},
 	}
 	searchDescription = `
@@ -106,15 +129,9 @@ func searchCmd(c *cli.Context) error {
 		limit:   c.Int("limit"),
 		filter:  c.StringSlice("filter"),
 	}
-
-	var registries []string
-	if len(c.StringSlice("registry")) > 0 {
-		registries = c.StringSlice("registry")
-	} else {
-		registries, err = sysreg.GetRegistries()
-		if err != nil {
-			return errors.Wrapf(err, "error getting registries to search")
-		}
+	registries, sc, err := getSystemContextAndRegistries(c)
+	if err != nil {
+		return err
 	}
 
 	filter, err := parseSearchFilter(&opts)
@@ -122,7 +139,7 @@ func searchCmd(c *cli.Context) error {
 		return err
 	}
 
-	return generateSearchOutput(term, registries, opts, *filter)
+	return generateSearchOutput(term, registries, opts, *filter, sc)
 }
 
 func genSearchFormat(format string) string {
@@ -153,8 +170,63 @@ func (s *searchParams) headerMap() map[string]string {
 	return values
 }
 
-func getSearchOutput(term string, registries []string, opts searchOpts, filter searchFilterParams) ([]searchParams, error) {
-	sc := common.GetSystemContext("", "", false)
+// A wrapper for GetSystemContext and GetInsecureRegistries
+// Sets up system context and active list of registries to search with
+func getSystemContextAndRegistries(c *cli.Context) ([]string, *types.SystemContext, error) {
+	sc := common.GetSystemContext(c.String("signature-policy"), "", false)
+	sc.DockerCertPath = c.String("cert-dir")
+
+	if c.IsSet("creds") {
+		creds, err := util.ParseRegistryCreds(c.String("creds"))
+		if err != nil {
+			return nil, nil, err
+		}
+		sc.DockerAuthConfig = creds
+	}
+
+	// Variables for setting up Registry and TLSVerify
+	tlsVerify := c.BoolT("tls-verify")
+	regFlagged := len(c.StringSlice("registry")) > 0
+	forceSecure := false
+
+	if c.IsSet("tls-verify") {
+		forceSecure = c.Bool("tls-verify")
+	}
+
+	var registries []string
+	if regFlagged {
+		registries = c.StringSlice("registry")
+	} else {
+		var err error
+		registries, err = sysreg.GetRegistries()
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "error getting registries to search")
+		}
+	}
+
+	// If user flagged to skip verify for HTTP connections, set System Context as such
+	if !tlsVerify {
+		// If tls-verify is set to false, allow insecure always.
+		sc.DockerInsecureSkipTLSVerify = true
+	} else if !forceSecure {
+		// if the user didn't allow nor disallow insecure registries, check to see if the registry is insecure
+		insecureRegistries, err := sysreg.GetInsecureRegistries()
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "error getting insecure registries to search")
+		}
+
+		if regFlagged && util.StringInSlice(registries[0], insecureRegistries) {
+			sc.DockerInsecureSkipTLSVerify = true
+			logrus.Info(fmt.Sprintf("%s is an insecure registry; pushing with tls-verify=false", registries[0]))
+		} else if !regFlagged {
+			sc.DockerInsecureSkipTLSVerify = true
+			registries = append(registries, insecureRegistries...)
+		}
+	}
+	return registries, sc, nil
+}
+
+func getSearchOutput(term string, registries []string, opts searchOpts, filter searchFilterParams, sc *types.SystemContext) ([]searchParams, error) {
 	// Max number of queries by default is 25
 	limit := maxQueries
 	if opts.limit != 0 {
@@ -222,8 +294,8 @@ func getSearchOutput(term string, registries []string, opts searchOpts, filter s
 	return paramsArr, nil
 }
 
-func generateSearchOutput(term string, registries []string, opts searchOpts, filter searchFilterParams) error {
-	searchOutput, err := getSearchOutput(term, registries, opts, filter)
+func generateSearchOutput(term string, registries []string, opts searchOpts, filter searchFilterParams, sc *types.SystemContext) error {
+	searchOutput, err := getSearchOutput(term, registries, opts, filter, sc)
 	if err != nil {
 		return err
 	}

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -29,6 +29,23 @@ using the **--filter** flag.
 
 ## OPTIONS
 
+**--authfile**
+
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+**--creds="CREDENTIALS"**
+
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
+
+**cert-dir="PATHNAME"**
+
+Pathname of a directory containing TLS certificates and keys.
+Default certificates directory is _/etc/containers/certs.d_.
+
+
 **--filter, -f**
 Filter output based on conditions provided (default [])
 
@@ -63,6 +80,12 @@ Do not truncate the output
 
 **--registry**
 Specific registry to search (only the given registry will be searched, not the default registries)
+
+**--signature-policy="PATHNAME"**
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred
 
 ## EXAMPLES
 

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -2,7 +2,9 @@ package integration
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,6 +23,7 @@ var _ = Describe("Podman search", func() {
 			os.Exit(1)
 		}
 		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
 	})
 
 	AfterEach(func() {
@@ -95,5 +98,96 @@ var _ = Describe("Podman search", func() {
 		for i := 0; i < len(output); i++ {
 			Expect(output[i]).To(Equal(""))
 		}
+	})
+
+	It("podman search attempts HTTP if tls-verify flag is set false", func() {
+		fakereg := podmanTest.Podman([]string{"run", "-d", "-p", "5000:5000", "--name", "registry", "registry:2"})
+		fakereg.WaitWithDefaultTimeout()
+		Expect(fakereg.ExitCode()).To(Equal(0))
+
+		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "fake/image:andtag", "--tls-verify=false"})
+		search.WaitWithDefaultTimeout()
+
+		// if this test succeeded, there will be no output (there is no entry named fake/image:andtag in an empty registry)
+		// and the exit code will be 0
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(search.OutputToString()).Should(BeEmpty())
+
+	})
+
+	It("podman search in local registry", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", "docker.io/library/registry:2", "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		if !WaitContainerReady(&podmanTest, "registry", "listening on", 20, 1) {
+			Skip("Can not start docker registry.")
+		}
+
+		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+		push.WaitWithDefaultTimeout()
+		Expect(push.ExitCode()).To(Equal(0))
+		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "my-alpine", "--tls-verify=false"})
+		search.WaitWithDefaultTimeout()
+
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(search.OutputToString()).ShouldNot(BeEmpty())
+	})
+
+	It("podman search from local registry with authorization", func() {
+		authPath := filepath.Join(podmanTest.TempDir, "auth")
+		os.Mkdir(authPath, os.ModePerm)
+		os.MkdirAll("/etc/containers/certs.d/localhost:5000", os.ModePerm)
+		debug := podmanTest.SystemExec("ls", []string{"-l", podmanTest.TempDir})
+		debug.WaitWithDefaultTimeout()
+
+		cwd, _ := os.Getwd()
+		certPath := filepath.Join(cwd, "../", "certs")
+
+		if IsCommandAvailable("getenforce") {
+			ge := podmanTest.SystemExec("getenforce", []string{})
+			ge.WaitWithDefaultTimeout()
+			if ge.OutputToString() == "Enforcing" {
+				se := podmanTest.SystemExec("setenforce", []string{"0"})
+				se.WaitWithDefaultTimeout()
+
+				defer podmanTest.SystemExec("setenforce", []string{"1"})
+			}
+		}
+
+		session := podmanTest.Podman([]string{"run", "--entrypoint", "htpasswd", "registry:2", "-Bbn", "podmantest", "test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		f, _ := os.Create(filepath.Join(authPath, "htpasswd"))
+		defer f.Close()
+
+		f.WriteString(session.OutputToString())
+		f.Sync()
+		debug = podmanTest.SystemExec("cat", []string{filepath.Join(authPath, "htpasswd")})
+		debug.WaitWithDefaultTimeout()
+
+		session = podmanTest.Podman([]string{"run", "-d", "-p", "5000:5000", "--name", "registry", "-v",
+			strings.Join([]string{authPath, "/auth"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
+			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
+			"-v", strings.Join([]string{certPath, "/certs"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
+			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", "registry:2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		if !WaitContainerReady(&podmanTest, "registry", "listening on", 20, 1) {
+			Skip("Can not start docker registry.")
+		}
+
+		session = podmanTest.Podman([]string{"logs", "registry"})
+		session.WaitWithDefaultTimeout()
+
+		push := podmanTest.Podman([]string{"push", "--creds=podmantest:test", "--tls-verify=false", ALPINE, "localhost:5000/tlstest"})
+		push.WaitWithDefaultTimeout()
+		Expect(push.ExitCode()).To(Equal(0))
+
+		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "tlstest", "--creds=podmantest:test", "--tls-verify=false"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
 	})
 })


### PR DESCRIPTION
added option to patch #914 

Podman search doesn't respect registry.insecure , but I wasn't sure how to test that, so I chose the flag option instead. Test included.