### PR TITLE
hack/release.sh: Add a guard against -dev suffixes for argv[2]

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -12,6 +12,15 @@
 
 VERSION="$1"
 NEXT_VERSION="$2"
+
+if test "${NEXT_VERSION}" != "${NEXT_VERSION%-dev}"
+then
+	echo "The next-version argument '${NEXT_VERSION}' should not end in '-dev'." >&2
+	echo "This script will add the -dev suffix as needed internally.  Try:" >&2
+	echo "  $0 ${VERSION} ${NEXT_VERSION%-dev}" >&2
+	exit 1
+fi
+
 DATE=$(date '+%Y-%m-%d')
 LAST_TAG=$(git describe --tags --abbrev=0)
 


### PR DESCRIPTION
Because it's easier to recover from that if we fail early instead of going through and creating a "Bump to v1.2.3-dev-dev" commit, etc.

cc @rhatdan.