### PR TITLE
Record whether the container has exited

### DIFF
--- a/cmd/podman/batchcontainer/container.go
+++ b/cmd/podman/batchcontainer/container.go
@@ -38,6 +38,7 @@ type BatchContainerStruct struct {
 	ConConfig          *libpod.ContainerConfig
 	ConState           libpod.ContainerStatus
 	ExitCode           int32
+	Exited             bool
 	Pid                int
 	RootFsSize, RwSize int64
 	StartedTime        time.Time
@@ -63,6 +64,7 @@ func BatchContainerOp(ctr *libpod.Container, opts PsOptions) (BatchContainerStru
 		conState           libpod.ContainerStatus
 		err                error
 		exitCode           int32
+		exited             bool
 		pid                int
 		rootFsSize, rwSize int64
 		startedTime        time.Time
@@ -75,7 +77,7 @@ func BatchContainerOp(ctr *libpod.Container, opts PsOptions) (BatchContainerStru
 			return errors.Wrapf(err, "unable to obtain container state")
 		}
 
-		exitCode, _, err = c.ExitCode()
+		exitCode, exited, err = c.ExitCode()
 		if err != nil {
 			return errors.Wrapf(err, "unable to obtain container exit code")
 		}
@@ -115,6 +117,7 @@ func BatchContainerOp(ctr *libpod.Container, opts PsOptions) (BatchContainerStru
 		ConConfig:   conConfig,
 		ConState:    conState,
 		ExitCode:    exitCode,
+		Exited:      exited,
 		Pid:         pid,
 		RootFsSize:  rootFsSize,
 		RwSize:      rwSize,

--- a/cmd/podman/batchcontainer/container.go
+++ b/cmd/podman/batchcontainer/container.go
@@ -75,7 +75,7 @@ func BatchContainerOp(ctr *libpod.Container, opts PsOptions) (BatchContainerStru
 			return errors.Wrapf(err, "unable to obtain container state")
 		}
 
-		exitCode, err = c.ExitCode()
+		exitCode, _, err = c.ExitCode()
 		if err != nil {
 			return errors.Wrapf(err, "unable to obtain container exit code")
 		}

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -324,8 +324,8 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			return nil, errors.Wrapf(err, "exited code out of range %q", filterValue)
 		}
 		return func(c *libpod.Container) bool {
-			ec, _, err := c.ExitCode()
-			if ec == int32(exitCode) && err == nil {
+			ec, exited, err := c.ExitCode()
+			if ec == int32(exitCode) && err == nil && exited == true {
 				return true
 			}
 			return false

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -282,22 +282,16 @@ func checkFlagsPassed(c *cli.Context) error {
 	if c.Int("last") >= 0 && c.Bool("latest") {
 		return errors.Errorf("last and latest are mutually exclusive")
 	}
-	// quiet, size, namespace, and format with Go template are mutually exclusive
-	flags := 0
+	// Quiet conflicts with size, namespace, and format with a Go template
 	if c.Bool("quiet") {
-		flags++
+		if c.Bool("size") || c.Bool("namespace") || (c.IsSet("format") &&
+			c.String("format") != formats.JSONString) {
+			return errors.Errorf("quiet conflicts with size, namespace, and format with go template")
+		}
 	}
-	if c.Bool("size") {
-		flags++
-	}
-	if c.Bool("namespace") {
-		flags++
-	}
-	if c.IsSet("format") && c.String("format") != formats.JSONString {
-		flags++
-	}
-	if flags > 1 {
-		return errors.Errorf("quiet, size, namespace, and format with Go template are mutually exclusive")
+	// Size and namespace conflict with each other
+	if c.Bool("size") && c.Bool("namespace") {
+		return errors.Errorf("size and namespace options conflict")
 	}
 	return nil
 }

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -324,7 +324,7 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			return nil, errors.Wrapf(err, "exited code out of range %q", filterValue)
 		}
 		return func(c *libpod.Container) bool {
-			ec, err := c.ExitCode()
+			ec, _, err := c.ExitCode()
 			if ec == int32(exitCode) && err == nil {
 				return true
 			}

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -58,6 +58,7 @@ type psJSONParams struct {
 	Command          []string                  `json:"command"`
 	CreatedAt        time.Time                 `json:"createdAt"`
 	ExitCode         int32                     `json:"exitCode"`
+	Exited           bool                      `json:"exited"`
 	RunningFor       time.Duration             `json:"runningFor"`
 	Status           string                    `json:"status"`
 	PID              int                       `json:"PID"`
@@ -576,22 +577,26 @@ func getAndSortJSONParams(containers []*libpod.Container, opts batchcontainer.Ps
 			ns = batchcontainer.GetNamespaces(batchInfo.Pid)
 		}
 		params := psJSONParams{
-			ID:         ctr.ID(),
-			Image:      batchInfo.ConConfig.RootfsImageName,
-			ImageID:    batchInfo.ConConfig.RootfsImageID,
-			Command:    batchInfo.ConConfig.Spec.Process.Args,
-			CreatedAt:  batchInfo.ConConfig.CreatedTime,
-			Status:     batchInfo.ConState.String(),
-			Ports:      batchInfo.ConConfig.PortMappings,
-			RootFsSize: batchInfo.RootFsSize,
-			RWSize:     batchInfo.RwSize,
-			Names:      batchInfo.ConConfig.Name,
-			Labels:     batchInfo.ConConfig.Labels,
-			Mounts:     batchInfo.ConConfig.UserVolumes,
-			Namespaces: ns,
+			ID:               ctr.ID(),
+			Image:            batchInfo.ConConfig.RootfsImageName,
+			ImageID:          batchInfo.ConConfig.RootfsImageID,
+			Command:          batchInfo.ConConfig.Spec.Process.Args,
+			CreatedAt:        batchInfo.ConConfig.CreatedTime,
+			ExitCode:         batchInfo.ExitCode,
+			Exited:           batchInfo.Exited,
+			Status:           batchInfo.ConState.String(),
+			PID:              batchInfo.Pid,
+			Ports:            batchInfo.ConConfig.PortMappings,
+			RootFsSize:       batchInfo.RootFsSize,
+			RWSize:           batchInfo.RwSize,
+			Names:            batchInfo.ConConfig.Name,
+			Labels:           batchInfo.ConConfig.Labels,
+			Mounts:           batchInfo.ConConfig.UserVolumes,
+			ContainerRunning: batchInfo.ConState == libpod.ContainerStateRunning,
+			Namespaces:       ns,
 		}
 
-		if !batchInfo.StartedTime.IsZero() {
+		if !batchInfo.StartedTime.IsZero() && batchInfo.ConState == libpod.ContainerStateRunning {
 			params.RunningFor = time.Since(batchInfo.StartedTime)
 		}
 

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -63,8 +63,8 @@ type psJSONParams struct {
 	Status           string                    `json:"status"`
 	PID              int                       `json:"PID"`
 	Ports            []ocicni.PortMapping      `json:"ports"`
-	RootFsSize       int64                     `json:"rootFsSize"`
-	RWSize           int64                     `json:"rwSize"`
+	RootFsSize       int64                     `json:"rootFsSize,omitempty"`
+	RWSize           int64                     `json:"rwSize,omitempty"`
 	Names            string                    `json:"names"`
 	Labels           fields.Set                `json:"labels"`
 	Mounts           []string                  `json:"mounts"`

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -586,6 +586,8 @@ func (c *Container) reinit(ctx context.Context) error {
 	// Set and save now to make sure that, if the init() below fails
 	// we still have a valid state
 	c.state.State = ContainerStateConfigured
+	c.state.ExitCode = 0
+	c.state.Exited = false
 	if err := c.save(); err != nil {
 		return err
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -450,6 +450,7 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container) error {
 			ctr.state.OOMKilled = true
 		}
 
+		ctr.state.Exited = true
 	}
 
 	return nil

--- a/pkg/varlinkapi/util.go
+++ b/pkg/varlinkapi/util.go
@@ -65,13 +65,15 @@ func makeListContainer(containerID string, batchInfo batchcontainer.BatchContain
 		Runningfor:       time.Since(batchInfo.ConConfig.CreatedTime).String(),
 		Status:           batchInfo.ConState.String(),
 		Ports:            ports,
-		Rootfssize:       batchInfo.RootFsSize,
-		Rwsize:           batchInfo.RwSize,
 		Names:            batchInfo.ConConfig.Name,
 		Labels:           batchInfo.ConConfig.Labels,
 		Mounts:           mounts,
 		Containerrunning: batchInfo.ConState == libpod.ContainerStateRunning,
 		Namespaces:       namespace,
+	}
+	if batchInfo.Size != nil {
+		lc.Rootfssize = batchInfo.Size.RootFsSize
+		lc.Rwsize = batchInfo.Size.RwSize
 	}
 	return lc
 }

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -201,12 +201,15 @@ var _ = Describe("Podman ps", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"ps", "-a", "--sort=size", "--format", "{{.Size}}"})
+		session = podmanTest.Podman([]string{"ps", "-a", "-s", "--sort=size", "--format", "{{.Size}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		sortedArr := session.OutputToStringArray()
 
+		// TODO: This may be broken - the test was running without the
+		// ability to perform any sorting for months and succeeded
+		// without error.
 		Expect(sort.SliceIsSorted(sortedArr, func(i, j int) bool {
 			r := regexp.MustCompile(`^\S+\s+\(virtual (\S+)\)`)
 			matches1 := r.FindStringSubmatch(sortedArr[i])


### PR DESCRIPTION
Use this to supplement exit codes returned from containers, to make sure we know when exit codes are invalid (as the container has not yet exited)