### PR TITLE
conmon no longer writes to syslog

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -280,6 +280,12 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string) (er
 	if r.noPivot {
 		args = append(args, "--no-pivot")
 	}
+
+	if logrus.GetLevel() == logrus.DebugLevel {
+		logrus.Debug("%s messages will be logged to syslog", r.conmonPath)
+		args = append(args, "--syslog")
+	}
+
 	logrus.WithFields(logrus.Fields{
 		"args": args,
 	}).Debugf("running conmon: %s", r.conmonPath)

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -323,7 +323,7 @@ func (i *LibpodAPI) RestartContainer(call ioprojectatomicpodman.VarlinkCall, nam
 // KillContainer kills a running container.  If you want to use the default SIGTERM signal, just send a -1
 // for the signal arg.
 func (i *LibpodAPI) KillContainer(call ioprojectatomicpodman.VarlinkCall, name string, signal int64) error {
-	var killSignal uint = uint(syscall.SIGTERM)
+	killSignal := uint(syscall.SIGTERM)
 	if signal != -1 {
 		killSignal = uint(signal)
 	}


### PR DESCRIPTION
If the caller sets up the app to be in logrus.DebugLevel,
then we will add the --syslog flag to conmon to get all of the
messages.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>