### PR TITLE
Fix cleanup of network namespaces for detached containers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -655,7 +655,7 @@ func (c *Container) stop(timeout uint) error {
 		return err
 	}
 
-	return c.cleanupStorage()
+	return c.cleanup()
 }
 
 // mountStorage sets up the container's root filesystem


### PR DESCRIPTION
The containernetworking/plugins ns package does not support unmounting and removing namespaces that were opened by another process. Work around this by doing it ourselves.

Closes: #858