### PR TITLE
Mark containers invalid earlier during removal

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -258,6 +258,9 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool)
 		}
 	}
 
+	// Set container as invalid so it can no longer be used
+	c.valid = false
+
 	// Clean up network namespace, cgroups, mounts
 	if err := c.cleanup(); err != nil {
 		if cleanupErr == nil {
@@ -288,9 +291,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool)
 			}
 		}
 	}
-
-	// Set container as invalid so it can no longer be used
-	c.valid = false
 
 	return cleanupErr
 }


### PR DESCRIPTION
Fixes a bug where we might try saving back to the database during cleanup, which would fail as the container was already removed from the database.