### PR TITLE
contrib/python/test/test_tunnel: Fix -nNT -> -nNTq

### DIFF
--- a/contrib/python/test/test_tunnel.py
+++ b/contrib/python/test/test_tunnel.py
@@ -66,7 +66,7 @@ class TestTunnel(unittest.TestCase):
 
         cmd = [
             'ssh',
-            '-nNT',
+            '-nNTq',
             '-L',
             '{}:{}'.format(context.local_socket, context.remote_socket),
             '-i',


### PR DESCRIPTION
Catching the tests up with 60427ab3 (#986) to avoid non-fatal smoketest failures [like][1]:

```
  ======================================================================
  FAIL: test_tunnel (test.test_tunnel.TestTunnel)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/usr/lib64/python3.6/unittest/mock.py", line 1179, in patched
      return func(*args, **keywargs)
    File "/go/src/github.com/projectatomic/libpod/contrib/python/test/test_tunnel.py", line 79, in test_tunnel
      mock_Popen.assert_called_once_with(cmd, close_fds=True)
    File "/usr/lib64/python3.6/unittest/mock.py", line 825, in assert_called_once_with
      return self.assert_called_with(*args, **kwargs)
    File "/usr/lib64/python3.6/unittest/mock.py", line 814, in assert_called_with
      raise AssertionError(_error_message()) from cause
  AssertionError: Expected call: Popen(['ssh', '-nNT', '-L', '/tmp/user/socket:/run/podman/socket', '-i', '~/.ssh/id_rsa', 'ssh://user@hostname'], close_fds=True)
  Actual call: Popen(['ssh', '-nNTq', '-L', '/tmp/user/socket:/run/podman/socket', '-i', '~/.ssh/id_rsa', 'ssh://user@hostname'], close_fds=True)
```

Maybe these Python tests should be fatal to protect against this sort of thing in the future?  As it stands there are a number of Python failures (including this one) which make it hard to find the fatal errors when the smoketest CI finds one.

[1]: https://s3.amazonaws.com/aos-ci/ghprb/projectatomic/libpod/0d792d5c92900ebd07c75bc3c0cb11753319682e.1.1529764423989739036/output.log