### PR TITLE
Containers refresh

### DIFF
--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -20,6 +20,7 @@ var (
 		pauseCommand,
 		portCommand,
 		//		pruneCommand,
+		refreshCommand,
 		restartCommand,
 		rmCommand,
 		runCommand,

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -62,6 +62,7 @@ func main() {
 		portCommand,
 		pullCommand,
 		pushCommand,
+		refreshCommand,
 		restartCommand,
 		rmCommand,
 		rmiCommand,

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -62,7 +62,6 @@ func main() {
 		portCommand,
 		pullCommand,
 		pushCommand,
-		refreshCommand,
 		restartCommand,
 		rmCommand,
 		rmiCommand,

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
+	"github.com/urfave/cli"
+)
+
+var (
+	refreshFlags = []cli.Flag{}
+
+	refreshDescription = "The refresh command resets the state of all containers to handle database changes after a Podman upgrade. All running containers will be restarted."
+
+	refreshCommand = cli.Command{
+		Name:                   "refresh",
+		Usage:                  "Refresh container state",
+		Description:            refreshDescription,
+		Flags:                  refreshFlags,
+		Action:                 refreshCmd,
+		UseShortOptionHandling: true,
+	}
+)
+
+func refreshCmd(c *cli.Context) error {
+	if len(c.Args()) > 0 {
+		return errors.Errorf("refresh does not accept any arguments")
+	}
+
+	if err := validateFlags(c, refreshFlags); err != nil {
+		return err
+	}
+
+	runtime, err := libpodruntime.GetRuntime(c)
+	if err != nil {
+		return errors.Wrapf(err, "error creating libpod runtime")
+	}
+	defer runtime.Shutdown(false)
+
+	allCtrs, err := runtime.GetAllContainers()
+	if err != nil {
+		return err
+	}
+
+	ctx := getContext()
+
+	var lastError error
+	for _, ctr := range allCtrs {
+		if err := ctr.Refresh(ctx); err != nil {
+			if lastError != nil {
+				fmt.Fprintln(os.Stderr, lastError)
+			}
+			lastError = errors.Wrapf(err, "error refreshing container %s state", ctr.ID())
+		}
+	}
+
+	return lastError
+}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -718,6 +718,14 @@ _podman_container_port() {
      _podman_port
 }
 
+_podman_container_refresh() {
+     local options_with_args="
+     "
+     local boolean_options="
+     "
+     _complete_ "$options_with_args" "$boolean_options"
+}
+
 _podman_container_restart() {
      _podman_restart
 }
@@ -781,6 +789,7 @@ _podman_container() {
 	 mount
 	 pause
 	 port
+	 refresh
 	 restart
 	 rm
 	 run

--- a/docs/podman-container-refresh.1.md
+++ b/docs/podman-container-refresh.1.md
@@ -1,0 +1,25 @@
+% podman-container-refresh '1'
+
+## NAME
+podman\-container\-refresh - Refresh all containers
+
+## SYNOPSIS
+**podman container refresh**
+
+## DESCRIPTION
+The refresh command refreshes the state of all containers to pick up database
+schema or general configuration changes. It is not necessary during normal
+operation, and will typically be invoked by package managers after finishing an
+upgrade of the Podman package.
+
+As part of refresh, all running containers will be restarted.
+
+## EXAMPLES ##
+
+```
+podman container refresh
+[root@localhost /]#
+```
+
+## SEE ALSO
+podman(1), podman-run(1)

--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -26,6 +26,7 @@ The container command allows you to manage containers
 | mount    | [podman-mount(1)](podman-mount.1.md)      | Mount a working container's root filesystem.                                   |
 | pause    | [podman-pause(1)](podman-pause.1.md)      | Pause one or more containers.                                                  |
 | port     | [podman-port(1)](podman-port.1.md)        | List port mappings for the container.                                          |
+| refresh  | [podman-refresh(1)](podman-refresh.1.md)  | Refresh the state of all containers                                            |
 | restart  | [podman-restart(1)](podman-restart.1.md)  | Restart one or more containers.                                                |
 | rm       | [podman-rm(1)](podman-rm.1.md)            | Remove one or more containers.                                                 |
 | run      | [podman-run(1)](podman-run.1.md)          | Run a command in a container.                                                  |

--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -11,33 +11,33 @@ The container command allows you to manage containers
 
 ## COMMANDS
 
-| Command  | Man Page                                  | Description                                                                    |
-| -------  | ----------------------------------------- | ------------------------------------------------------------------------------ |
-| attach   | [podman-attach(1)](podman-attach.1.md)    | Attach to a running container.                                                 |
-| commit   | [podman-commit(1)](podman-commit.1.md)    | Create new image based on the changed container.                               |
-| create   | [podman-create(1)](podman-create.1.md)    | Create a new container.                                                        |
-| diff     | [podman-diff(1)](podman-diff.1.md)        | Inspect changes on a container or image's filesystem.                          |
-| exec     | [podman-exec(1)](podman-exec.1.md)        | Execute a command in a running container.                                      |
-| export   | [podman-export(1)](podman-export.1.md)   | Export a container's filesystem contents as a tar archive.                      |
-| inspect  | [podman-inspect(1)](podman-inspect.1.md)  | Display a container or image's configuration.                                  |
-| kill     | [podman-kill(1)](podman-kill.1.md)        | Kill the main process in one or more containers.                               |
-| logs     | [podman-logs(1)](podman-logs.1.md)        | Display the logs of a container.                                               |
-| ls       | [podman-ps(1)](podman-ps.1.md)            | Prints out information about containers.                                       |
-| mount    | [podman-mount(1)](podman-mount.1.md)      | Mount a working container's root filesystem.                                   |
-| pause    | [podman-pause(1)](podman-pause.1.md)      | Pause one or more containers.                                                  |
-| port     | [podman-port(1)](podman-port.1.md)        | List port mappings for the container.                                          |
-| refresh  | [podman-refresh(1)](podman-refresh.1.md)  | Refresh the state of all containers                                            |
-| restart  | [podman-restart(1)](podman-restart.1.md)  | Restart one or more containers.                                                |
-| rm       | [podman-rm(1)](podman-rm.1.md)            | Remove one or more containers.                                                 |
-| run      | [podman-run(1)](podman-run.1.md)          | Run a command in a container.                                                  |
-| start    | [podman-start(1)](podman-start.1.md)      | Starts one or more containers.                                                 |
-| stats    | [podman-stats(1)](podman-stats.1.md)      | Display a live stream of one or more container's resource usage statistics.    |
-| stop     | [podman-stop(1)](podman-stop.1.md)        | Stop one or more running containers.                                           |
-| top      | [podman-top(1)](podman-top.1.md)          | Display the running processes of a container.                                  |
-| umount   | [podman-umount(1)](podman-umount.1.md)    | Unmount a working container's root filesystem.                                 |
-| unmount  | [podman-umount(1)](podman-umount.1.md)    | Unmount a working container's root filesystem.                                 |
-| unpause  | [podman-unpause(1)](podman-unpause.1.md)  | Unpause one or more containers.                                                |
-| wait     | [podman-wait(1)](podman-wait.1.md)        | Wait on one or more containers to stop and print their exit codes.             |
+| Command  | Man Page                                            | Description                                                                  |
+| -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| attach   | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
+| commit   | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
+| create   | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |
+| diff     | [podman-diff(1)](podman-diff.1.md)                  | Inspect changes on a container or image's filesystem.                        |
+| exec     | [podman-exec(1)](podman-exec.1.md)                  | Execute a command in a running container.                                    |
+| export   | [podman-export(1)](podman-export.1.md)              | Export a container's filesystem contents as a tar archive.                   |
+| inspect  | [podman-inspect(1)](podman-inspect.1.md)            | Display a container or image's configuration.                                |
+| kill     | [podman-kill(1)](podman-kill.1.md)                  | Kill the main process in one or more containers.                             |
+| logs     | [podman-logs(1)](podman-logs.1.md)                  | Display the logs of a container.                                             |
+| ls       | [podman-ps(1)](podman-ps.1.md)                      | Prints out information about containers.                                     |
+| mount    | [podman-mount(1)](podman-mount.1.md)                | Mount a working container's root filesystem.                                 |
+| pause    | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
+| port     | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
+| refresh  | [podman-refresh(1)](podman-container-refresh.1.md)  | Refresh the state of all containers                                          |
+| restart  | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
+| rm       | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |
+| run      | [podman-run(1)](podman-run.1.md)                    | Run a command in a container.                                                |
+| start    | [podman-start(1)](podman-start.1.md)                | Starts one or more containers.                                               |
+| stats    | [podman-stats(1)](podman-stats.1.md)                | Display a live stream of one or more container's resource usage statistics.  |
+| stop     | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |
+| top      | [podman-top(1)](podman-top.1.md)                    | Display the running processes of a container.                                |
+| umount   | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
+| unmount  | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
+| unpause  | [podman-unpause(1)](podman-unpause.1.md)            | Unpause one or more containers.                                              |
+| wait     | [podman-wait(1)](podman-wait.1.md)                  | Wait on one or more containers to stop and print their exit codes.           |
 
 ## SEE ALSO
 podman, podman-exec, podman-run

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -174,15 +174,9 @@ func (s *BoltState) Refresh() error {
 				return errors.Wrapf(err, "error unmarshalling state for container %s", string(id))
 			}
 
-			state.PID = 0
-			state.Mountpoint = ""
-			state.Mounted = false
-			state.State = ContainerStateConfigured
-			state.ExecSessions = make(map[string]*ExecSession)
-			state.IPs = nil
-			state.Interfaces = nil
-			state.Routes = nil
-			state.BindMounts = make(map[string]string)
+			if err := resetState(state); err != nil {
+				return errors.Wrapf(err, "error resetting state for container %s", string(id))
+			}
 
 			newStateBytes, err := json.Marshal(state)
 			if err != nil {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -167,6 +167,9 @@ type containerState struct {
 	// the path of the file on disk outside the container
 	BindMounts map[string]string `json:"bindMounts,omitempty"`
 
+	// CgroupCreated indicates that the container has created a cgroup
+	CgroupCreated bool `json:"cgroupCreated,omitempty"`
+
 	// UserNSRoot is the directory used as root for the container when using
 	// user namespaces.
 	UserNSRoot string `json:"userNSRoot,omitempty"`

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -811,6 +811,8 @@ func (c *Container) Refresh(ctx context.Context) error {
 		return err
 	}
 
+	logrus.Debugf("Resetting state of container %s", c.ID())
+
 	// We've finished unwinding the container back to its initial state
 	// Now safe to refresh container state
 	if err := resetState(c.state); err != nil {

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -483,15 +483,8 @@ func (c *Container) Pause() error {
 	if c.state.State != ContainerStateRunning {
 		return errors.Wrapf(ErrCtrStateInvalid, "%q is not running, can't pause", c.state.State)
 	}
-	if err := c.runtime.ociRuntime.pauseContainer(c); err != nil {
-		return err
-	}
 
-	logrus.Debugf("Paused container %s", c.ID())
-
-	c.state.State = ContainerStatePaused
-
-	return c.save()
+	return c.pause()
 }
 
 // Unpause unpauses a container
@@ -508,15 +501,8 @@ func (c *Container) Unpause() error {
 	if c.state.State != ContainerStatePaused {
 		return errors.Wrapf(ErrCtrStateInvalid, "%q is not paused, can't unpause", c.ID())
 	}
-	if err := c.runtime.ociRuntime.unpauseContainer(c); err != nil {
-		return err
-	}
 
-	logrus.Debugf("Unpaused container %s", c.ID())
-
-	c.state.State = ContainerStateRunning
-
-	return c.save()
+	return c.unpause()
 }
 
 // Export exports a container's root filesystem as a tar archive
@@ -758,4 +744,107 @@ func (c *Container) RestartWithTimeout(ctx context.Context, timeout uint) error 
 	}
 
 	return c.start()
+}
+
+// Refresh refreshes a container's state in the database, restarting the
+// container if it is running
+func (c *Container) Refresh(ctx context.Context) error {
+	if !c.batched {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		if err := c.syncContainer(); err != nil {
+			return err
+		}
+	}
+
+	wasCreated := false
+	if c.state.State == ContainerStateCreated {
+		wasCreated = true
+	}
+	wasRunning := false
+	if c.state.State == ContainerStateRunning {
+		wasRunning = true
+	}
+	wasPaused := false
+	if c.state.State == ContainerStatePaused {
+		wasPaused = true
+	}
+
+	// First, unpause the container if it's paused
+	if c.state.State == ContainerStatePaused {
+		if err := c.unpause(); err != nil {
+			return err
+		}
+	}
+
+	// Next, if the container is running, stop it
+	if c.state.State == ContainerStateRunning {
+		if err := c.stop(c.config.StopTimeout); err != nil {
+			return err
+		}
+	}
+
+	// If there are active exec sessions, we need to kill them
+	if len(c.state.ExecSessions) > 0 {
+		logrus.Infof("Killing %d exec sessions in container %s. They will not be restored after refresh.",
+			len(c.state.ExecSessions), c.ID())
+		if err := c.runtime.ociRuntime.execStopContainer(c, c.config.StopTimeout); err != nil {
+			return err
+		}
+	}
+
+	// If the container is in ContainerStateStopped, we need to delete it
+	// from the runtime and clear conmon state
+	if c.state.State == ContainerStateStopped {
+		if err := c.delete(ctx); err != nil {
+			return err
+		}
+		if err := c.removeConmonFiles(); err != nil {
+			return err
+		}
+	}
+
+	// Fire cleanup code one more time unconditionally to ensure we are good
+	// to refresh
+	if err := c.cleanup(); err != nil {
+		return err
+	}
+
+	// We've finished unwinding the container back to its initial state
+	// Now safe to refresh container state
+	if err := resetState(c.state); err != nil {
+		return errors.Wrapf(err, "error resetting state of container %s", c.ID())
+	}
+	if err := c.refresh(); err != nil {
+		return err
+	}
+
+	logrus.Debugf("Successfully refresh container %s state")
+
+	// Initialize the container if it was created in runc
+	if wasCreated || wasRunning || wasPaused {
+		if err := c.prepare(); err != nil {
+			return err
+		}
+		if err := c.init(ctx); err != nil {
+			return err
+		}
+	}
+
+	// If the container was running before, start it
+	if wasRunning || wasPaused {
+		if err := c.start(); err != nil {
+			return err
+		}
+	}
+
+	// If the container was paused before, re-pause it
+	if wasPaused {
+		if err := c.pause(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -127,9 +127,6 @@ func (p *Pod) save() error {
 
 // Refresh a pod's state after restart
 func (p *Pod) refresh() error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	if !p.valid {
 		return ErrPodRemoved
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -570,14 +570,20 @@ func (r *Runtime) refresh(alivePath string) error {
 		return errors.Wrapf(err, "error retrieving all pods from state")
 	}
 	for _, ctr := range ctrs {
+		ctr.lock.Lock()
 		if err := ctr.refresh(); err != nil {
+			ctr.lock.Unlock()
 			return err
 		}
+		ctr.lock.Unlock()
 	}
 	for _, pod := range pods {
+		pod.lock.Lock()
 		if err := pod.refresh(); err != nil {
+			pod.lock.Unlock()
 			return err
 		}
+		pod.lock.Unlock()
 	}
 
 	// Create a file indicating the runtime is alive and ready

--- a/test/e2e/refresh_test.go
+++ b/test/e2e/refresh_test.go
@@ -1,0 +1,68 @@
+package integration
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman refresh", func() {
+	var (
+		tmpdir     string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tmpdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tmpdir)
+		podmanTest.RestoreAllArtifacts()
+		podmanTest.RestoreArtifact(fedoraMinimal)
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+	})
+
+	Specify("Refresh with no containers succeeds", func() {
+		session := podmanTest.Podman([]string{"container", "refresh"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	Specify("Refresh with created container succeeds", func() {
+		createSession := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		createSession.WaitWithDefaultTimeout()
+		Expect(createSession.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(0))
+
+		refreshSession := podmanTest.Podman([]string{"container", "refresh"})
+		refreshSession.WaitWithDefaultTimeout()
+		Expect(refreshSession.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(0))
+	})
+
+	Specify("Refresh with running container restarts container", func() {
+		createSession := podmanTest.Podman([]string{"run", "-d", ALPINE, "sleep", "120"})
+		createSession.WaitWithDefaultTimeout()
+		Expect(createSession.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(1))
+
+		// HACK: ensure container starts before we move on
+		time.Sleep(1 * time.Second)
+
+		refreshSession := podmanTest.Podman([]string{"container", "refresh"})
+		refreshSession.WaitWithDefaultTimeout()
+		Expect(refreshSession.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(1))
+	})
+})


### PR DESCRIPTION
Add a new command to manually reset container state, allowing us to more gracefully handle potentially-breaking changes in the database. This would run as a post-install script in package managers, and perform a task somewhat similar to a daemon restart (except without the daemon) - containers go down, have their state updated to reflect changes in the current version, and come back up.

Also make some changes to the way we handle CGroups to address bugs I found while writing this.