### PR TITLE
Added --sort to ps

### DIFF
--- a/cmd/podman/batchcontainer/container.go
+++ b/cmd/podman/batchcontainer/container.go
@@ -27,6 +27,7 @@ type PsOptions struct {
 	NoTrunc   bool
 	Quiet     bool
 	Size      bool
+	Sort      string
 	Label     string
 	Namespace bool
 }

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -53,9 +53,9 @@ type imagesSorted []imagesTemplateParams
 func (a imagesSorted) Len() int      { return len(a) }
 func (a imagesSorted) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
-type imagesSortedTime struct{ imagesSorted }
+type imagesSortedCreated struct{ imagesSorted }
 
-func (a imagesSortedTime) Less(i, j int) bool {
+func (a imagesSortedCreated) Less(i, j int) bool {
 	return a.imagesSorted[i].CreatedTime.After(a.imagesSorted[j].CreatedTime)
 }
 
@@ -113,8 +113,8 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "sort",
-			Usage: "Sort by size, time, id, repository or tag",
-			Value: "time",
+			Usage: "Sort by created, id, repository, size, or tag",
+			Value: "created",
 		},
 	}
 
@@ -252,8 +252,8 @@ func sortImagesOutput(sortBy string, imagesOutput imagesSorted) imagesSorted {
 	case "repository":
 		sort.Sort(imagesSortedRepository{imagesOutput})
 	default:
-		// default is time
-		sort.Sort(imagesSortedTime{imagesOutput})
+		// default is created time
+		sort.Sort(imagesSortedCreated{imagesOutput})
 	}
 	return imagesOutput
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1846,6 +1846,7 @@ _podman_ps() {
      --filter -f
      --format
      --last -n
+     --sort
      "
      local boolean_options="
      --all -a

--- a/docs/podman-images.1.md
+++ b/docs/podman-images.1.md
@@ -42,7 +42,7 @@ Lists only the image IDs.
 
 **--sort**
 
-Sort by id, repository, size, tag or time (default: time)
+Sort by created, id, repository, size or tag (default: created)
 
 ## EXAMPLE
 

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -63,6 +63,11 @@ Valid placeholders for the Go template are listed below:
 | .Labels         | All the labels assigned to the container         |
 | .Mounts         | Volumes mounted in the container                 |
 
+**--sort**
+
+Sort by command, created, id, image, names, runningfor, size, or status",
+Note: Choosing size will sort by size of rootFs, not alphabetically like the rest of the options
+Default: created
 
 **--size, -s**
 
@@ -128,6 +133,12 @@ CONTAINER ID    NAMES                                                           
 a31ebbee9cee7   k8s_podsandbox1-redis_podsandbox1_redhat.test.crio_redhat-test-crio_0   29717   4026531835   4026532585   4026532587   4026532508   4026532589   4026531837   4026532588
 ```
 
+```
+sudo podman ps -a --size --sort names
+CONTAINER ID   IMAGE         COMMAND         CREATED       STATUS                    PORTS     NAMES
+69ed779d8ef9f  redis:alpine  "redis-server"  25 hours ago  Created                   6379/tcp  k8s_container1_podsandbox1_redhat.test.crio_redhat-test-crio_1
+02f65160e14ca  redis:alpine  "redis-server"  19 hours ago  Exited (-1) 19 hours ago  6379/tcp  k8s_podsandbox1-redis_podsandbox1_redhat.test.crio_redhat-test-crio_0
+```
 ## ps
 Print a list of containers
 


### PR DESCRIPTION
Also podman ps now allows user to only output size of root FS, and changed language of images and ps --sort to be sorted by "created" as opposed to "time".

Finishes fix: #898 

Signed-off-by: haircommander <pehunt@redhat.com>