### PR TITLE
Let containers/storage keep track of mounts

### DIFF
--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -58,7 +58,7 @@ func umountCmd(c *cli.Context) error {
 				continue
 			}
 
-			if err = unmountContainer(ctr); err != nil {
+			if err = ctr.Unmount(); err != nil {
 				if lastError != nil {
 					logrus.Error(lastError)
 				}
@@ -78,7 +78,7 @@ func umountCmd(c *cli.Context) error {
 				continue
 			}
 
-			if err = unmountContainer(ctr); err != nil {
+			if err = ctr.Unmount(); err != nil {
 				if lastError != nil {
 					logrus.Error(lastError)
 				}
@@ -89,13 +89,4 @@ func umountCmd(c *cli.Context) error {
 		}
 	}
 	return lastError
-}
-
-func unmountContainer(ctr *libpod.Container) error {
-	if mounted, err := ctr.Mounted(); mounted {
-		return ctr.Unmount()
-	} else {
-		return err
-	}
-	return errors.Errorf("container is not mounted")
 }

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -248,6 +248,21 @@ func (r *storageService) UnmountContainerImage(idOrName string) (bool, error) {
 	return mounted, nil
 }
 
+func (r *storageService) MountedContainerImage(idOrName string) (int, error) {
+	if idOrName == "" {
+		return 0, ErrEmptyID
+	}
+	container, err := r.store.Container(idOrName)
+	if err != nil {
+		return 0, err
+	}
+	mounted, err := r.store.Mounted(container.ID)
+	if err != nil {
+		return 0, err
+	}
+	return mounted, nil
+}
+
 func (r *storageService) GetWorkDir(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {


### PR DESCRIPTION
Currently we unmount storage that is still in use.
We should not be unmounting storeage that we mounted
via a different command or by podman mount.  This
change relies on containers/storage to umount keep track of
how many times the storage was mounted before really unmounting
it from the system.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>