### PR TITLE
Touchups for registries.conf across a few man pages

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -416,10 +416,10 @@ podman build --volume /home/test:/myvol:ro,Z -t imageName .
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), buildah(1)
+podman(1), buildah(1), registries.conf(5)
 
 ## HISTORY
 

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -10,7 +10,7 @@ podman\-info - Display system information
 
 ## DESCRIPTION
 
-Displays information pertinent to the host, current storage stats, configured registries, and build of podman.
+Displays information pertinent to the host, current storage stats, configured container registries, and build of podman.
 
 
 ## OPTIONS
@@ -93,4 +93,4 @@ map[registries:[docker.io registry.fedoraproject.org registry.access.redhat.com]
 ```
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1), registries.conf(5), storage.conf(5), crio(8)

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -136,9 +136,14 @@ Writing manifest to image destination
 Storing signatures
 03290064078cb797f3e0a530e78c20c13dd22a3dd3adf84a5da2127b48df0438
 ```
+## FILES
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), podman-push(1), podman-login(1), crio(8)
+podman(1), podman-push(1), podman-login(1), registries.conf(5), crio(8)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -105,9 +105,14 @@ INDEX               NAME
 fedoraproject.org   fedoraproject.org/fedora
 fedoraproject.org   fedoraproject.org/fedora-minimal
 ```
+## FILES
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1), registries.conf(5), crio(8)
 
 ## HISTORY
 January 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -132,10 +132,10 @@ has the capability to debug pods/images created by crio.
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-	registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-`oci-hooks(5)`, `storage.conf(5)`, `crio(8)`
+`oci-hooks(5)`, `registries.conf(5)`, `storage.conf(5)`, `crio(8)`
 
 ## HISTORY
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds registries.conf link/info to a number of podman pages. This along with a change in container/images (https://github.com/containers/image/pull/465) should complete #789