### PR TITLE
On success start prints UUID or container name that user inputs

### DIFF
--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -129,7 +129,7 @@ func startCmd(c *cli.Context) error {
 			lastError = errors.Wrapf(err, "unable to start container %q", container)
 			continue
 		}
-		fmt.Println(ctr.ID())
+		fmt.Println(container)
 	}
 
 	return lastError


### PR DESCRIPTION
Start now matches docker functionality

Fixes: #1017 

Signed-off-by: haircommander <pehunt@redhat.com>