### PR TITLE
RFC: Naming refactor and tests

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1074,9 +1074,3 @@ func (i *Image) Comment(ctx context.Context, manifestType string) (string, error
 	}
 	return ociv1Img.History[0].Comment, nil
 }
-
-// HasShaInInputName returns a bool as to whether the user provide an image name that includes
-// a reference to a specific sha
-func (i *Image) HasShaInInputName() bool {
-	return strings.Contains(i.InputName, "@sha256:")
-}

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -28,10 +28,7 @@ func decompose(input string) (imageParts, error) {
 	if err != nil {
 		return parts, err
 	}
-	ntag, isTagged, err := getTags(input)
-	if err != nil {
-		return parts, err
-	}
+	ntag, isTagged := imgRef.(reference.NamedTagged)
 	if !isTagged {
 		tag = "latest"
 		if strings.Contains(input, "@sha256:") {

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/containers/image/docker/reference"
 )
@@ -31,7 +30,7 @@ func decompose(input string) (imageParts, error) {
 	ntag, isTagged := imgRef.(reference.NamedTagged)
 	if !isTagged {
 		tag = "latest"
-		if strings.Contains(input, "@sha256:") {
+		if _, hasDigest := imgRef.(reference.Digested); hasDigest {
 			tag = "none"
 		}
 	} else {

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -1,0 +1,69 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecompose(t *testing.T) {
+	const digestSuffix = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	for _, c := range []struct {
+		input                          string
+		transport, registry, name, tag string
+		isTagged, hasRegistry          bool
+		assembled                      string
+		assembledWithTransport         string
+	}{
+		{"#", "", "", "", "", false, false, "", ""}, // Entirely invalid input
+		{ // Fully qualified docker.io, name-only input
+			"docker.io/library/busybox", "docker://", "docker.io", "library/busybox", "latest", false, true,
+			"docker.io/library/busybox:latest", "docker://docker.io/library/busybox:latest",
+		},
+		{ // Fully qualified example.com, name-only input
+			"example.com/ns/busybox", "docker://", "example.com", "ns/busybox", "latest", false, true,
+			"example.com/ns/busybox:latest", "docker://example.com/ns/busybox:latest",
+		},
+		{ // Unqualified single-name input
+			"busybox", "docker://", "", "busybox", "latest", false, false,
+			// FIXME? The [empty]/busybox syntax is surprising.
+			"/busybox:latest", "docker:///busybox:latest",
+		},
+		{ // Unqualified namespaced input
+			// FIXME: .registry == "ns" !!
+			"ns/busybox", "docker://", "ns", "busybox", "latest", false, true,
+			"ns/busybox:latest", "docker://ns/busybox:latest",
+		},
+		{ // name:tag
+			"example.com/ns/busybox:notlatest", "docker://", "example.com", "ns/busybox", "notlatest", true, true,
+			"example.com/ns/busybox:notlatest", "docker://example.com/ns/busybox:notlatest",
+		},
+		{ // name@digest
+			// FIXME? .tag == "none"
+			"example.com/ns/busybox" + digestSuffix, "docker://", "example.com", "ns/busybox", "none", false, true,
+			// FIXME: this drops the digest and replaces it with an incorrect tag.
+			"example.com/ns/busybox:none", "docker://example.com/ns/busybox:none",
+		},
+		{ // name:tag@digest
+			"example.com/ns/busybox:notlatest" + digestSuffix, "docker://", "example.com", "ns/busybox", "notlatest", true, true,
+			// FIXME: This drops the digest
+			"example.com/ns/busybox:notlatest", "docker://example.com/ns/busybox:notlatest",
+		},
+	} {
+		parts, err := decompose(c.input)
+		if c.transport == "" {
+			assert.Error(t, err, c.input)
+		} else {
+			assert.NoError(t, err, c.input)
+			assert.Equal(t, c.transport, parts.transport, c.input)
+			assert.Equal(t, c.registry, parts.registry, c.input)
+			assert.Equal(t, c.name, parts.name, c.input)
+			assert.Equal(t, c.tag, parts.tag, c.input)
+			assert.Equal(t, c.isTagged, parts.isTagged, c.input)
+			assert.Equal(t, c.hasRegistry, parts.hasRegistry, c.input)
+			assert.Equal(t, c.assembled, parts.assemble(), c.input)
+			assert.Equal(t, c.assembledWithTransport, parts.assembleWithTransport(), c.input)
+		}
+	}
+}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -324,17 +324,17 @@ func (i *Image) createNamesToPull() ([]*pullRefPair, error) {
 }
 
 // pullRefPairsFromNames converts a []*pullRefName to []*pullRefPair
-func (ir *Runtime) pullRefPairsFromRefNames(pullNames []*pullRefName) ([]*pullRefPair, error) {
+func (ir *Runtime) pullRefPairsFromRefNames(refNames []*pullRefName) ([]*pullRefPair, error) {
 	// Here we construct the destination references
-	res := make([]*pullRefPair, len(pullNames))
-	for j, pStruct := range pullNames {
-		destRef, err := is.Transport.ParseStoreReference(ir.store, pStruct.dstName)
+	res := make([]*pullRefPair, len(refNames))
+	for i, rn := range refNames {
+		destRef, err := is.Transport.ParseStoreReference(ir.store, rn.dstName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error parsing dest reference name")
 		}
-		res[j] = &pullRefPair{
-			image:  pStruct.image,
-			srcRef: pStruct.srcRef,
+		res[i] = &pullRefPair{
+			image:  rn.image,
+			srcRef: rn.srcRef,
 			dstRef: destRef,
 		}
 	}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -195,7 +195,7 @@ func (i *Image) pullImage(ctx context.Context, writer io.Writer, authfile, signa
 	srcRef, err := alltransports.ParseImageName(i.InputName)
 	if err != nil {
 		// could be trying to pull from registry with short name
-		pullRefPairs, err = i.createNamesToPull()
+		pullRefPairs, err = i.refPairsFromPossiblyUnqualifiedName()
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting default registries to try")
 		}
@@ -264,9 +264,9 @@ func (i *Image) pullImage(ctx context.Context, writer io.Writer, authfile, signa
 	return images, nil
 }
 
-// createNamesToPull looks at a decomposed image and determines the possible
-// images names to try pulling in combination with the registries.conf file as well
-func (i *Image) createNamesToPull() ([]*pullRefPair, error) {
+// refNamesFromPossiblyUnqualifiedName looks at a decomposed image and determines the possible
+// image names to try pulling in combination with the registries.conf file as well
+func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
 	var (
 		pullNames []*pullRefName
 		imageName string
@@ -320,7 +320,17 @@ func (i *Image) createNamesToPull() ([]*pullRefPair, error) {
 			pullNames = append(pullNames, &ps)
 		}
 	}
-	return i.imageruntime.pullRefPairsFromRefNames(pullNames)
+	return pullNames, nil
+}
+
+// refPairsFromPossiblyUnqualifiedName looks at a decomposed image and determines the possible
+// image references to try pulling in combination with the registries.conf file as well
+func (i *Image) refPairsFromPossiblyUnqualifiedName() ([]*pullRefPair, error) {
+	refNames, err := i.refNamesFromPossiblyUnqualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	return i.imageruntime.pullRefPairsFromRefNames(refNames)
 }
 
 // pullRefPairsFromNames converts a []*pullRefName to []*pullRefPair

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -272,31 +272,31 @@ func hasShaInInputName(inputName string) bool {
 
 // refNamesFromPossiblyUnqualifiedName looks at a decomposed image and determines the possible
 // image names to try pulling in combination with the registries.conf file as well
-func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
+func refNamesFromPossiblyUnqualifiedName(inputName string) ([]*pullRefName, error) {
 	var (
 		pullNames []*pullRefName
 		imageName string
 	)
 
-	decomposedImage, err := decompose(i.InputName)
+	decomposedImage, err := decompose(inputName)
 	if err != nil {
 		return nil, err
 	}
 	if decomposedImage.hasRegistry {
-		if hasShaInInputName(i.InputName) {
-			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, i.InputName)
+		if hasShaInInputName(inputName) {
+			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, inputName)
 		} else {
 			imageName = decomposedImage.assembleWithTransport()
 		}
 		srcRef, err := alltransports.ParseImageName(imageName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to parse '%s'", i.InputName)
+			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}
 		ps := pullRefName{
-			image:  i.InputName,
+			image:  inputName,
 			srcRef: srcRef,
 		}
-		if hasShaInInputName(i.InputName) {
+		if hasShaInInputName(inputName) {
 			ps.dstName = decomposedImage.assemble()
 		} else {
 			ps.dstName = ps.image
@@ -311,12 +311,12 @@ func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
 		for _, registry := range searchRegistries {
 			decomposedImage.registry = registry
 			imageName := decomposedImage.assembleWithTransport()
-			if hasShaInInputName(i.InputName) {
-				imageName = fmt.Sprintf("%s%s/%s", decomposedImage.transport, registry, i.InputName)
+			if hasShaInInputName(inputName) {
+				imageName = fmt.Sprintf("%s%s/%s", decomposedImage.transport, registry, inputName)
 			}
 			srcRef, err := alltransports.ParseImageName(imageName)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to parse '%s'", i.InputName)
+				return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 			}
 			ps := pullRefName{
 				image:  decomposedImage.assemble(),
@@ -332,7 +332,7 @@ func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
 // refPairsFromPossiblyUnqualifiedName looks at a decomposed image and determines the possible
 // image references to try pulling in combination with the registries.conf file as well
 func (i *Image) refPairsFromPossiblyUnqualifiedName() ([]*pullRefPair, error) {
-	refNames, err := i.refNamesFromPossiblyUnqualifiedName()
+	refNames, err := refNamesFromPossiblyUnqualifiedName(i.InputName)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -326,13 +326,3 @@ func (i *Image) createNamesToPull() ([]*pullStruct, error) {
 
 	return pullNames, nil
 }
-
-// isShortName returns a bool response if the input image name has a registry
-// name in it or not
-func (i *Image) isShortName() (bool, error) {
-	decomposedImage, err := decompose(i.InputName)
-	if err != nil {
-		return false, err
-	}
-	return decomposedImage.hasRegistry, nil
-}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -320,11 +320,15 @@ func (i *Image) createNamesToPull() ([]*pullRefPair, error) {
 			pullNames = append(pullNames, &ps)
 		}
 	}
+	return i.imageruntime.pullRefPairsFromRefNames(pullNames)
+}
 
+// pullRefPairsFromNames converts a []*pullRefName to []*pullRefPair
+func (ir *Runtime) pullRefPairsFromRefNames(pullNames []*pullRefName) ([]*pullRefPair, error) {
 	// Here we construct the destination references
 	res := make([]*pullRefPair, len(pullNames))
 	for j, pStruct := range pullNames {
-		destRef, err := is.Transport.ParseStoreReference(i.imageruntime.store, pStruct.dstName)
+		destRef, err := is.Transport.ParseStoreReference(ir.store, pStruct.dstName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error parsing dest reference name")
 		}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -264,6 +264,12 @@ func (i *Image) pullImage(ctx context.Context, writer io.Writer, authfile, signa
 	return images, nil
 }
 
+// hasShaInInputName returns a bool as to whether the user provided an image name that includes
+// a reference to a specific sha
+func hasShaInInputName(inputName string) bool {
+	return strings.Contains(inputName, "@sha256:")
+}
+
 // refNamesFromPossiblyUnqualifiedName looks at a decomposed image and determines the possible
 // image names to try pulling in combination with the registries.conf file as well
 func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
@@ -277,7 +283,7 @@ func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
 		return nil, err
 	}
 	if decomposedImage.hasRegistry {
-		if i.HasShaInInputName() {
+		if hasShaInInputName(i.InputName) {
 			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, i.InputName)
 		} else {
 			imageName = decomposedImage.assembleWithTransport()
@@ -290,7 +296,7 @@ func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
 			image:  i.InputName,
 			srcRef: srcRef,
 		}
-		if i.HasShaInInputName() {
+		if hasShaInInputName(i.InputName) {
 			ps.dstName = decomposedImage.assemble()
 		} else {
 			ps.dstName = ps.image
@@ -305,7 +311,7 @@ func (i *Image) refNamesFromPossiblyUnqualifiedName() ([]*pullRefName, error) {
 		for _, registry := range searchRegistries {
 			decomposedImage.registry = registry
 			imageName := decomposedImage.assembleWithTransport()
-			if i.HasShaInInputName() {
+			if hasShaInInputName(i.InputName) {
 				imageName = fmt.Sprintf("%s%s/%s", decomposedImage.transport, registry, i.InputName)
 			}
 			srcRef, err := alltransports.ParseImageName(imageName)

--- a/libpod/image/pull_test.go
+++ b/libpod/image/pull_test.go
@@ -1,0 +1,125 @@
+package image
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/image/transports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const registriesConfWithSearch = `[registries.search]
+registries = ['example.com', 'docker.io']
+`
+
+func TestRefNamesFromPossiblyUnqualifiedName(t *testing.T) {
+	const digestSuffix = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	type pullRefStrings struct{ image, srcRef, dstName string } // pullRefName with string data only
+
+	registriesConf, err := ioutil.TempFile("", "TestRefNamesFromPossiblyUnqualifiedName")
+	require.NoError(t, err)
+	defer registriesConf.Close()
+	defer os.Remove(registriesConf.Name())
+
+	err = ioutil.WriteFile(registriesConf.Name(), []byte(registriesConfWithSearch), 0600)
+	require.NoError(t, err)
+
+	// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
+	// run in parallel unless they opt in by calling t.Parallel().  So don’t do that.
+	oldRCP, hasRCP := os.LookupEnv("REGISTRIES_CONFIG_PATH")
+	defer func() {
+		if hasRCP {
+			os.Setenv("REGISTRIES_CONFIG_PATH", oldRCP)
+		} else {
+			os.Unsetenv("REGISTRIES_CONFIG_PATH")
+		}
+	}()
+	os.Setenv("REGISTRIES_CONFIG_PATH", registriesConf.Name())
+
+	for _, c := range []struct {
+		input    string
+		expected []pullRefStrings
+	}{
+		{"#", nil}, // Clearly invalid.
+		{ // Fully-explicit docker.io, name-only.
+			"docker.io/library/busybox",
+			// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
+			[]pullRefStrings{{"docker.io/library/busybox", "docker://busybox:latest", "docker.io/library/busybox"}},
+		},
+		{ // docker.io with implied /library/, name-only.
+			"docker.io/busybox",
+			// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
+			// The .dstName fields differ for the explicit/implicit /library/ cases, but StorageTransport.ParseStoreReference normalizes that.
+			[]pullRefStrings{{"docker.io/busybox", "docker://busybox:latest", "docker.io/busybox"}},
+		},
+		{ // Qualified example.com, name-only.
+			"example.com/ns/busybox",
+			[]pullRefStrings{{"example.com/ns/busybox", "docker://example.com/ns/busybox:latest", "example.com/ns/busybox"}},
+		},
+		{ // Qualified example.com, name:tag.
+			"example.com/ns/busybox:notlatest",
+			[]pullRefStrings{{"example.com/ns/busybox:notlatest", "docker://example.com/ns/busybox:notlatest", "example.com/ns/busybox:notlatest"}},
+		},
+		{ // Qualified example.com, name@digest.
+			"example.com/ns/busybox" + digestSuffix,
+			[]pullRefStrings{{"example.com/ns/busybox" + digestSuffix, "docker://example.com/ns/busybox" + digestSuffix,
+				// FIXME?! Why is .dstName dropping the digest, and adding :none?!
+				"example.com/ns/busybox:none"}},
+		},
+		// Qualified example.com, name:tag@digest.  This code is happy to try, but .srcRef parsing currently rejects such input.
+		{"example.com/ns/busybox:notlatest" + digestSuffix, nil},
+		{ // Unqualified, single-name, name-only
+			"busybox",
+			[]pullRefStrings{
+				{"example.com/busybox:latest", "docker://example.com/busybox:latest", "example.com/busybox:latest"},
+				// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
+				{"docker.io/busybox:latest", "docker://busybox:latest", "docker.io/busybox:latest"},
+			},
+		},
+		{ // Unqualified, namespaced, name-only
+			"ns/busybox",
+			// FIXME: This is interpreted as "registry == ns", and actual pull happens from docker.io/ns/busybox:latest;
+			// example.com should be first in the list but isn't used at all.
+			[]pullRefStrings{
+				{"ns/busybox", "docker://ns/busybox:latest", "ns/busybox"},
+			},
+		},
+		{ // Unqualified, name:tag
+			"busybox:notlatest",
+			[]pullRefStrings{
+				{"example.com/busybox:notlatest", "docker://example.com/busybox:notlatest", "example.com/busybox:notlatest"},
+				// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
+				{"docker.io/busybox:notlatest", "docker://busybox:notlatest", "docker.io/busybox:notlatest"},
+			},
+		},
+		{ // Unqualified, name@digest
+			"busybox" + digestSuffix,
+			[]pullRefStrings{
+				// FIXME?! Why is .input and .dstName dropping the digest, and adding :none?!
+				{"example.com/busybox:none", "docker://example.com/busybox" + digestSuffix, "example.com/busybox:none"},
+				// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
+				{"docker.io/busybox:none", "docker://busybox" + digestSuffix, "docker.io/busybox:none"},
+			},
+		},
+		// Unqualified, name:tag@digest. This code is happy to try, but .srcRef parsing currently rejects such input.
+		{"busybox:notlatest" + digestSuffix, nil},
+	} {
+		res, err := refNamesFromPossiblyUnqualifiedName(c.input)
+		if len(c.expected) == 0 {
+			assert.Error(t, err, c.input)
+		} else {
+			assert.NoError(t, err, c.input)
+			strings := make([]pullRefStrings, len(res))
+			for i, rn := range res {
+				strings[i] = pullRefStrings{
+					image:   rn.image,
+					srcRef:  transports.ImageName(rn.srcRef),
+					dstName: rn.dstName,
+				}
+			}
+			assert.Equal(t, c.expected, strings, c.input)
+		}
+	}
+}

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -12,16 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getTags(nameInput string) (reference.NamedTagged, bool, error) {
-	inputRef, err := reference.Parse(nameInput)
-	if err != nil {
-		return nil, false, errors.Wrapf(err, "unable to obtain tag from input name")
-	}
-	tagged, isTagged := inputRef.(reference.NamedTagged)
-
-	return tagged, isTagged, nil
-}
-
 // findImageInRepotags takes an imageParts struct and searches images' repotags for
 // a match on name:tag
 func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, error) {


### PR DESCRIPTION
This is motivated by the outstanding comments in #1085, but I’m really only starting to build the confidence I need to touch that code. Still, it is independent enough to perhaps be merged, and at least to gather comments about this work.

So, for now there should be exactly one functional change: supporting all kinds of digests instead of only `@sha256:` in `imageParts`. The rest is:

- renames for clarity and consistency
- splitting functions into stateless and easily-testable and the storage-dependent environment handling
- hopefully comprehensive unit tests for `imageParts`, `TagImage` input normalization, and interpreting non-_transport_`:` inputs for `pullImage`.

Please see individual commit messages for more details.

**RFC**:
- Is this wanted at all? Or should I just leave working-enough code alone, and not slow everyone down with merge conflicts? (FWIW at least some of the `FIXME` comments are real bugs.)
- Is structuring the PR as a series of small commits acceptable?
- AFAICT the outcome of #1085, apart from pulling the right image, which is clearly correct, is that pulled _name_`@sha256:`_digest_ images are named in the storage as _name_`:none` (where `none` is an actual tag string, not “missing”, and the digest not recorded). (I can now confidently refactor the code to do this inside the `imageParts` abstraction without breaking anything, but that exposes how irregular the code doing this is.) 
  - Is using the explicit `none` tag  Is that intentional? If so, why is it necessary? 
  - Is dropping the digest and not recording it in the storage intentional? If so, why is it necessary? (Looking at `Image.RepoDigests`, it forms a series of _name_`@`_digest_ values, all with the same `Image.image.Digest` value — but a single image (single image ID == config digest) can exist with multiple different manifest digests. Shouldn’t the original values be recorded when pulling, and reproduced in `RepoDigests` in `podman inspect`?)