### PR TITLE
Remove per-container CGroup parents

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -162,9 +162,6 @@ type containerState struct {
 	// the path of the file on disk outside the container
 	BindMounts map[string]string `json:"bindMounts,omitempty"`
 
-	// CgroupCreated indicates that the container has created a cgroup
-	CgroupCreated bool `json:"cgroupCreated,omitempty"`
-
 	// UserNSRoot is the directory used as root for the container when using
 	// user namespaces.
 	UserNSRoot string `json:"userNSRoot,omitempty"`
@@ -871,7 +868,7 @@ func (c *Container) NamespacePath(ns LinuxNS) (string, error) {
 func (c *Container) CGroupPath() (string, error) {
 	switch c.runtime.config.CgroupManager {
 	case CgroupfsCgroupsManager:
-		return filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-%s", c.ID()), "ctr"), nil
+		return filepath.Join(c.config.CgroupParent, fmt.Sprintf("libpod-%s", c.ID())), nil
 	case SystemdCgroupsManager:
 		return filepath.Join(c.config.CgroupParent, createUnitName("libpod", c.ID())), nil
 	default:

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -325,7 +325,6 @@ func resetState(state *containerState) error {
 	state.Interfaces = nil
 	state.Routes = nil
 	state.BindMounts = make(map[string]string)
-	state.CgroupCreated = false
 
 	return nil
 }
@@ -561,7 +560,6 @@ func (c *Container) init(ctx context.Context) error {
 	logrus.Debugf("Created container %s in OCI runtime", c.ID())
 
 	c.state.State = ContainerStateCreated
-	c.state.CgroupCreated = true
 
 	if err := c.save(); err != nil {
 		return err
@@ -830,20 +828,6 @@ func (c *Container) cleanup() error {
 	// Clean up network namespace, if present
 	if err := c.cleanupNetwork(); err != nil {
 		lastError = err
-	}
-
-	if err := c.cleanupCgroups(); err != nil {
-		/*
-			if lastError != nil {
-				logrus.Errorf("Error cleaning up container %s CGroups: %v", c.ID(), err)
-			} else {
-				lastError = err
-			}
-		*/
-		// For now we are going to only warn on failures to clean up cgroups
-		// We have a conflict with running podman containers cleanup in same cgroup as container
-		logrus.Warnf("Ignoring Error cleaning up container %s CGroups: %v", c.ID(), err)
-
 	}
 
 	// Unmount storage

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -8,10 +8,6 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (c *Container) cleanupCgroups() error {
-	return ErrOSNotSupported
-}
-
 func (c *Container) mountSHM(shmOptions string) error {
 	return ErrNotImplemented
 }

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -28,7 +28,7 @@ func (r *OCIRuntime) moveConmonToCgroup(ctr *Container, cgroupParent string, cmd
 				logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
 			}
 		} else {
-			cgroupPath := filepath.Join(ctr.config.CgroupParent, fmt.Sprintf("libpod-%s", ctr.ID()), "conmon")
+			cgroupPath := filepath.Join(ctr.config.CgroupParent, "conmon")
 			control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cgroupPath), &spec.LinuxResources{})
 			if err != nil {
 				logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)


### PR DESCRIPTION
Originally, it seemed like a good idea to place Conmon and the container it managed under a shared CGroup, so we could manage the two together. It's become increasingly clear that this is a
potential performance sore point, gains us little practical benefit in managing Conmon, and adds extra steps to container cleanup that interfere with Conmon postrun hooks.

Revert back to a shared CGroup for conmon processes under the CGroup parent. This will retain per-pod conmon CGroups as well if the pod is set to create a CGroup and act as CGroup parent for
its containers.

I think this may obsolete #820 (minus making systemd the default) and it will certainly obsolete #1032 