### PR TITLE
fix pull image that includes a sha

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -960,3 +960,9 @@ func (i *Image) Comment(ctx context.Context, manifestType string) (string, error
 	}
 	return ociv1Img.History[0].Comment, nil
 }
+
+// HasShaInInputName returns a bool as to whether the user provide an image name that includes
+// a reference to a specific sha
+func (i *Image) HasShaInInputName() bool {
+	return strings.Contains(i.InputName, "@sha256:")
+}

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containers/image/docker/reference"
 )
@@ -33,6 +34,9 @@ func decompose(input string) (imageParts, error) {
 	}
 	if !isTagged {
 		tag = "latest"
+		if strings.Contains(input, "@sha256:") {
+			tag = "none"
+		}
 	} else {
 		tag = ntag.Tag()
 	}

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Podman pull", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "alpine:latest"})
+		session = podmanTest.Podman([]string{"rmi", "alpine:none"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})


### PR DESCRIPTION
when pulling an image that includes a sha such as:

centos/nginx-112-centos7@sha256:42330f7f29ba1ad67819f4ff3ae2472f62de13a827a74736a5098728462212e7

the final image name in libpod should not contain portions of the sha itself nor the sha
identifier.  and like docker, we provide a 'none' tag as well.

this should fix #877

Signed-off-by: baude <bbaude@redhat.com>