### PR TITLE
Add --authfile to podman search

### DIFF
--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -23,6 +23,10 @@ const (
 
 var (
 	searchFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
 		cli.StringSliceFlag{
 			Name:  "filter, f",
 			Usage: "filter output based on conditions provided (default [])",
@@ -71,10 +75,11 @@ type searchParams struct {
 }
 
 type searchOpts struct {
-	filter  []string
-	limit   int
-	noTrunc bool
-	format  string
+	filter   []string
+	limit    int
+	noTrunc  bool
+	format   string
+	authfile string
 }
 
 type searchFilterParams struct {
@@ -105,10 +110,11 @@ func searchCmd(c *cli.Context) error {
 
 	format := genSearchFormat(c.String("format"))
 	opts := searchOpts{
-		format:  format,
-		noTrunc: c.Bool("no-trunc"),
-		limit:   c.Int("limit"),
-		filter:  c.StringSlice("filter"),
+		format:   format,
+		noTrunc:  c.Bool("no-trunc"),
+		limit:    c.Int("limit"),
+		filter:   c.StringSlice("filter"),
+		authfile: c.String("authfile"),
 	}
 	regAndSkipTLS, err := getRegistriesAndSkipTLS(c)
 	if err != nil {
@@ -206,7 +212,7 @@ func getSearchOutput(term string, regAndSkipTLS map[string]bool, opts searchOpts
 		limit = opts.limit
 	}
 
-	sc := common.GetSystemContext("", "", false)
+	sc := common.GetSystemContext("", opts.authfile, false)
 	var paramsArr []searchParams
 	for reg, skipTLS := range regAndSkipTLS {
 		// set the SkipTLSVerify bool depending on the registry being searched through

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1289,6 +1289,7 @@ _podman_pull() {
 
 _podman_search() {
 	local options_with_args="
+	--authfile
 	--filter -f
 	--format
 	--limit

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -29,6 +29,10 @@ using the **--filter** flag.
 
 ## OPTIONS
 
+**--authfile**
+
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+
 **--filter, -f**
 
 Filter output based on conditions provided (default [])

--- a/vendor.conf
+++ b/vendor.conf
@@ -10,7 +10,7 @@ github.com/containerd/cgroups 77e628511d924b13a77cebdc73b757a47f6d751b
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins 1fb94a4222eafc6f948eacdca9c9f2158b427e53
-github.com/containers/image ad33f7b73fbac0acf05b9e2cea021b61b4b0c3e0
+github.com/containers/image 5144ced37a1b21b63c6ef605e56811e29a687528
 github.com/containers/storage 51f1f85c2b7863b2fd361471f05b937fd8059124
 github.com/coreos/go-systemd v14
 github.com/cri-o/ocicni master

--- a/vendor/github.com/containers/image/copy/copy.go
+++ b/vendor/github.com/containers/image/copy/copy.go
@@ -347,6 +347,9 @@ func checkImageDestinationForCurrentRuntimeOS(ctx context.Context, sys *types.Sy
 
 // updateEmbeddedDockerReference handles the Docker reference embedded in Docker schema1 manifests.
 func (ic *imageCopier) updateEmbeddedDockerReference() error {
+	if ic.c.dest.IgnoresEmbeddedDockerReference() {
+		return nil // Destination would prefer us not to update the embedded reference.
+	}
 	destRef := ic.c.dest.Reference().DockerReference()
 	if destRef == nil {
 		return nil // Destination does not care about Docker references

--- a/vendor/github.com/containers/image/directory/directory_dest.go
+++ b/vendor/github.com/containers/image/directory/directory_dest.go
@@ -117,6 +117,13 @@ func (d *dirImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *dirImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, DockerReference() returns nil.
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -280,13 +280,19 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	v2Res := &V2Results{}
 	v1Res := &V1Results{}
 
+	// Get credentials from authfile for the underlying hostname
+	username, password, err := config.GetAuthentication(sys, registry)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting username and password")
+	}
+
 	// The /v2/_catalog endpoint has been disabled for docker.io therefore the call made to that endpoint will fail
 	// So using the v1 hostname for docker.io for simplicity of implementation and the fact that it returns search results
 	if registry == dockerHostname {
 		registry = dockerV1Hostname
 	}
 
-	client, err := newDockerClientWithDetails(sys, registry, "", "", "", nil, "")
+	client, err := newDockerClientWithDetails(sys, registry, username, password, "", nil, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating new docker client")
 	}

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -95,6 +95,13 @@ func (d *dockerImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *dockerImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // We do want the manifest updated; older registry versions refuse manifests if the embedded reference does not match.
+}
+
 // sizeCounter is an io.Writer which only counts the total size of its input.
 type sizeCounter struct{ size int64 }
 

--- a/vendor/github.com/containers/image/docker/tarfile/dest.go
+++ b/vendor/github.com/containers/image/docker/tarfile/dest.go
@@ -75,6 +75,13 @@ func (d *Destination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *Destination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, we only accept schema2 images where EmbeddedDockerReferenceConflicts() is always false.
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/vendor/github.com/containers/image/oci/archive/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/archive/oci_dest.go
@@ -70,6 +70,13 @@ func (d *ociArchiveImageDestination) MustMatchRuntimeOS() bool {
 	return d.unpackedDest.MustMatchRuntimeOS()
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *ociArchiveImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return d.unpackedDest.IgnoresEmbeddedDockerReference()
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/vendor/github.com/containers/image/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_dest.go
@@ -95,6 +95,13 @@ func (d *ociImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *ociImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, DockerReference() returns nil.
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -23,8 +23,14 @@ func init() {
 	transports.Register(Transport)
 }
 
-// Transport is an ImageTransport for OCI directories.
-var Transport = ociTransport{}
+var (
+	// Transport is an ImageTransport for OCI directories.
+	Transport = ociTransport{}
+
+	// ErrMoreThanOneImage is an error returned when the manifest includes
+	// more than one image and the user should choose which one to use.
+	ErrMoreThanOneImage = errors.New("more than one image in oci, choose an image")
+)
 
 type ociTransport struct{}
 
@@ -184,7 +190,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 			d = &index.Manifests[0]
 		} else {
 			// ask user to choose image when more than one image in the oci directory
-			return imgspecv1.Descriptor{}, errors.Wrapf(err, "more than one image in oci, choose an image")
+			return imgspecv1.Descriptor{}, ErrMoreThanOneImage
 		}
 	} else {
 		// if image specified, look through all manifests for a match

--- a/vendor/github.com/containers/image/openshift/openshift.go
+++ b/vendor/github.com/containers/image/openshift/openshift.go
@@ -369,6 +369,13 @@ func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *openshiftImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return d.docker.IgnoresEmbeddedDockerReference()
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/vendor/github.com/containers/image/storage/storage_reference.go
+++ b/vendor/github.com/containers/image/storage/storage_reference.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
-	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -17,55 +16,65 @@ import (
 // A storageReference holds an arbitrary name and/or an ID, which is a 32-byte
 // value hex-encoded into a 64-character string, and a reference to a Store
 // where an image is, or would be, kept.
+// Either "named" or "id" must be set.
 type storageReference struct {
 	transport storageTransport
-	reference string
+	named     reference.Named // may include a tag and/or a digest
 	id        string
-	name      reference.Named
-	tag       string
-	digest    digest.Digest
 }
 
-func newReference(transport storageTransport, reference, id string, name reference.Named, tag string, digest digest.Digest) *storageReference {
+func newReference(transport storageTransport, named reference.Named, id string) (*storageReference, error) {
+	if named == nil && id == "" {
+		return nil, ErrInvalidReference
+	}
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by
 	// further calls to the original transport's SetStore() method.
 	return &storageReference{
 		transport: transport,
-		reference: reference,
+		named:     named,
 		id:        id,
-		name:      name,
-		tag:       tag,
-		digest:    digest,
+	}, nil
+}
+
+// imageMatchesRepo returns true iff image.Names contains an element with the same repo as ref
+func imageMatchesRepo(image *storage.Image, ref reference.Named) bool {
+	repo := ref.Name()
+	for _, name := range image.Names {
+		if named, err := reference.ParseNormalizedNamed(name); err == nil {
+			if named.Name() == repo {
+				return true
+			}
+		}
 	}
+	return false
 }
 
 // Resolve the reference's name to an image ID in the store, if there's already
 // one present with the same name or ID, and return the image.
 func (s *storageReference) resolveImage() (*storage.Image, error) {
+	var loadedImage *storage.Image
 	if s.id == "" {
 		// Look for an image that has the expanded reference name as an explicit Name value.
-		image, err := s.transport.store.Image(s.reference)
+		image, err := s.transport.store.Image(s.named.String())
 		if image != nil && err == nil {
+			loadedImage = image
 			s.id = image.ID
 		}
 	}
-	if s.id == "" && s.name != nil && s.digest != "" {
-		// Look for an image with the specified digest that has the same name,
-		// though possibly with a different tag or digest, as a Name value, so
-		// that the canonical reference can be implicitly resolved to the image.
-		images, err := s.transport.store.ImagesByDigest(s.digest)
-		if images != nil && err == nil {
-			repo := reference.FamiliarName(reference.TrimNamed(s.name))
-		search:
-			for _, image := range images {
-				for _, name := range image.Names {
-					if named, err := reference.ParseNormalizedNamed(name); err == nil {
-						if reference.FamiliarName(reference.TrimNamed(named)) == repo {
-							s.id = image.ID
-							break search
-						}
+	if s.id == "" && s.named != nil {
+		if digested, ok := s.named.(reference.Digested); ok {
+			// Look for an image with the specified digest that has the same name,
+			// though possibly with a different tag or digest, as a Name value, so
+			// that the canonical reference can be implicitly resolved to the image.
+			images, err := s.transport.store.ImagesByDigest(digested.Digest())
+			if images != nil && err == nil {
+				for _, image := range images {
+					if imageMatchesRepo(image, s.named) {
+						loadedImage = image
+						s.id = image.ID
+						break
 					}
 				}
 			}
@@ -75,27 +84,20 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		logrus.Debugf("reference %q does not resolve to an image ID", s.StringWithinTransport())
 		return nil, errors.Wrapf(ErrNoSuchImage, "reference %q does not resolve to an image ID", s.StringWithinTransport())
 	}
-	img, err := s.transport.store.Image(s.id)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image %q", s.id)
-	}
-	if s.name != nil {
-		repo := reference.FamiliarName(reference.TrimNamed(s.name))
-		nameMatch := false
-		for _, name := range img.Names {
-			if named, err := reference.ParseNormalizedNamed(name); err == nil {
-				if reference.FamiliarName(reference.TrimNamed(named)) == repo {
-					nameMatch = true
-					break
-				}
-			}
+	if loadedImage == nil {
+		img, err := s.transport.store.Image(s.id)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading image %q", s.id)
 		}
-		if !nameMatch {
+		loadedImage = img
+	}
+	if s.named != nil {
+		if !imageMatchesRepo(loadedImage, s.named) {
 			logrus.Errorf("no image matching reference %q found", s.StringWithinTransport())
 			return nil, ErrNoSuchImage
 		}
 	}
-	return img, nil
+	return loadedImage, nil
 }
 
 // Return a Transport object that defaults to using the same store that we used
@@ -110,20 +112,7 @@ func (s storageReference) Transport() types.ImageTransport {
 
 // Return a name with a tag or digest, if we have either, else return it bare.
 func (s storageReference) DockerReference() reference.Named {
-	if s.name == nil {
-		return nil
-	}
-	if s.tag != "" {
-		if namedTagged, err := reference.WithTag(s.name, s.tag); err == nil {
-			return namedTagged
-		}
-	}
-	if s.digest != "" {
-		if canonical, err := reference.WithDigest(s.name, s.digest); err == nil {
-			return canonical
-		}
-	}
-	return s.name
+	return s.named
 }
 
 // Return a name with a tag, prefixed with the graph root and driver name, to
@@ -135,25 +124,25 @@ func (s storageReference) StringWithinTransport() string {
 	if len(options) > 0 {
 		optionsList = ":" + strings.Join(options, ",")
 	}
-	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "+" + s.transport.store.RunRoot() + optionsList + "]"
-	if s.reference == "" {
-		return storeSpec + "@" + s.id
+	res := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "+" + s.transport.store.RunRoot() + optionsList + "]"
+	if s.named != nil {
+		res = res + s.named.String()
 	}
-	if s.id == "" {
-		return storeSpec + s.reference
+	if s.id != "" {
+		res = res + "@" + s.id
 	}
-	return storeSpec + s.reference + "@" + s.id
+	return res
 }
 
 func (s storageReference) PolicyConfigurationIdentity() string {
-	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
-	if s.name == nil {
-		return storeSpec + "@" + s.id
+	res := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
+	if s.named != nil {
+		res = res + s.named.String()
 	}
-	if s.id == "" {
-		return storeSpec + s.reference
+	if s.id != "" {
+		res = res + "@" + s.id
 	}
-	return storeSpec + s.reference + "@" + s.id
+	return res
 }
 
 // Also accept policy that's tied to the combination of the graph root and
@@ -164,9 +153,17 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
 	driverlessStoreSpec := "[" + s.transport.store.GraphRoot() + "]"
 	namespaces := []string{}
-	if s.name != nil {
-		name := reference.TrimNamed(s.name)
-		components := strings.Split(name.String(), "/")
+	if s.named != nil {
+		if s.id != "" {
+			// The reference without the ID is also a valid namespace.
+			namespaces = append(namespaces, storeSpec+s.named.String())
+		}
+		tagged, isTagged := s.named.(reference.Tagged)
+		_, isDigested := s.named.(reference.Digested)
+		if isTagged && isDigested { // s.named is "name:tag@digest"; add a "name:tag" parent namespace.
+			namespaces = append(namespaces, storeSpec+s.named.Name()+":"+tagged.Tag())
+		}
+		components := strings.Split(s.named.Name(), "/")
 		for len(components) > 0 {
 			namespaces = append(namespaces, storeSpec+strings.Join(components, "/"))
 			components = components[:len(components)-1]

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -174,6 +174,11 @@ type ImageDestination interface {
 	AcceptsForeignLayerURLs() bool
 	// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
 	MustMatchRuntimeOS() bool
+	// IgnoresEmbeddedDockerReference() returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+	// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+	// Does not make a difference if Reference().DockerReference() is nil.
+	IgnoresEmbeddedDockerReference() bool
+
 	// PutBlob writes contents of stream and returns data representing the result.
 	// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 	// inputInfo.Size is the expected length of stream, if known.

--- a/vendor/github.com/containers/image/vendor.conf
+++ b/vendor/github.com/containers/image/vendor.conf
@@ -40,3 +40,5 @@ github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
 github.com/gogo/protobuf fcdc5011193ff531a548e9b0301828d5a5b97fd8
 github.com/pquerna/ffjson master
 github.com/syndtr/gocapability master
+github.com/Microsoft/go-winio ab35fc04b6365e8fcb18e6e9e41ea4a02b10b175
+github.com/Microsoft/hcsshim eca7177590cdcbd25bbc5df27e3b693a54b53a6a


### PR DESCRIPTION
Since podman search requires credentials to search private registries,
add the --authfile flag to allow users to pass in credentials from a
different authfile than the default one.

Vendor in latest containers/image
Fixes issue with podman search of private registries. Podman search
was not picking up the credentials from the authfile. This fixes it.

Signed-off-by: umohnani8 <umohnani@redhat.com>