### PR TITLE
Refactor podman/utils with a single container start and attach function

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -75,7 +75,7 @@ func attachCmd(c *cli.Context) error {
 		inputStream = nil
 	}
 
-	if err := attachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys"), c.BoolT("sig-proxy")); err != nil {
+	if err := startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.String("detach-keys"), c.BoolT("sig-proxy"), false); err != nil {
 		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 	}
 

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -194,7 +194,7 @@ func runCmd(c *cli.Context) error {
 		}
 	}
 
-	if err := startAttachCtr(ctr, outputStream, errorStream, inputStream, c.String("detach-keys"), c.BoolT("sig-proxy")); err != nil {
+	if err := startAttachCtr(ctr, outputStream, errorStream, inputStream, c.String("detach-keys"), c.BoolT("sig-proxy"), true); err != nil {
 		// This means the command did not exist
 		exitCode = 127
 		if strings.Index(err.Error(), "permission denied") > -1 {


### PR DESCRIPTION
Use a single function startAttachCtr() to handle both container start with attach and attach to running containers, as the code handling the attach is common for the 2 use cases.

