### PR TITLE
Add cap-add and cap-drop to build man page

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -859,7 +859,8 @@ _podman_build() {
      --annotation
      --authfile
      --build-arg
-     --cert-dir
+     --cap-add
+     --cap-drop
      --cgroup-parent
      --cni-config-dir
      --cni-plugin-path

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -47,6 +47,26 @@ resulting image's configuration.
 
 Images to utilize as potential cache sources. Podman does not currently support caching so this is a NOOP.
 
+**--cap-add**=*CAP\_xxx*
+
+When executing RUN instructions, run the command specified in the instruction
+with the specified capability added to its capability set.
+Certain capabilities are granted by default; this option can be used to add
+more.
+
+**--cap-drop**=*CAP\_xxx*
+
+When executing RUN instructions, run the command specified in the instruction
+with the specified capability removed from its capability set.
+The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
+granted by default; this option can be used to remove them.
+
+If a capability is specified to both the **--cap-add** and **--cap-drop**
+options, it will be dropped, regardless of the order in which the options were
+given.
+
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
@@ -360,9 +380,17 @@ Directly specifies a UID mapping which should be used to set ownership, at the
 filesytem level, on the working container's contents.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
+
 Entries in this map take the form of one or more triples of a starting
 in-container UID, a corresponding starting host-level UID, and the number of
 consecutive IDs which the map entry represents.
+
+This option overrides the *remap-uids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-uid-map setting is
+supplied, settings from the global option will be used.
+
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
 are specified, but --userns-gid-map is specified, the UID map will be set to
 use the same numeric values as the GID map.
@@ -373,9 +401,17 @@ Directly specifies a GID mapping which should be used to set ownership, at the
 filesytem level, on the working container's contents.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
+
 Entries in this map take the form of one or more triples of a starting
 in-container GID, a corresponding starting host-level GID, and the number of
 consecutive IDs which the map entry represents.
+
+This option overrides the *remap-gids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-gid-map setting is
+supplied, settings from the global option will be used.
+
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
 are specified, but --userns-uid-map is specified, the GID map will be set to
 use the same numeric values as the UID map.

--- a/vendor.conf
+++ b/vendor.conf
@@ -88,7 +88,7 @@ k8s.io/kube-openapi 275e2ce91dec4c05a4094a7b1daee5560b555ac9 https://github.com/
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kubernetes/utils
 github.com/mrunalp/fileutils master
 github.com/varlink/go master
-github.com/projectatomic/buildah fc438bb932e891cbe04109cfae1dfbe3c99307a5
+github.com/projectatomic/buildah 2441ff4f9f6a5e635f85c177892f096a46503d6f
 github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master

--- a/vendor/github.com/projectatomic/buildah/add.go
+++ b/vendor/github.com/projectatomic/buildah/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
 	"github.com/projectatomic/libpod/pkg/chrootuser"
 	"github.com/sirupsen/logrus"
 )
@@ -98,7 +99,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		return err
 	}
 	containerOwner := idtools.IDPair{UID: int(user.UID), GID: int(user.GID)}
-	hostUID, hostGID, err := getHostIDs(b.IDMappingOptions.UIDMap, b.IDMappingOptions.GIDMap, user.UID, user.GID)
+	hostUID, hostGID, err := util.GetHostIDs(b.IDMappingOptions.UIDMap, b.IDMappingOptions.GIDMap, user.UID, user.GID)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/projectatomic/buildah/bind/mount.go
+++ b/vendor/github.com/projectatomic/buildah/bind/mount.go
@@ -1,0 +1,294 @@
+// +build linux
+
+package bind
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// SetupIntermediateMountNamespace creates a new mount namespace and bind
+// mounts all bind-mount sources into a subdirectory of bundlePath that can
+// only be reached by the root user of the container's user namespace, except
+// for Mounts which include the NoBindOption option in their options list.  The
+// NoBindOption will then merely be removed.
+func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmountAll func() error, err error) {
+	defer stripNoBindOption(spec)
+
+	// We expect a root directory to be defined.
+	if spec.Root == nil {
+		return nil, errors.Errorf("configuration has no root filesystem?")
+	}
+	rootPath := spec.Root.Path
+
+	// Create a new mount namespace in which to do the things we're doing.
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		return nil, errors.Wrapf(err, "error creating new mount namespace for %v", spec.Process.Args)
+	}
+
+	// Make all of our mounts private to our namespace.
+	if err := mount.MakeRPrivate("/"); err != nil {
+		return nil, errors.Wrapf(err, "error making mounts private to mount namespace for %v", spec.Process.Args)
+	}
+
+	// Make sure the bundle directory is searchable.  We created it with
+	// TempDir(), so it should have started with permissions set to 0700.
+	info, err := os.Stat(bundlePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error checking permissions on %q", bundlePath)
+	}
+	if err = os.Chmod(bundlePath, info.Mode()|0111); err != nil {
+		return nil, errors.Wrapf(err, "error loosening permissions on %q", bundlePath)
+	}
+
+	// Figure out who needs to be able to reach these bind mounts in order
+	// for the container to be started.
+	rootUID, rootGID, err := util.GetHostRootIDs(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hand back a callback that the caller can use to clean up everything
+	// we're doing here.
+	unmount := []string{}
+	unmountAll = func() (err error) {
+		for _, mountpoint := range unmount {
+			// Unmount it and anything under it.
+			if err2 := UnmountMountpoints(mountpoint, nil); err2 != nil {
+				logrus.Warnf("pkg/bind: error unmounting %q: %v", mountpoint, err2)
+				if err == nil {
+					err = err2
+				}
+			}
+			if err2 := unix.Unmount(mountpoint, unix.MNT_DETACH); err2 != nil {
+				if errno, ok := err2.(syscall.Errno); !ok || errno != syscall.EINVAL {
+					logrus.Warnf("pkg/bind: error detaching %q: %v", mountpoint, err2)
+					if err == nil {
+						err = err2
+					}
+				}
+			}
+			// Remove just the mountpoint.
+			retry := 10
+			remove := unix.Unlink
+			err2 := remove(mountpoint)
+			for err2 != nil && retry > 0 {
+				if errno, ok := err2.(syscall.Errno); ok {
+					switch errno {
+					default:
+						retry = 0
+						continue
+					case syscall.EISDIR:
+						remove = unix.Rmdir
+						err2 = remove(mountpoint)
+					case syscall.EBUSY:
+						if err3 := unix.Unmount(mountpoint, unix.MNT_DETACH); err3 == nil {
+							err2 = remove(mountpoint)
+						}
+					}
+					retry--
+				}
+			}
+			if err2 != nil {
+				logrus.Warnf("pkg/bind: error removing %q: %v", mountpoint, err2)
+				if err == nil {
+					err = err2
+				}
+			}
+		}
+		return err
+	}
+
+	// Create a top-level directory that the "root" user will be able to
+	// access, that "root" from containers which use different mappings, or
+	// other unprivileged users outside of containers, shouldn't be able to
+	// access.
+	mnt := filepath.Join(bundlePath, "mnt")
+	if err = idtools.MkdirAndChown(mnt, 0100, idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}); err != nil {
+		return unmountAll, errors.Wrapf(err, "error creating %q owned by the container's root user", mnt)
+	}
+
+	// Make that directory private, and add it to the list of locations we
+	// unmount at cleanup time.
+	if err = mount.MakeRPrivate(mnt); err != nil {
+		return unmountAll, errors.Wrapf(err, "error marking filesystem at %q as private", mnt)
+	}
+	unmount = append([]string{mnt}, unmount...)
+
+	// Create a bind mount for the root filesystem and add it to the list.
+	rootfs := filepath.Join(mnt, "rootfs")
+	if err = os.Mkdir(rootfs, 0000); err != nil {
+		return unmountAll, errors.Wrapf(err, "error creating directory %q", rootfs)
+	}
+	if err = unix.Mount(rootPath, rootfs, "", unix.MS_BIND|unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		return unmountAll, errors.Wrapf(err, "error bind mounting root filesystem from %q to %q", rootPath, rootfs)
+	}
+	unmount = append([]string{rootfs}, unmount...)
+	spec.Root.Path = rootfs
+
+	// Do the same for everything we're binding in.
+	mounts := make([]specs.Mount, 0, len(spec.Mounts))
+	for i := range spec.Mounts {
+		// If we're not using an intermediate, leave it in the list.
+		if leaveBindMountAlone(spec.Mounts[i]) {
+			mounts = append(mounts, spec.Mounts[i])
+			continue
+		}
+		// Check if the source is a directory or something else.
+		info, err := os.Stat(spec.Mounts[i].Source)
+		if err != nil {
+			if os.IsNotExist(err) {
+				logrus.Warnf("couldn't find %q on host to bind mount into container", spec.Mounts[i].Source)
+				continue
+			}
+			return unmountAll, errors.Wrapf(err, "error checking if %q is a directory", spec.Mounts[i].Source)
+		}
+		stage := filepath.Join(mnt, fmt.Sprintf("buildah-bind-target-%d", i))
+		if info.IsDir() {
+			// If the source is a directory, make one to use as the
+			// mount target.
+			if err = os.Mkdir(stage, 0000); err != nil {
+				return unmountAll, errors.Wrapf(err, "error creating directory %q", stage)
+			}
+		} else {
+			// If the source is not a directory, create an empty
+			// file to use as the mount target.
+			file, err := os.OpenFile(stage, os.O_WRONLY|os.O_CREATE, 0000)
+			if err != nil {
+				return unmountAll, errors.Wrapf(err, "error creating file %q", stage)
+			}
+			file.Close()
+		}
+		// Bind mount the source from wherever it is to a place where
+		// we know the runtime helper will be able to get to it...
+		if err = unix.Mount(spec.Mounts[i].Source, stage, "", unix.MS_BIND|unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+			return unmountAll, errors.Wrapf(err, "error bind mounting bind object from %q to %q", spec.Mounts[i].Source, stage)
+		}
+		logrus.Debugf("bind mounted %q to %q", spec.Mounts[i].Source, stage)
+		spec.Mounts[i].Source = stage
+		// ... and update the source location that we'll pass to the
+		// runtime to our intermediate location.
+		mounts = append(mounts, spec.Mounts[i])
+		unmount = append([]string{stage}, unmount...)
+	}
+	spec.Mounts = mounts
+
+	return unmountAll, nil
+}
+
+// Decide if the mount should not be redirected to an intermediate location first.
+func leaveBindMountAlone(mount specs.Mount) bool {
+	// If we know we shouldn't do a redirection for this mount, skip it.
+	if util.StringInSlice(NoBindOption, mount.Options) {
+		return true
+	}
+	// If we're not bind mounting it in, we don't need to do anything for it.
+	if mount.Type != "bind" && !util.StringInSlice("bind", mount.Options) && !util.StringInSlice("rbind", mount.Options) {
+		return true
+	}
+	return false
+}
+
+// UnmountMountpoints unmounts the given mountpoints and anything that's hanging
+// off of them, rather aggressively.  If a mountpoint also appears in the
+// mountpointsToRemove slice, the mountpoints are removed after they are
+// unmounted.
+func UnmountMountpoints(mountpoint string, mountpointsToRemove []string) error {
+	mounts, err := mount.GetMounts()
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving list of mounts")
+	}
+	// getChildren returns the list of mount IDs that hang off of the
+	// specified ID.
+	getChildren := func(id int) []int {
+		var list []int
+		for _, info := range mounts {
+			if info.Parent == id {
+				list = append(list, info.ID)
+			}
+		}
+		return list
+	}
+	// getTree returns the list of mount IDs that hang off of the specified
+	// ID, and off of those mount IDs, etc.
+	getTree := func(id int) []int {
+		mounts := []int{id}
+		i := 0
+		for i < len(mounts) {
+			children := getChildren(mounts[i])
+			mounts = append(mounts, children...)
+			i++
+		}
+		return mounts
+	}
+	// getMountByID looks up the mount info with the specified ID
+	getMountByID := func(id int) *mount.Info {
+		for i := range mounts {
+			if mounts[i].ID == id {
+				return mounts[i]
+			}
+		}
+		return nil
+	}
+	// getMountByPoint looks up the mount info with the specified mountpoint
+	getMountByPoint := func(mountpoint string) *mount.Info {
+		for i := range mounts {
+			if mounts[i].Mountpoint == mountpoint {
+				return mounts[i]
+			}
+		}
+		return nil
+	}
+	// find the top of the tree we're unmounting
+	top := getMountByPoint(mountpoint)
+	if top == nil {
+		return errors.Wrapf(err, "%q is not mounted", mountpoint)
+	}
+	// add all of the mounts that are hanging off of it
+	tree := getTree(top.ID)
+	// unmount each mountpoint, working from the end of the list (leaf nodes) to the top
+	for i := range tree {
+		var st unix.Stat_t
+		id := tree[len(tree)-i-1]
+		mount := getMountByID(id)
+		// check if this mountpoint is mounted
+		if err := unix.Lstat(mount.Mountpoint, &st); err != nil {
+			return errors.Wrapf(err, "error checking if %q is mounted", mount.Mountpoint)
+		}
+		if mount.Major != int(unix.Major(st.Dev)) || mount.Minor != int(unix.Minor(st.Dev)) {
+			logrus.Debugf("%q is apparently not really mounted, skipping", mount.Mountpoint)
+			continue
+		}
+		// do the unmount
+		if err := unix.Unmount(mount.Mountpoint, 0); err != nil {
+			// if it was busy, detach it
+			if errno, ok := err.(syscall.Errno); ok && errno == syscall.EBUSY {
+				err = unix.Unmount(mount.Mountpoint, unix.MNT_DETACH)
+			}
+			if err != nil {
+				// if it was invalid (not mounted), hide the error, else return it
+				if errno, ok := err.(syscall.Errno); !ok || errno != syscall.EINVAL {
+					logrus.Warnf("error unmounting %q: %v", mount.Mountpoint, err)
+					continue
+				}
+			}
+		}
+		// if we're also supposed to remove this thing, do that, too
+		if util.StringInSlice(mount.Mountpoint, mountpointsToRemove) {
+			if err := os.Remove(mount.Mountpoint); err != nil {
+				return errors.Wrapf(err, "error removing %q", mount.Mountpoint)
+			}
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/projectatomic/buildah/bind/mount_unsupported.go
+++ b/vendor/github.com/projectatomic/buildah/bind/mount_unsupported.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+package bind
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// SetupIntermediateMountNamespace returns a no-op unmountAll() and no error.
+func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmountAll func() error, err error) {
+	stripNoBuildahBindOption(spec)
+	return func() error { return nil }, nil
+}

--- a/vendor/github.com/projectatomic/buildah/bind/util.go
+++ b/vendor/github.com/projectatomic/buildah/bind/util.go
@@ -1,0 +1,39 @@
+package bind
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/projectatomic/buildah/util"
+)
+
+const (
+	// NoBindOption is an option which, if present in a Mount structure's
+	// options list, will cause SetupIntermediateMountNamespace to not
+	// redirect it through a bind mount.
+	NoBindOption = "nobuildahbind"
+)
+
+func stripNoBindOption(spec *specs.Spec) {
+	for i := range spec.Mounts {
+		if util.StringInSlice(NoBindOption, spec.Mounts[i].Options) {
+			prunedOptions := make([]string, 0, len(spec.Mounts[i].Options))
+			for _, option := range spec.Mounts[i].Options {
+				if option != NoBindOption {
+					prunedOptions = append(prunedOptions, option)
+				}
+			}
+			spec.Mounts[i].Options = prunedOptions
+		}
+	}
+}
+
+func dedupeStringSlice(slice []string) []string {
+	done := make([]string, 0, len(slice))
+	m := make(map[string]struct{})
+	for _, s := range slice {
+		if _, present := m[s]; !present {
+			m[s] = struct{}{}
+			done = append(done, s)
+		}
+	}
+	return done
+}

--- a/vendor/github.com/projectatomic/buildah/buildah.go
+++ b/vendor/github.com/projectatomic/buildah/buildah.go
@@ -163,6 +163,13 @@ type Builder struct {
 	CNIConfigDir string
 	// ID mapping options to use when running processes in the container with non-host user namespaces.
 	IDMappingOptions IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when running
+	// commands in the container.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set,
+	// after processing the AddCapabilities set, when running commands in the container.
+	// If a capability appears in both lists, it will be dropped.
+	DropCapabilities []string
 
 	CommonBuildOpts *CommonBuildOptions
 	// TopLayer is the top layer of the image
@@ -221,7 +228,7 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 
 // CommonBuildOptions are resources that can be defined by flags for both buildah from and build-using-dockerfile
 type CommonBuildOptions struct {
-	// AddHost is the list of hostnames to add to the resolv.conf
+	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
 	AddHost []string
 	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
 	CgroupParent string
@@ -327,6 +334,13 @@ type BuilderOptions struct {
 	CNIConfigDir string
 	// ID mapping options to use if we're setting up our own user namespace.
 	IDMappingOptions *IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when
+	// running commands in the container.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set,
+	// after processing the AddCapabilities set, when running commands in the
+	// container.  If a capability appears in both lists, it will be dropped.
+	DropCapabilities []string
 
 	CommonBuildOpts *CommonBuildOptions
 }

--- a/vendor/github.com/projectatomic/buildah/config.go
+++ b/vendor/github.com/projectatomic/buildah/config.go
@@ -1,218 +1,89 @@
 package buildah
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
-	digest "github.com/opencontainers/go-digest"
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/docker"
 )
 
-// makeOCIv1Image builds the best OCIv1 image structure we can from the
-// contents of the docker image structure.
-func makeOCIv1Image(dimage *docker.V2Image) (ociv1.Image, error) {
-	config := dimage.Config
-	if config == nil {
-		config = &dimage.ContainerConfig
-	}
-	dcreated := dimage.Created.UTC()
-	image := ociv1.Image{
-		Created:      &dcreated,
-		Author:       dimage.Author,
-		Architecture: dimage.Architecture,
-		OS:           dimage.OS,
-		Config: ociv1.ImageConfig{
-			User:         config.User,
-			ExposedPorts: map[string]struct{}{},
-			Env:          config.Env,
-			Entrypoint:   config.Entrypoint,
-			Cmd:          config.Cmd,
-			Volumes:      config.Volumes,
-			WorkingDir:   config.WorkingDir,
-			Labels:       config.Labels,
-			StopSignal:   config.StopSignal,
-		},
-		RootFS: ociv1.RootFS{
-			Type:    "",
-			DiffIDs: []digest.Digest{},
-		},
-		History: []ociv1.History{},
-	}
-	for port, what := range config.ExposedPorts {
-		image.Config.ExposedPorts[string(port)] = what
-	}
-	RootFS := docker.V2S2RootFS{}
-	if dimage.RootFS != nil {
-		RootFS = *dimage.RootFS
-	}
-	if RootFS.Type == docker.TypeLayers {
-		image.RootFS.Type = docker.TypeLayers
-		image.RootFS.DiffIDs = append(image.RootFS.DiffIDs, RootFS.DiffIDs...)
-	}
-	for _, history := range dimage.History {
-		hcreated := history.Created.UTC()
-		ohistory := ociv1.History{
-			Created:    &hcreated,
-			CreatedBy:  history.CreatedBy,
-			Author:     history.Author,
-			Comment:    history.Comment,
-			EmptyLayer: history.EmptyLayer,
-		}
-		image.History = append(image.History, ohistory)
-	}
-	return image, nil
-}
-
-// makeDockerV2S2Image builds the best docker image structure we can from the
-// contents of the OCI image structure.
-func makeDockerV2S2Image(oimage *ociv1.Image) (docker.V2Image, error) {
-	image := docker.V2Image{
-		V1Image: docker.V1Image{Created: oimage.Created.UTC(),
-			Author:       oimage.Author,
-			Architecture: oimage.Architecture,
-			OS:           oimage.OS,
-			ContainerConfig: docker.Config{
-				User:         oimage.Config.User,
-				ExposedPorts: docker.PortSet{},
-				Env:          oimage.Config.Env,
-				Entrypoint:   oimage.Config.Entrypoint,
-				Cmd:          oimage.Config.Cmd,
-				Volumes:      oimage.Config.Volumes,
-				WorkingDir:   oimage.Config.WorkingDir,
-				Labels:       oimage.Config.Labels,
-				StopSignal:   oimage.Config.StopSignal,
-			},
-		},
-		RootFS: &docker.V2S2RootFS{
-			Type:    "",
-			DiffIDs: []digest.Digest{},
-		},
-		History: []docker.V2S2History{},
-	}
-	for port, what := range oimage.Config.ExposedPorts {
-		image.ContainerConfig.ExposedPorts[docker.Port(port)] = what
-	}
-	if oimage.RootFS.Type == docker.TypeLayers {
-		image.RootFS.Type = docker.TypeLayers
-		image.RootFS.DiffIDs = append(image.RootFS.DiffIDs, oimage.RootFS.DiffIDs...)
-	}
-	for _, history := range oimage.History {
-		dhistory := docker.V2S2History{
-			Created:    history.Created.UTC(),
-			CreatedBy:  history.CreatedBy,
-			Author:     history.Author,
-			Comment:    history.Comment,
-			EmptyLayer: history.EmptyLayer,
-		}
-		image.History = append(image.History, dhistory)
-	}
-	image.Config = &image.ContainerConfig
-	return image, nil
-}
-
-// makeDockerV2S1Image builds the best docker image structure we can from the
-// contents of the V2S1 image structure.
-func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
-	// Treat the most recent (first) item in the history as a description of the image.
-	if len(manifest.History) == 0 {
-		return docker.V2Image{}, errors.Errorf("error parsing image configuration from manifest")
-	}
-	dimage := docker.V2Image{}
-	err := json.Unmarshal([]byte(manifest.History[0].V1Compatibility), &dimage)
+// unmarshalConvertedConfig obtains the config blob of img valid for the wantedManifestMIMEType format
+// (either as it exists, or converting the image if necessary), and unmarshals it into dest.
+// NOTE: The MIME type is of the _manifest_, not of the _config_ that is returned.
+func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.Image, wantedManifestMIMEType string) error {
+	_, actualManifestMIMEType, err := img.Manifest(ctx)
 	if err != nil {
-		return docker.V2Image{}, err
+		return errors.Wrapf(err, "error getting manifest MIME type for %q", transports.ImageName(img.Reference()))
 	}
-	if dimage.DockerVersion == "" {
-		return docker.V2Image{}, errors.Errorf("error parsing image configuration from history")
+	if wantedManifestMIMEType != actualManifestMIMEType {
+		img, err = img.UpdatedImage(ctx, types.ManifestUpdateOptions{
+			ManifestMIMEType: wantedManifestMIMEType,
+			InformationOnly: types.ManifestUpdateInformation{ // Strictly speaking, every value in here is invalid. But…
+				Destination:  nil, // Destination is technically required, but actually necessary only for conversion _to_ v2s1.  Leave it nil, we will crash if that ever changes.
+				LayerInfos:   nil, // LayerInfos is necessary for size information in v2s2/OCI manifests, but the code can work with nil, and we are not reading the converted manifest at all.
+				LayerDiffIDs: nil, // LayerDiffIDs are actually embedded in the converted manifest, but the code can work with nil, and the values are not needed until pushing the finished image, at which time containerImageRef.NewImageSource builds the values from scratch.
+			},
+		})
+		if err != nil {
+			return errors.Wrapf(err, "error converting image %q to %s", transports.ImageName(img.Reference()), wantedManifestMIMEType)
+		}
 	}
-	// The DiffID list is intended to contain the sums of _uncompressed_ blobs, and these are most
-	// likely compressed, so leave the list empty to avoid potential confusion later on.  We can
-	// construct a list with the correct values when we prep layers for pushing, so we don't lose.
-	// information by leaving this part undone.
-	rootFS := &docker.V2S2RootFS{
-		Type:    docker.TypeLayers,
-		DiffIDs: []digest.Digest{},
+	config, err := img.ConfigBlob(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "error reading %s config from %q", wantedManifestMIMEType, transports.ImageName(img.Reference()))
 	}
-	// Build a filesystem history.
-	history := []docker.V2S2History{}
-	lastID := ""
-	for i := range manifest.History {
-		// Decode the compatibility field.
-		dcompat := docker.V1Compatibility{}
-		if err = json.Unmarshal([]byte(manifest.History[i].V1Compatibility), &dcompat); err != nil {
-			return docker.V2Image{}, errors.Errorf("error parsing image compatibility data (%q) from history", manifest.History[i].V1Compatibility)
-		}
-		// Skip this history item if it shares the ID of the last one
-		// that we saw, since the image library will do the same.
-		if i > 0 && dcompat.ID == lastID {
-			continue
-		}
-		lastID = dcompat.ID
-		// Construct a new history item using the recovered information.
-		createdBy := ""
-		if len(dcompat.ContainerConfig.Cmd) > 0 {
-			createdBy = strings.Join(dcompat.ContainerConfig.Cmd, " ")
-		}
-		h := docker.V2S2History{
-			Created:    dcompat.Created.UTC(),
-			Author:     dcompat.Author,
-			CreatedBy:  createdBy,
-			Comment:    dcompat.Comment,
-			EmptyLayer: dcompat.ThrowAway,
-		}
-		// Prepend this layer to the list, because a v2s1 format manifest's list is in reverse order
-		// compared to v2s2, which lists earlier layers before later ones.
-		history = append([]docker.V2S2History{h}, history...)
+	if err := json.Unmarshal(config, dest); err != nil {
+		return errors.Wrapf(err, "error parsing %s configuration from %q", wantedManifestMIMEType, transports.ImageName(img.Reference()))
 	}
-	dimage.RootFS = rootFS
-	dimage.History = history
-	return dimage, nil
+	return nil
 }
 
-func (b *Builder) initConfig() {
-	image := ociv1.Image{}
-	dimage := docker.V2Image{}
-	if len(b.Config) > 0 {
-		// Try to parse the image configuration. If we fail start over from scratch.
-		if err := json.Unmarshal(b.Config, &dimage); err == nil && dimage.DockerVersion != "" {
-			if image, err = makeOCIv1Image(&dimage); err != nil {
-				image = ociv1.Image{}
-			}
-		} else {
-			if err := json.Unmarshal(b.Config, &image); err != nil {
-				if dimage, err = makeDockerV2S2Image(&image); err != nil {
-					dimage = docker.V2Image{}
-				}
-			}
+func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
+	if img != nil { // A pre-existing image, as opposed to a "FROM scratch" new one.
+		rawManifest, manifestMIMEType, err := img.Manifest(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "error reading image manifest for %q", transports.ImageName(img.Reference()))
 		}
-		b.OCIv1 = image
-		b.Docker = dimage
-	} else {
-		// Try to dig out the image configuration from the manifest.
-		manifest := docker.V2S1Manifest{}
-		if err := json.Unmarshal(b.Manifest, &manifest); err == nil && manifest.SchemaVersion == 1 {
-			if dimage, err = makeDockerV2S1Image(manifest); err == nil {
-				if image, err = makeOCIv1Image(&dimage); err != nil {
-					image = ociv1.Image{}
-				}
-			}
+		rawConfig, err := img.ConfigBlob(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "error reading image configuration for %q", transports.ImageName(img.Reference()))
 		}
-		b.OCIv1 = image
+		b.Manifest = rawManifest
+		b.Config = rawConfig
+
+		dimage := docker.V2Image{}
+		if err := unmarshalConvertedConfig(ctx, &dimage, img, manifest.DockerV2Schema2MediaType); err != nil {
+			return err
+		}
 		b.Docker = dimage
-	}
-	if len(b.Manifest) > 0 {
-		// Attempt to recover format-specific data from the manifest.
-		v1Manifest := ociv1.Manifest{}
-		if json.Unmarshal(b.Manifest, &v1Manifest) == nil {
+
+		oimage := ociv1.Image{}
+		if err := unmarshalConvertedConfig(ctx, &oimage, img, ociv1.MediaTypeImageManifest); err != nil {
+			return err
+		}
+		b.OCIv1 = oimage
+
+		if manifestMIMEType == ociv1.MediaTypeImageManifest {
+			// Attempt to recover format-specific data from the manifest.
+			v1Manifest := ociv1.Manifest{}
+			if err := json.Unmarshal(b.Manifest, &v1Manifest); err != nil {
+				return errors.Wrapf(err, "error parsing OCI manifest")
+			}
 			b.ImageAnnotations = v1Manifest.Annotations
 		}
 	}
+
 	b.fixupConfig()
+	return nil
 }
 
 func (b *Builder) fixupConfig() {

--- a/vendor/github.com/projectatomic/buildah/imagebuildah/build.go
+++ b/vendor/github.com/projectatomic/buildah/imagebuildah/build.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/docker/builder/dockerfile/parser"
 	docker "github.com/fsouza/go-dockerclient"
@@ -128,6 +127,13 @@ type BuildOptions struct {
 	// ID mapping options to use if we're setting up our own user namespace
 	// when handling RUN instructions.
 	IDMappingOptions *buildah.IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when
+	// handling RUN instructions.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set
+	// when handling RUN instructions. If a capability appears in both lists, it
+	// will be dropped.
+	DropCapabilities []string
 	CommonBuildOpts  *buildah.CommonBuildOptions
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
 	DefaultMountsFilePath string
@@ -472,8 +478,8 @@ func (b *Executor) Run(run imagebuilder.Run, config docker.Config) error {
 		Entrypoint: config.Entrypoint,
 		Cmd:        config.Cmd,
 		Stdin:      devNull,
-		Stdout:     ioutils.NopWriteCloser(b.out),
-		Stderr:     ioutils.NopWriteCloser(b.err),
+		Stdout:     b.out,
+		Stderr:     b.err,
 		Quiet:      b.quiet,
 	}
 	if config.NetworkDisabled {

--- a/vendor/github.com/projectatomic/buildah/pkg/cli/common.go
+++ b/vendor/github.com/projectatomic/buildah/pkg/cli/common.go
@@ -185,7 +185,15 @@ var (
 	FromAndBudFlags = append(append([]cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "add-host",
-			Usage: "add a custom host-to-IP mapping (host:ip) (default [])",
+			Usage: "add a custom host-to-IP mapping (`host:ip`) (default [])",
+		},
+		cli.StringSliceFlag{
+			Name:  "cap-add",
+			Usage: "add the specified capability when running (default [])",
+		},
+		cli.StringSliceFlag{
+			Name:  "cap-drop",
+			Usage: "drop the specified capability when running (default [])",
 		},
 		cli.StringFlag{
 			Name:  "cgroup-parent",

--- a/vendor/github.com/projectatomic/buildah/pkg/parse/parse.go
+++ b/vendor/github.com/projectatomic/buildah/pkg/parse/parse.go
@@ -332,7 +332,7 @@ func getDockerAuth(creds string) (*types.DockerAuthConfig, error) {
 	}, nil
 }
 
-//  IDMappingOptions parses the build options from user namespace
+// IDMappingOptions parses the build options related to user namespaces and ID mapping.
 func IDMappingOptions(c *cli.Context) (usernsOptions buildah.NamespaceOptions, idmapOptions *buildah.IDMappingOptions, err error) {
 	user := c.String("userns-uid-map-user")
 	group := c.String("userns-gid-map-group")
@@ -367,7 +367,14 @@ func IDMappingOptions(c *cli.Context) (usernsOptions buildah.NamespaceOptions, i
 		}
 		// Parse the flag's value as one or more triples (if it's even
 		// been set), and append them.
-		idmap, err := parseIDMap(c.StringSlice(option))
+		var spec []string
+		if c.GlobalIsSet(option) {
+			spec = c.GlobalStringSlice(option)
+		}
+		if c.IsSet(option) {
+			spec = c.StringSlice(option)
+		}
+		idmap, err := parseIDMap(spec)
 		if err != nil {
 			return nil, err
 		}
@@ -466,7 +473,7 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 	return m, nil
 }
 
-//  NamesapceOptions parses the build options from all namespaces except user namespace
+// NamespaceOptions parses the build options for all namespaces except for user namespace.
 func NamespaceOptions(c *cli.Context) (namespaceOptions buildah.NamespaceOptions, networkPolicy buildah.NetworkConfigurationPolicy, err error) {
 	options := make(buildah.NamespaceOptions, 0, 7)
 	policy := buildah.NetworkDefault

--- a/vendor/github.com/projectatomic/buildah/util/types.go
+++ b/vendor/github.com/projectatomic/buildah/util/types.go
@@ -8,3 +8,23 @@ const (
 	// DefaultCNIConfigDir is the default location of CNI configuration files.
 	DefaultCNIConfigDir = "/etc/cni/net.d"
 )
+
+var (
+	// DefaultCapabilities is the list of capabilities which we grant by
+	// default to containers which are running under UID 0.
+	DefaultCapabilities = []string{
+		"CAP_AUDIT_WRITE",
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FOWNER",
+		"CAP_FSETID",
+		"CAP_KILL",
+		"CAP_MKNOD",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SETFCAP",
+		"CAP_SETGID",
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SYS_CHROOT",
+	}
+)

--- a/vendor/github.com/projectatomic/buildah/vendor.conf
+++ b/vendor/github.com/projectatomic/buildah/vendor.conf
@@ -32,7 +32,7 @@ github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc master
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runtime-tools master
-github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
+github.com/opencontainers/selinux 6ccd0b50d53ae771fe5259ff7a4039110777aa2d
 github.com/openshift/imagebuilder master
 github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
 github.com/pborman/uuid master


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add --cap-add and --cap-drop to build man page.  This was recently added in https://github.com/projectatomic/buildah/pull/799.  Also --userns-uid-map/--userns-gid-map had some changes in the Buildah man page, these have been added from https://github.com/projectatomic/buildah/pull/803