### PR TITLE
Errors from closing a netns on removal from DB are nonfatal

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // BoltState is a state implementation backed by a Bolt DB
@@ -455,7 +456,7 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 		} else {
 			// Tear down the existing namespace
 			if err := s.runtime.teardownNetNS(ctr); err != nil {
-				return err
+				logrus.Warnf(err.Error())
 			}
 
 			// Open the new network namespace
@@ -469,7 +470,7 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 		// The container no longer has a network namespace
 		// Tear down the old one
 		if err := s.runtime.teardownNetNS(ctr); err != nil {
-			return err
+			logrus.Warnf(err.Error())
 		}
 	}
 


### PR DESCRIPTION
Upon updating a container, if its network namespace has been removed, we attempt to clean up the network namespace locally, to ensure we don't leave hanging file descriptors. This triggers
cleanup code which assumes the network namespace still exists, but it almost certainly was removed by whoever removed it from the database. As such, we end up with unavoidable errors if we
don't want to leak FDs. Make these errors nonfatal and log them because of this.

Closes #959 