### PR TITLE
Add podman-image and podman-container man page links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ install.man: docs
 	install ${SELINUXOPT} -d -m 755 $(MANDIR)/man5
 	install ${SELINUXOPT} -m 644 $(filter %.1,$(MANPAGES)) -t $(MANDIR)/man1
 	install ${SELINUXOPT} -m 644 $(filter %.5,$(MANPAGES)) -t $(MANDIR)/man5
+	install ${SELINUXOPT} -m 644 docs/links/*1 -t $(MANDIR)/man1
 
 install.config:
 	install ${SELINUXOPT} -D -m 644 libpod.conf ${SHAREDIR_CONTAINERS}/libpod.conf

--- a/docs/links/podman-container-attach.1
+++ b/docs/links/podman-container-attach.1
@@ -1,0 +1,1 @@
+.so man1/podman-attach.1

--- a/docs/links/podman-container-commit.1
+++ b/docs/links/podman-container-commit.1
@@ -1,0 +1,1 @@
+.so man1/podman-commit.1

--- a/docs/links/podman-container-create.1
+++ b/docs/links/podman-container-create.1
@@ -1,0 +1,1 @@
+.so man1/podman-create.1

--- a/docs/links/podman-container-diff.1
+++ b/docs/links/podman-container-diff.1
@@ -1,0 +1,1 @@
+.so man1/podman-diff.1

--- a/docs/links/podman-container-exec.1
+++ b/docs/links/podman-container-exec.1
@@ -1,0 +1,1 @@
+.so man1/podman-exec.1

--- a/docs/links/podman-container-export.1
+++ b/docs/links/podman-container-export.1
@@ -1,0 +1,1 @@
+.so man1/podman-export.1

--- a/docs/links/podman-container-inspect.1
+++ b/docs/links/podman-container-inspect.1
@@ -1,0 +1,1 @@
+.so man1/podman-inspect.1

--- a/docs/links/podman-container-kill.1
+++ b/docs/links/podman-container-kill.1
@@ -1,0 +1,1 @@
+.so man1/podman-kill.1

--- a/docs/links/podman-container-list.1
+++ b/docs/links/podman-container-list.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/links/podman-container-logs.1
+++ b/docs/links/podman-container-logs.1
@@ -1,0 +1,1 @@
+.so man1/podman-logs.1

--- a/docs/links/podman-container-ls.1
+++ b/docs/links/podman-container-ls.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/links/podman-container-mount.1
+++ b/docs/links/podman-container-mount.1
@@ -1,0 +1,1 @@
+.so man1/podman-mount.1

--- a/docs/links/podman-container-pause.1
+++ b/docs/links/podman-container-pause.1
@@ -1,0 +1,1 @@
+.so man1/podman-pause.1

--- a/docs/links/podman-container-port.1
+++ b/docs/links/podman-container-port.1
@@ -1,0 +1,1 @@
+.so man1/podman-port.1

--- a/docs/links/podman-container-restart.1
+++ b/docs/links/podman-container-restart.1
@@ -1,0 +1,1 @@
+.so man1/podman-restart.1

--- a/docs/links/podman-container-rm.1
+++ b/docs/links/podman-container-rm.1
@@ -1,0 +1,1 @@
+.so man1/podman-rm.1

--- a/docs/links/podman-container-run.1
+++ b/docs/links/podman-container-run.1
@@ -1,0 +1,1 @@
+.so man1/podman-run.1

--- a/docs/links/podman-container-start.1
+++ b/docs/links/podman-container-start.1
@@ -1,0 +1,1 @@
+.so man1/podman-start.1

--- a/docs/links/podman-container-stats.1
+++ b/docs/links/podman-container-stats.1
@@ -1,0 +1,1 @@
+.so man1/podman-stats.1

--- a/docs/links/podman-container-stop.1
+++ b/docs/links/podman-container-stop.1
@@ -1,0 +1,1 @@
+.so man1/podman-stop.1

--- a/docs/links/podman-container-top.1
+++ b/docs/links/podman-container-top.1
@@ -1,0 +1,1 @@
+.so man1/podman-top.1

--- a/docs/links/podman-container-umount.1
+++ b/docs/links/podman-container-umount.1
@@ -1,0 +1,1 @@
+.so man1/podman-umount,.1

--- a/docs/links/podman-container-unmount.1
+++ b/docs/links/podman-container-unmount.1
@@ -1,0 +1,1 @@
+.so man1/podman-umount,.1

--- a/docs/links/podman-container-unpause.1
+++ b/docs/links/podman-container-unpause.1
@@ -1,0 +1,1 @@
+.so man1/podman-unpause.1

--- a/docs/links/podman-container-wait.1
+++ b/docs/links/podman-container-wait.1
@@ -1,0 +1,1 @@
+.so man1/podman-wait.1

--- a/docs/links/podman-image-build.1
+++ b/docs/links/podman-image-build.1
@@ -1,0 +1,1 @@
+.so man1/podman-build.1

--- a/docs/links/podman-image-history.1
+++ b/docs/links/podman-image-history.1
@@ -1,0 +1,1 @@
+.so man1/podman-history.1

--- a/docs/links/podman-image-import.1
+++ b/docs/links/podman-image-import.1
@@ -1,0 +1,1 @@
+.so man1/podman-import.1

--- a/docs/links/podman-image-inspect.1
+++ b/docs/links/podman-image-inspect.1
@@ -1,0 +1,1 @@
+.so man1/podman-inspect.1

--- a/docs/links/podman-image-load.1
+++ b/docs/links/podman-image-load.1
@@ -1,0 +1,1 @@
+.so man1/podman-load.1

--- a/docs/links/podman-image-ls.1
+++ b/docs/links/podman-image-ls.1
@@ -1,0 +1,1 @@
+.so man1/podman-images.1

--- a/docs/links/podman-image-pull.1
+++ b/docs/links/podman-image-pull.1
@@ -1,0 +1,1 @@
+.so man1/podman-pull.1

--- a/docs/links/podman-image-push.1
+++ b/docs/links/podman-image-push.1
@@ -1,0 +1,1 @@
+.so man1/podman-push.1

--- a/docs/links/podman-image-rm.1
+++ b/docs/links/podman-image-rm.1
@@ -1,0 +1,1 @@
+.so man1/podman-rm.1

--- a/docs/links/podman-image-save.1
+++ b/docs/links/podman-image-save.1
@@ -1,0 +1,1 @@
+.so man1/podman-save.1

--- a/docs/links/podman-image-tag.1
+++ b/docs/links/podman-image-tag.1
@@ -1,0 +1,1 @@
+.so man1/podman-tag.1


### PR DESCRIPTION
podman image and podman container have alternate CLI
to standard CLI for a lot of commands.  The man pages
can be shared between both.  This patch adds links so that
of some executes

`podman image load`, they will actually see the `podman load` man page.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>