### PR TITLE
container exit code should default to 125

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -48,6 +48,11 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		hostnamePath = getPath
 	}
 
+	exitCode := int32(0)
+	if runtimeInfo.State == ContainerStateStopped {
+		exitCode = runtimeInfo.ExitCode
+	}
+
 	data := &inspect.ContainerInspectData{
 		ID:      config.ID,
 		Created: config.CreatedTime,
@@ -61,7 +66,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 			OOMKilled:  runtimeInfo.OOMKilled,
 			Dead:       runtimeInfo.State.String() == "bad state",
 			Pid:        runtimeInfo.PID,
-			ExitCode:   runtimeInfo.ExitCode,
+			ExitCode:   exitCode,
 			Error:      "", // can't get yet
 			StartedAt:  runtimeInfo.StartedTime,
 			FinishedAt: runtimeInfo.FinishedTime,

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -183,6 +183,8 @@ func newContainer(rspec *spec.Spec, lockDir string) (*Container, error) {
 	ctr := new(Container)
 	ctr.config = new(ContainerConfig)
 	ctr.state = new(containerState)
+	// Exit Code 125 indicates exit code was never set.
+	ctr.state.ExitCode = 125
 
 	ctr.config.ID = stringid.GenerateNonCryptoID()
 


### PR DESCRIPTION
We should only report the exit code in inspect if the container
has exited, otherwise it is not really defined.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>