### PR TITLE
Podman load/tag/save prepends localhost when no registry is present

### DIFF
--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -170,12 +170,12 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	// foo should resolve to foo:latest
 	repoTag, err := newImage.MatchRepoTag("foo")
 	assert.NoError(t, err)
-	assert.Equal(t, "foo:latest", repoTag)
+	assert.Equal(t, "localhost/foo:latest", repoTag)
 
 	// foo:bar should resolve to foo:bar
 	repoTag, err = newImage.MatchRepoTag("foo:bar")
 	assert.NoError(t, err)
-	assert.Equal(t, "foo:bar", repoTag)
+	assert.Equal(t, "localhost/foo:bar", repoTag)
 	// Shutdown the runtime and remove the temporary storage
 	cleanup(workdir, ir)
 }

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -46,6 +46,9 @@ var (
 	AtomicTransport = "atomic"
 	// DefaultTransport is a prefix that we apply to an image name
 	DefaultTransport = DockerTransport
+	// DefaultLocalRepo is the default local repository for local image operations
+	// Remote pulls will still use defined registries
+	DefaultLocalRepo = "localhost"
 )
 
 type pullStruct struct {
@@ -56,6 +59,14 @@ type pullStruct struct {
 }
 
 func (ir *Runtime) getPullStruct(srcRef types.ImageReference, destName string) (*pullStruct, error) {
+	imgPart, err := decompose(destName)
+	if err == nil && !imgPart.hasRegistry {
+		// If the image doesn't have a registry, set it as the default repo
+		imgPart.registry = DefaultLocalRepo
+		imgPart.hasRegistry = true
+		destName = imgPart.assemble()
+	}
+
 	reference := destName
 	if srcRef.DockerReference() != nil {
 		reference = srcRef.DockerReference().String()
@@ -149,7 +160,9 @@ func (ir *Runtime) getPullListFromRef(ctx context.Context, srcRef types.ImageRef
 		image := splitArr[1]
 		// remove leading "/"
 		if image[:1] == "/" {
-			image = image[1:]
+			// Instead of removing the leading /, set localhost as the registry
+			// so docker.io isn't prepended, and the path becomes the repository
+			image = DefaultLocalRepo + image
 		}
 		pullInfo, err := ir.getPullStruct(srcRef, image)
 		if err != nil {

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Podman tag", func() {
 		Expect(results.ExitCode()).To(Equal(0))
 		inspectData := results.InspectImageJSON()
 		Expect(StringInSlice("docker.io/library/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
-		Expect(StringInSlice("foobar:latest", inspectData[0].RepoTags)).To(BeTrue())
+		Expect(StringInSlice("localhost/foobar:latest", inspectData[0].RepoTags)).To(BeTrue())
 	})
 
 	It("podman tag shortname", func() {
@@ -51,7 +51,7 @@ var _ = Describe("Podman tag", func() {
 		Expect(results.ExitCode()).To(Equal(0))
 		inspectData := results.InspectImageJSON()
 		Expect(StringInSlice("docker.io/library/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
-		Expect(StringInSlice("foobar:latest", inspectData[0].RepoTags)).To(BeTrue())
+		Expect(StringInSlice("localhost/foobar:latest", inspectData[0].RepoTags)).To(BeTrue())
 	})
 
 	It("podman tag shortname:tag", func() {
@@ -64,7 +64,7 @@ var _ = Describe("Podman tag", func() {
 		Expect(results.ExitCode()).To(Equal(0))
 		inspectData := results.InspectImageJSON()
 		Expect(StringInSlice("docker.io/library/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
-		Expect(StringInSlice("foobar:new", inspectData[0].RepoTags)).To(BeTrue())
+		Expect(StringInSlice("localhost/foobar:new", inspectData[0].RepoTags)).To(BeTrue())
 	})
 
 	It("podman tag shortname image no tag", func() {


### PR DESCRIPTION
Instead of having docker.io/library as its repository. 

The image was being pulled with no registry, and docker code threw in the docker.io/library.
This change didn't mess with any of the e2e tests.

Signed-off-by: haircommander <pehunt@redhat.com>