### PR TITLE
Mask /proc/keys to protect information leak about keys on host

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -287,6 +287,7 @@ func blockAccessToKernelFilesystems(config *CreateConfig, g *generate.Generator)
 		for _, mp := range []string{
 			"/proc/acpi",
 			"/proc/kcore",
+			"/proc/keys",
 			"/proc/latency_stats",
 			"/proc/timer_list",
 			"/proc/timer_stats",


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>