### PR TITLE
Add extra debug so we can tell apart postdelete hooks

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -913,7 +913,7 @@ func (c *Container) postDeleteHooks(ctx context.Context) (err error) {
 				return err
 			}
 			for i, hook := range extensionHooks {
-				logrus.Debugf("container %s: invoke poststop hook %d", c.ID(), i)
+				logrus.Debugf("container %s: invoke poststop hook %d, path %s", c.ID(), i, hook.Path)
 				var stderr, stdout bytes.Buffer
 				hookErr, err := exec.Run(ctx, &hook, state, &stdout, &stderr, exec.DefaultPostKillTimeout)
 				if err != nil {


### PR DESCRIPTION
Trivial patch to add some debug so we can tell which postdelete hooks are throwing errors.