### PR TITLE
travis: bump go to 1.9.x and 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,19 +29,19 @@ jobs:
       script:
         - make gofmt
         - make lint
-      go: 1.9.x
+      go: 1.10.x
     - script:
         - make testunit
-      go: 1.8.x
+      go: 1.9.x
     - stage: Build and Verify
       script:
         - make testunit
-      go: 1.9.x
+      go: 1.10.x
     - stage: Integration Test
       script:
         - make all
         - make integration
-      go: 1.8.x
+      go: 1.9.x
 
 notifications:
   irc: "chat.freenode.net#podman"


### PR DESCRIPTION
Update the used go versions from 1.8.x to 1.9.x and 1.9.x to 1.10.x.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>