### PR TITLE
Remove the --registry flag from podman search

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1303,7 +1303,6 @@ _podman_search() {
 	--filter -f
 	--format
 	--limit
-	--registry
 	"
 	local boolean_options="
 	--no-trunc

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -15,8 +15,9 @@ podman\-search - Search a registry for an image
 
 ## DESCRIPTION
 **podman search** searches a registry or a list of registries for a matching image.
-The user can specify which registry to search by setting the **--registry** flag, default
-is the default registries set in the config file - **/etc/containers/registries.conf**.
+The user can specify which registry to search by prefixing the registry in the search term
+(example **registry.fedoraproject.org/fedora**), default is the registries in the
+**registires.search** table in the config file - **/etc/containers/registries.conf**.
 The number of results can be limited using the **--limit** flag. If more than one registry
 is being searched, the limit will be applied to each registry. The output can be filtered
 using the **--filter** flag.
@@ -70,10 +71,6 @@ The order of the search results is the order in which the API endpoint returns t
 
 Do not truncate the output
 
-**--registry**
-
-Specific registry to search (only the given registry will be searched, not the default registries)
-
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
@@ -104,7 +101,7 @@ docker.io   docker.io/tenstartups/alpine                     Alpine linux base d
 ```
 
 ```
-# podman search --registry registry.fedoraproject.org fedora
+# podman search registry.fedoraproject.org/fedora
 INDEX               NAME                               DESCRIPTION   STARS   OFFICIAL   AUTOMATED
 fedoraproject.org   fedoraproject.org/fedora                         0
 fedoraproject.org   fedoraproject.org/fedora-minimal                 0
@@ -117,7 +114,7 @@ docker.io   docker.io/library/alpine   A minimal Docker image based on Alpine Li
 ```
 
 ```
-# podman search --registry registry.fedoraproject.org --format "table {{.Index}} {{.Name}}" fedora
+# podman search --format "table {{.Index}} {{.Name}}" registry.fedoraproject.org/fedora
 INDEX               NAME
 fedoraproject.org   fedoraproject.org/fedora
 fedoraproject.org   fedoraproject.org/fedora-minimal

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -58,8 +58,8 @@ var _ = Describe("Podman search", func() {
 		Expect(search.LineInOutputContains("docker.io/library/alpine")).To(BeTrue())
 	})
 
-	It("podman search registry flag", func() {
-		search := podmanTest.Podman([]string{"search", "--registry", "registry.fedoraproject.org", "fedora-minimal"})
+	It("podman search single registry flag", func() {
+		search := podmanTest.Podman([]string{"search", "registry.fedoraproject.org/fedora-minimal"})
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Equal(0))
 		Expect(search.LineInOutputContains("fedoraproject.org/fedora-minimal")).To(BeTrue())
@@ -128,7 +128,7 @@ var _ = Describe("Podman search", func() {
 			Skip("Can not start docker registry.")
 		}
 
-		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "fake/image:andtag", "--tls-verify=false"})
+		search := podmanTest.Podman([]string{"search", "localhost:5000/fake/image:andtag", "--tls-verify=false"})
 		search.WaitWithDefaultTimeout()
 
 		// if this test succeeded, there will be no output (there is no entry named fake/image:andtag in an empty registry)
@@ -150,7 +150,7 @@ var _ = Describe("Podman search", func() {
 		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
-		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "my-alpine", "--tls-verify=false"})
+		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine", "--tls-verify=false"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -176,7 +176,7 @@ var _ = Describe("Podman search", func() {
 		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
 		ioutil.WriteFile(outfile, regFileBytes, 0644)
 
-		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "my-alpine"})
+		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -206,7 +206,7 @@ var _ = Describe("Podman search", func() {
 		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
 		ioutil.WriteFile(outfile, regFileBytes, 0644)
 
-		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "my-alpine", "--tls-verify=true"})
+		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine", "--tls-verify=true"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -236,7 +236,7 @@ var _ = Describe("Podman search", func() {
 		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
 		ioutil.WriteFile(outfile, regFileBytes, 0644)
 
-		search := podmanTest.Podman([]string{"search", "--registry", "localhost:5000", "my-alpine"})
+		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Instead of setting the --registry flag to search a single registry,
prefix the registry before the image name in the input, an example is
`podman search registry.fedoraproject.org/fedora` and this will search for
the fedora image in only registry.fedoraproject.org.

Fixes https://github.com/projectatomic/libpod/issues/977

Signed-off-by: umohnani8 <umohnani@redhat.com>