### PR TITLE
rootless: unshare mount namespace

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -92,7 +92,7 @@ reexec_in_user_namespace(int ready)
 
   sprintf (uid, "%d", geteuid ());
 
-  pid = syscall_clone (CLONE_NEWUSER|SIGCHLD, NULL);
+  pid = syscall_clone (CLONE_NEWUSER|CLONE_NEWNS|SIGCHLD, NULL);
   if (pid)
     return pid;
 


### PR DESCRIPTION
unshare the mount namespace as well when creating an user namespace so
that we are the owner of the mount namespace and we can mount FUSE
file systems on Linux 4.18.  Tested on Fedora Rawhide:

podman --storage-opt overlay.fuse_program=/usr/bin/fuse-overlayfs run alpine echo hello
hello

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>