### PR TITLE
rootless: fix issues that prevented podman rootess to work with XDG_RUNTIME_DIR unset

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -425,7 +425,10 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container) error {
 	// Store old state so we know if we were already stopped
 	oldState := ctr.state.State
 
-	out, err := exec.Command(r.path, "state", ctr.ID()).CombinedOutput()
+	cmd := exec.Command(r.path, "state", ctr.ID())
+	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", GetRootlessRuntimeDir()))
+
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "does not exist") {
 			ctr.removeConmonFiles()
@@ -654,7 +657,7 @@ func (r *OCIRuntime) execContainer(c *Container, cmd, capAdd, env []string, tty 
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
 	execCmd.Stdin = os.Stdin
-
+	execCmd.Env = append(execCmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", GetRootlessRuntimeDir()))
 	return execCmd, nil
 }
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -217,6 +217,14 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 		if _, err := os.Stat(configPath); err != nil {
 			foundConfig = false
 		}
+
+		// containers/image uses XDG_RUNTIME_DIR to locate the auth file.
+		// So make sure the env variable is set.
+		err = os.Setenv("XDG_RUNTIME_DIR", GetRootlessRuntimeDir())
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot set XDG_RUNTIME_DIR")
+		}
+
 	} else if _, err := os.Stat(OverrideConfigPath); err == nil {
 		// Use the override configuration path
 		configPath = OverrideConfigPath

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	gosignal "os/signal"
 	"runtime"
+	"strconv"
 	"syscall"
 
 	"github.com/containers/storage/pkg/idtools"
@@ -24,6 +25,16 @@ import "C"
 // IsRootless tells us if we are running in rootless mode
 func IsRootless() bool {
 	return os.Getuid() != 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != ""
+}
+
+// GetRootlessUID returns the UID of the user in the parent userNS
+func GetRootlessUID() int {
+	uidEnv := os.Getenv("_LIBPOD_ROOTLESS_UID")
+	if uidEnv != "" {
+		u, _ := strconv.Atoi(uidEnv)
+		return u
+	}
+	return os.Getuid()
 }
 
 // BecomeRootInUserNS re-exec podman in a new userNS


### PR DESCRIPTION
Fix several issues that prevented podman rootless to work when `XDG_RUNTIME_DIR` is not set.

Also, add `/run/user/$UID` to the paths to lookup, this should help to prevent a DB mismatch on Fedora if for any reason `XDG_RUNTIME_DIR` is not set,