### PR TITLE
podman rmi should only untag image if parent of another

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/storage"
+	"github.com/sirupsen/logrus"
+
 	"github.com/docker/go-units"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -259,12 +260,16 @@ func sortImagesOutput(sortBy string, imagesOutput imagesSorted) imagesSorted {
 }
 
 // getImagesTemplateOutput returns the images information to be printed in human readable format
-func getImagesTemplateOutput(ctx context.Context, runtime *libpod.Runtime, images []*image.Image, opts imagesOptions, storageLayers []storage.Layer) (imagesOutput imagesSorted) {
+func getImagesTemplateOutput(ctx context.Context, runtime *libpod.Runtime, images []*image.Image, opts imagesOptions) (imagesOutput imagesSorted) {
 	for _, img := range images {
 		// If all is false and the image doesn't have a name, check to see if the top layer of the image is a parent
 		// to another image's top layer. If it is, then it is an intermediate image so don't print out if the --all flag
 		// is not set.
-		if !opts.all && len(img.Names()) == 0 && !layerIsLeaf(storageLayers, img.TopLayer()) {
+		isParent, err := img.IsParent()
+		if err != nil {
+			logrus.Errorf("error checking if image is a parent %q: %v", img.ID(), err)
+		}
+		if !opts.all && len(img.Names()) == 0 && isParent {
 			continue
 		}
 		createdTime := img.Created()
@@ -325,17 +330,13 @@ func generateImagesOutput(ctx context.Context, runtime *libpod.Runtime, images [
 		return nil
 	}
 	var out formats.Writer
-	storageLayers, err := runtime.GetLayers()
-	if err != nil {
-		return errors.Wrap(err, "error getting layers from store")
-	}
 
 	switch opts.format {
 	case formats.JSONString:
 		imagesOutput := getImagesJSONOutput(ctx, runtime, images)
 		out = formats.JSONStructArray{Output: imagesToGeneric([]imagesTemplateParams{}, imagesOutput)}
 	default:
-		imagesOutput := getImagesTemplateOutput(ctx, runtime, images, opts, storageLayers)
+		imagesOutput := getImagesTemplateOutput(ctx, runtime, images, opts)
 		out = formats.StdoutTemplateArray{Output: imagesToGeneric(imagesOutput, []imagesJSONParams{}), Template: opts.outputformat, Fields: imagesOutput[0].HeaderMap()}
 	}
 	return formats.Writer(out).Out()
@@ -390,15 +391,4 @@ func CreateFilterFuncs(ctx context.Context, r *libpod.Runtime, c *cli.Context, i
 		filterFuncs = append(filterFuncs, image.OutputImageFilter(img))
 	}
 	return filterFuncs, nil
-}
-
-// layerIsLeaf goes through the layers in the store and checks if "layer" is
-// the parent of any other layer in store.
-func layerIsLeaf(storageLayers []storage.Layer, layer string) bool {
-	for _, storeLayer := range storageLayers {
-		if storeLayer.Parent == layer {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
podman rmi was deleting an image even if it was a parent of
another image. This fix just untags the image instead.
This also fixes podman rmi to remove intermediate images of
an image when the image is removed.

Fixes https://github.com/projectatomic/libpod/issues/992

Signed-off-by: umohnani8 <umohnani@redhat.com>