### PR TITLE
rootless: fix when argv[0] is not an absolute path

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -112,7 +112,7 @@ reexec_in_user_namespace(int ready)
       setresuid (0, 0, 0) < 0)
     _exit (1);
 
-  execv (argv[0], argv);
+  execvp (argv[0], argv);
 
   _exit (1);
 }


### PR DESCRIPTION
use execvp instead of exec so that we keep the PATH environment
variable and the lookup for the "podman" executable works.

Closes: https://github.com/projectatomic/libpod/issues/1070

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>