### PR TITLE
libpod/container_internal: Rename cleanupCgroups to cleanupResourceLimits

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -832,18 +832,12 @@ func (c *Container) cleanup() error {
 		lastError = err
 	}
 
-	if err := c.cleanupCgroups(); err != nil {
-		/*
-			if lastError != nil {
-				logrus.Errorf("Error cleaning up container %s CGroups: %v", c.ID(), err)
-			} else {
-				lastError = err
-			}
-		*/
-		// For now we are going to only warn on failures to clean up cgroups
-		// We have a conflict with running podman containers cleanup in same cgroup as container
-		logrus.Warnf("Ignoring Error cleaning up container %s CGroups: %v", c.ID(), err)
-
+	if err := c.cleanupResourceLimits(); err != nil {
+		if lastError != nil {
+			logrus.Errorf("Error cleaning up container %s resource limits: %v", c.ID(), err)
+		} else {
+			lastError = err
+		}
 	}
 
 	// Unmount storage

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -26,7 +26,7 @@ import (
 
 // cleanupCgroup cleans up residual CGroups after container execution
 // This is a no-op for the systemd cgroup driver
-func (c *Container) cleanupCgroups() error {
+func (c *Container) cleanupResourceLimits() error {
 	if !c.state.CgroupCreated {
 		logrus.Debugf("Cgroups are not present, ignoring...")
 		return nil
@@ -53,7 +53,10 @@ func (c *Container) cleanupCgroups() error {
 	}
 
 	if err := cgroup.Delete(); err != nil {
-		return err
+		// For now we are going to only warn on failures to clean up cgroups
+		// We have a conflict with running podman containers cleanup in same cgroup as container
+		logrus.Warnf("Ignoring Error cleaning up container %s CGroups: %v", c.ID(), err)
+		return nil
 	}
 
 	c.state.CgroupCreated = false

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -8,7 +8,7 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (c *Container) cleanupCgroups() error {
+func (c *Container) cleanupResourceLimits() error {
 	return ErrOSNotSupported
 }
 


### PR DESCRIPTION
This was recently split over OSes in b2df0dd1 (changes to allow for darwin compilation, 2018-06-20, #1015).  But cleanupCgroups is never going to implemented outside of Linux.  This commit switches to an OS-agnostic name that may eventually be implemented for the other OSes.

Spun off from [here][1].  I'll rebase once #1015 is cherry-picked into master.

[1]: https://github.com/projectatomic/libpod/pull/1015#discussion_r198647744