### PR TITLE
Fix docs on --sig-proxy to match current behaviour

### DIFF
--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -523,7 +523,7 @@ If you omit the unit, the system uses bytes. If you omit the size entirely, the 
 
 **--sig-proxy**=*true*|*false*
 
-Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+Proxy signals sent to the `podman run` command to the container process. SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
 
 **--stop-signal**=*SIGTERM*
 


### PR DESCRIPTION
Signals are proxied to the container process whether or not
the tty is used

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>