### PR TITLE
rootless: fix usage on Fedora Silverblue/CoreOS

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -24,7 +24,11 @@ func GetRuntime(c *cli.Context) (*libpod.Runtime, error) {
 func GetRootlessStorageOpts() (storage.StoreOptions, error) {
 	var opts storage.StoreOptions
 
-	opts.RunRoot = filepath.Join(libpod.GetRootlessRuntimeDir(), "run")
+	rootlessRuntime, err := libpod.GetRootlessRuntimeDir()
+	if err != nil {
+		return opts, err
+	}
+	opts.RunRoot = filepath.Join(rootlessRuntime, "run")
 
 	dataDir := os.Getenv("XDG_DATA_HOME")
 	if dataDir == "" {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -27,13 +27,13 @@ func main() {
 	debug := false
 	cpuProfile := false
 
-	became, err := rootless.BecomeRootInUserNS()
+	became, ret, err := rootless.BecomeRootInUserNS()
 	if err != nil {
 		logrus.Errorf(err.Error())
 		os.Exit(1)
 	}
 	if became {
-		os.Exit(0)
+		os.Exit(ret)
 	}
 
 	if reexec.Init() {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -691,18 +690,6 @@ func (r *Runtime) generateName() (string, error) {
 		return name, nil
 	}
 	// The code should never reach here.
-}
-
-// SaveDefaultConfig saves a copy of the default config at the given path
-func SaveDefaultConfig(path string) error {
-	var w bytes.Buffer
-	e := toml.NewEncoder(&w)
-
-	if err := e.Encode(&defaultRuntimeConfig); err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(path, w.Bytes(), 0644)
 }
 
 // ImageRuntime returns the imageruntime for image resolution

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -105,16 +105,16 @@ reexec_in_user_namespace(int ready)
     ret = read (ready, &b, 1) < 0;
   while (ret < 0 && errno == EINTR);
   if (ret < 0)
-    _exit (1);
+    _exit (EXIT_FAILURE);
   close (ready);
 
   if (setresgid (0, 0, 0) < 0 ||
       setresuid (0, 0, 0) < 0)
-    _exit (1);
+    _exit (EXIT_FAILURE);
 
   execvp (argv[0], argv);
 
-  _exit (1);
+  _exit (EXIT_FAILURE);
 }
 
 int

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -13,8 +13,8 @@ func IsRootless() bool {
 
 // BecomeRootInUserNS is a stub function that always returns false and an
 // error on unsupported OS's
-func BecomeRootInUserNS() (bool, error) {
-	return false, errors.New("this function is not supported on this os")
+func BecomeRootInUserNS() (bool, int, error) {
+	return false, -1, errors.New("this function is not supported on this os")
 }
 
 // GetRootlessUID returns the UID of the user in the parent userNS


### PR DESCRIPTION
here the home directory is a symlink to `/var/home` and runc does like symlinks into the rootfs path.

Resolve the path to the storage before using it.

As part of the PR, also fix the code propagation from the re-exec'ed podman.