### PR TITLE
install: need to install make on Fedora-like distros

### DIFF
--- a/install.md
+++ b/install.md
@@ -41,6 +41,7 @@ yum install -y \
   libgpg-error-devel \
   libseccomp-devel \
   libselinux-devel \
+  make \
   ostree-devel \
   pkgconfig \
   runc \


### PR DESCRIPTION
Somehow `make` fails to get brought in with all the build tools, so
explicitly install it.

Signed-off-by: Micah Abbott <miabbott@redhat.com>