### PR TITLE
add darwin ci compilation test

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -66,3 +66,40 @@ tests:
     - CONTAINER_RUNTIME="podman" sh .papr_prepare.sh
 required: false
 context: "Fedora fedora/28/cloud Podman"
+
+---
+
+container:
+    image: registry.fedoraproject.org/fedora:28
+
+packages:
+    - btrfs-progs-devel
+    - bzip2
+    - device-mapper-devel
+    - findutils
+    - git
+    - glib2-devel
+    - gnupg
+    - golang
+    - libassuan-devel
+    - make
+    - ostree-devel
+    - skopeo-containers
+    - golang-github-cpuguy83-go-md2man
+
+required: true
+pulls: true
+
+env:
+    GOPATH: /go
+    GOSRC: /go/src/github.com/projectatomic
+
+tests:
+    - mkdir -p $GOSRC && ln -s /var/tmp/checkout $GOSRC/libpod
+    - cd $GOSRC/libpod && make darwin
+    - cd $GOSRC/libpod && make install.tools && GOOS=darwin GOPATH=/go make validate
+
+artifacts:
+    - test-suite.log
+
+context: "darwin CI"

--- a/libpod/finished_32.go
+++ b/libpod/finished_32.go
@@ -1,4 +1,4 @@
-// +build arm 386
+// +build arm,386,linux
 
 package libpod
 

--- a/libpod/finished_unsupported.go
+++ b/libpod/finished_unsupported.go
@@ -1,4 +1,4 @@
-// +build darwin,!linux
+// +build !linux
 
 package libpod
 


### PR DESCRIPTION
add a CI task that compiles libpod for a darwin target. it also checks gofmt
as well because that isn't run for non-linux platforms.

also addressed a review comment from wking on build tags that was not gotten
on the previous PR.

Signed-off-by: baude <bbaude@redhat.com>