### PR TITLE
Fix Exit Status handling in podman run and start.

### DIFF
--- a/cmd/podman/sigproxy.go
+++ b/cmd/podman/sigproxy.go
@@ -25,6 +25,8 @@ func ProxySignals(ctr *libpod.Container) {
 
 			if err := ctr.Kill(uint(s.(syscall.Signal))); err != nil {
 				logrus.Errorf("Error forwarding signal %d to container %s: %v", s, ctr.ID(), err)
+				signal.StopCatch(sigBuffer)
+				syscall.Kill(syscall.Getpid(), s.(syscall.Signal))
 			}
 		}
 	}()

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -114,7 +114,7 @@ func startCmd(c *cli.Context) error {
 				return errors.Wrapf(err, "unable to start container %s", ctr.ID())
 			}
 
-			if ecode, err := ctr.ExitCode(); err != nil {
+			if ecode, err := ctr.Wait(); err != nil {
 				logrus.Errorf("unable to get exit code of container %s: %q", ctr.ID(), err)
 			} else {
 				exitCode = int(ecode)


### PR DESCRIPTION
We need to wait for the conmon process to exit before collecting the exit status.