### PR TITLE
rootless: require subids to be present

### DIFF
--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -158,6 +158,8 @@ Podman can also be used as non-root user.  When podman runs in rootless mode, an
 
 Containers created by a non-root user are not visible to other users and are not seen or managed by podman running as root.
 
+It is required to have multiple uids/gids set for an user.  Be sure the user is present in the files `/etc/subuid` and `/etc/subgid`.
+
 Images are pulled under `XDG_DATA_HOME` when specified, otherwise in the home directory of the user under `.local/share/containers/storage`.
 
 Currently it is not possible to create a network device, so rootless containers need to run in the host network namespace.  If a rootless container creates a network namespace,

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -104,6 +104,9 @@ func BecomeRootInUserNS() (bool, int, error) {
 	var uids, gids []idtools.IDMap
 	username := os.Getenv("USER")
 	mappings, err := idtools.NewIDMappings(username, username)
+	if err != nil && os.Getenv("PODMAN_ALLOW_SINGLE_ID_MAPPING_IN_USERNS") == "" {
+		return false, -1, err
+	}
 	if err == nil {
 		uids = mappings.UIDs()
 		gids = mappings.GIDs()

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Podman rootless", func() {
 			env := os.Environ()
 			env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
 			env = append(env, fmt.Sprintf("HOME=%s", home))
+			env = append(env, "PODMAN_ALLOW_SINGLE_ID_MAPPING_IN_USERNS=1")
 			cmd := podmanTest.PodmanAsUser([]string{"run", "--rootfs", mountPath, "echo", "hello"}, 1000, 1000, env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())


### PR DESCRIPTION
Most images won't work without multiple ids/gids.  Error out
immediately if there are no multiple ids available.

The error code when the user is not present in /etc/sub{g,u}ids looks
like:

$ bin/podman run --rm -ti alpine echo hello
ERRO[0000] No subuid ranges found for user "gscrivano"

Closes: https://github.com/projectatomic/libpod/issues/1087

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>