### PR TITLE
hack/ostree_tag.sh: Fill in OSTree dependencies

### DIFF
--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-if ! pkg-config ostree-1 2> /dev/null ; then
+if ! pkg-config glib-2.0 gobject-2.0 ostree-1 libselinux 2> /dev/null ; then
 	echo containers_image_ostree_stub
 fi


### PR DESCRIPTION
Copying the libraries from:

```console
$ git grep pkg-config vendor/github.com/containers/image/
vendor/github.com/containers/image/ostree/ostree_dest.go:// #cgo pkg-config: glib-2.0 gobject-2.0 ostree-1 libselinux
vendor/github.com/containers/image/ostree/ostree_src.go:// #cgo pkg-config: glib-2.0 gobject-2.0 ostree-1
```

We need all of those to compile the vendored Go dependency, not just `ostree-1`.