### PR TITLE
Add --volumes-from flag to podman run and create

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -302,6 +302,10 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		return nil, err
 	}
 
+	if err = parseVolumesFrom(c.StringSlice("volumes-from")); err != nil {
+		return nil, err
+	}
+
 	tty := c.Bool("tty")
 
 	pidMode := container.PidMode(c.String("pid"))
@@ -596,6 +600,7 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		Volumes:     c.StringSlice("volume"),
 		WorkDir:     workDir,
 		Rootfs:      rootfs,
+		VolumesFrom: c.StringSlice("volumes-from"),
 	}
 
 	if !config.Privileged {

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -654,6 +654,40 @@ change propagation properties of source mount. Say `/` is source mount for
 To disable automatic copying of data from the container path to the volume, use
 the `nocopy` flag. The `nocopy` flag can be set on bind mounts and named volumes.
 
+**--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
+
+Mount volumes from the specified container(s).
+*OPTIONS* is a comma delimited list with the following available elements:
+
+* [rw|ro]
+* z
+
+Mounts already mounted volumes from a source container onto another
+container. You must supply the source's container-id or container-name.
+To share a volume, use the --volumes-from option when running
+the target container. You can share volumes even if the source container
+is not running.
+
+By default, podman mounts the volumes in the same mode (read-write or
+read-only) as it is mounted in the source container. Optionally, you
+can change this by suffixing the container-id with either the `ro` or
+`rw` keyword.
+
+Labeling systems like SELinux require that proper labels are placed on volume
+content mounted into a container. Without a label, the security system might
+prevent the processes running inside the container from using the content. By
+default, podman does not change the labels set by the OS.
+
+To change a label in the container context, you can add `z` to the volume mount.
+This suffix tells podman to relabel file objects on the shared volumes. The `z`
+option tells podman that two containers share the volume content. As a result,
+podman labels the content with a shared content label. Shared volume labels allow
+all containers to read/write content.
+
+If the location of the volume from the source container overlaps with
+data residing on a target container, then the volume hides
+that data on the target.
+
 **-w**, **--workdir**=""
 
 Working directory inside the container

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -686,6 +686,40 @@ change propagation properties of source mount. Say `/` is source mount for
 To disable automatic copying of data from the container path to the volume, use
 the `nocopy` flag. The `nocopy` flag can be set on bind mounts and named volumes.
 
+**--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
+
+Mount volumes from the specified container(s).
+*OPTIONS* is a comma delimited list with the following available elements:
+
+* [rw|ro]
+* z
+
+Mounts already mounted volumes from a source container onto another
+container. You must supply the source's container-id or container-name.
+To share a volume, use the --volumes-from option when running
+the target container. You can share volumes even if the source container
+is not running.
+
+By default, podman mounts the volumes in the same mode (read-write or
+read-only) as it is mounted in the source container. Optionally, you
+can change this by suffixing the container-id with either the `ro` or
+`rw` keyword.
+
+Labeling systems like SELinux require that proper labels are placed on volume
+content mounted into a container. Without a label, the security system might
+prevent the processes running inside the container from using the content. By
+default, podman does not change the labels set by the OS.
+
+To change a label in the container context, you can add `z` to the volume mount.
+This suffix tells podman to relabel file objects on the shared volumes. The `z`
+option tells podman that two containers share the volume content. As a result,
+podman labels the content with a shared content label. Shared volume labels allow
+all containers to read/write content.
+
+If the location of the volume from the source container overlaps with
+data residing on a target container, then the volume hides
+that data on the target.
+
 **-w**, **--workdir**=""
 
 Working directory inside the container

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -313,6 +313,9 @@ type ContainerConfig struct {
 	// ExitCommand is the container's exit command.
 	// This Command will be executed when the container exits
 	ExitCommand []string `json:"exitCommand,omitempty"`
+	// LocalVolumes are the built-in volumes we get from the --volumes-from flag
+	// It picks up the built-in volumes of the container used by --volumes-from
+	LocalVolumes []string
 }
 
 // ContainerStatus returns a string representation for users

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -127,7 +127,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 
 	// Bind builtin image volumes
 	if c.config.Rootfs == "" && c.config.ImageVolumes {
-		if err := c.addImageVolumes(ctx, &g); err != nil {
+		if err := c.addLocalVolumes(ctx, &g); err != nil {
 			return nil, errors.Wrapf(err, "error mounting image volumes")
 		}
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -885,6 +885,24 @@ func WithUserVolumes(volumes []string) CtrCreateOption {
 	}
 }
 
+// WithLocalVolumes sets the built-in volumes of the container retrieved
+// from a container passed in to the --volumes-from flag.
+// This stores the built-in volume information in the ContainerConfig so we can
+// add them when creating the container.
+func WithLocalVolumes(volumes []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+
+		if volumes != nil {
+			ctr.config.LocalVolumes = append(ctr.config.LocalVolumes, volumes...)
+		}
+
+		return nil
+	}
+}
+
 // WithEntrypoint sets the entrypoint of the container.
 // This is not used to change the container's spec, but will instead be used
 // during commit to populate the entrypoint of the new image.

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -248,6 +248,9 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 	}
 
 	// BIND MOUNTS
+	if err := config.GetVolumesFrom(); err != nil {
+		return nil, errors.Wrap(err, "error getting volume mounts from --volumes-from flag")
+	}
 	mounts, err := config.GetVolumeMounts(configSpec.Mounts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting volume mounts")


### PR DESCRIPTION
podman now supports --volumes-from flag, which allows users
to add all the volumes an existing container has to a new one.

Fixes https://github.com/projectatomic/libpod/issues/541

Signed-off-by: umohnani8 <umohnani@redhat.com>