### PR TITLE
Rephrase docs and info on podman search

### DIFF
--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -49,8 +49,9 @@ var (
 		},
 	}
 	searchDescription = `
-	Search registries for a given image. Can search all the default registries or a specific registry.
-	Can limit the number of results, and filter the output based on certain conditions.`
+	Search registries for a given image. Will search all the default registries in /etc/containers/registries.conf.
+	To search only a specific registry use the --registry flag. Can limit the number of results, and filter the output
+	based on certain conditions.`
 	searchCommand = cli.Command{
 		Name:        "search",
 		Usage:       "search registry for image",

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -15,11 +15,11 @@ podman\-search - Search a registry for an image
 
 ## DESCRIPTION
 **podman search** searches a registry or a list of registries for a matching image.
-The user can specify which registry to search by setting the **--registry** flag, default
-is the default registries set in the config file - **/etc/containers/registries.conf**.
-The number of results can be limited using the **--limit** flag. If more than one registry
-is being searched, the limit will be applied to each registry. The output can be filtered
-using the **--filter** flag.
+By default, **podman search** will search all the registries in the config file
+**/etc/containers/registries.conf**. The user can specify which registry to search by
+setting the **--registry** flag. The number of results can be limited using the **--limit**
+flag. If more than one registry is being searched, the limit will be applied to each
+registry. The output can be filtered using the **--filter** flag.
 
 **podman [GLOBAL OPTIONS]**
 


### PR DESCRIPTION
Rephrase the information shown when doing "podman search --help"
to clarify what exactly --registry is used for.
Touched up the man page too.

Should address https://github.com/projectatomic/libpod/issues/977

Signed-off-by: umohnani8 <umohnani@redhat.com>