### PR TITLE
oci: keep exposed ports busy and leak the fd into conmon

### DIFF
--- a/Dockerfile.CentOS
+++ b/Dockerfile.CentOS
@@ -23,6 +23,7 @@ RUN yum -y install btrfs-progs-devel \
               python3-dateutil \
               which\
               golang-github-cpuguy83-go-md2man \
+              nmap-ncat \
               iptables && yum clean all
 
 # Install CNI plugins

--- a/Dockerfile.Fedora
+++ b/Dockerfile.Fedora
@@ -25,6 +25,7 @@ RUN dnf -y install btrfs-progs-devel \
               which\
               golang-github-cpuguy83-go-md2man \
               procps-ng \
+              nmap-ncat \
               iptables && dnf clean all
 
 # Install CNI plugins

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -65,6 +65,10 @@ var _ = Describe("Podman rmi", func() {
 		results.Wait(30)
 		Expect(results.ExitCode()).To(Equal(0))
 		Expect(results.OutputToString()).To(ContainSubstring("8000"))
+
+		ncBusy := podmanTest.SystemExec("nc", []string{"-l", "-p", "80"})
+		ncBusy.Wait(10)
+		Expect(ncBusy.ExitCode()).ToNot(Equal(0))
 	})
 
 	It("podman run network expose ports in image metadata", func() {


### PR DESCRIPTION
Bind all the specified TCP and UDP ports so that another process
cannot reuse them.  The fd of the listener is then leaked into conmon
so that the socket is kept busy until the container exits.

Closes: https://github.com/projectatomic/libpod/issues/210

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>