### PR TITLE
Containers can dissappear

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
 	"github.com/projectatomic/libpod/libpod"
 	"github.com/projectatomic/libpod/pkg/util"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"k8s.io/apimachinery/pkg/fields"
 )
@@ -564,6 +565,10 @@ func getAndSortJSONParams(containers []*libpod.Container, opts batchcontainer.Ps
 	for _, ctr := range containers {
 		batchInfo, err := batchcontainer.BatchContainerOp(ctr, opts)
 		if err != nil {
+			if errors.Cause(err) == libpod.ErrNoSuchCtr {
+				logrus.Warn(err)
+				continue
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Between the time that ps command gets the list of containers
and is able to ask for more data, the container could have
exited.  This patch logs Clibpod.ErrNoSuchCtr errors and just continues
processing.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>