### PR TITLE
TLS is skipped per registry.

### DIFF
--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -73,8 +73,9 @@ Specific registry to search (only the given registry will be searched, not the d
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
-then tls verification will be used, If set to false then tls verification will not be used. If not specified
-both insecured and default registries will be searched through, and tls will be used when possible.
+then tls verification will be used. If set to false then tls verification will not be used if needed. If not specified
+default registries will be searched through (in /etc/containers/registries.conf), and tls will be skipped if a default
+registry is listed in the insecure registries.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Prior, TLS verify was skipped for all registries, if any of the searchable registries were listed as insecure, and the user didn't specify to force a secure connection.

TLS verify is now set on a finer grain, based on whether the registry being searched is in the listed insecure registries in /etc/containers/registries.conf

Patches: #932 

Signed-off-by: haircommander <pehunt@redhat.com>
