### PR TITLE
Add Pod and Container namespaces

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -88,6 +88,10 @@ func GetRuntimeWithStorageOpts(c *cli.Context, storageOpts *storage.StoreOptions
 	// TODO CLI flags for image config?
 	// TODO CLI flag for signature policy?
 
+	if c.GlobalIsSet("namespace") {
+		options = append(options, libpod.WithNamespace(c.GlobalString("namespace")))
+	}
+
 	if c.GlobalIsSet("runtime") {
 		options = append(options, libpod.WithOCIRuntime(c.GlobalString("runtime")))
 	}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -174,7 +174,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "namespace",
-			Usage: "set the libpod namespace, used create separate views of the containers and pods on the system",
+			Usage: "set the libpod namespace, used to create separate views of the containers and pods on the system",
 			Value: "",
 		},
 		cli.StringFlag{

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -173,6 +173,11 @@ func main() {
 			Value: "error",
 		},
 		cli.StringFlag{
+			Name:  "namespace",
+			Usage: "set the libpod namespace, used create separate views of the containers and pods on the system",
+			Value: "",
+		},
+		cli.StringFlag{
 			Name:  "root",
 			Usage: "path to the root directory in which data, including images, is stored",
 		},

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2224,6 +2224,7 @@ _podman_podman() {
            --storage-driver
            --storage-opt
            --log-level
+           --namespace
     "
      local boolean_options="
            --help -h

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -39,6 +39,11 @@ Path to where the cpu performance results should be written
 
 log messages above specified level: debug, info, warn, error (default), fatal or panic
 
+**--namespace**
+
+set namespace libpod namespace. Namespaces are used to separate groups of containers and pods in libpod's state.
+When namespace is set, created containers and pods will join the given namespace, and only containers and pods in the given namespace will be visible to Podman.
+
 **--root**=**value**
 
 Path to the root directory in which data, including images, is stored

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -37,11 +37,11 @@ Path to where the cpu performance results should be written
 
 **--log-level**
 
-log messages above specified level: debug, info, warn, error (default), fatal or panic
+Log messages above specified level: debug, info, warn, error (default), fatal or panic
 
 **--namespace**
 
-set libpod namespace. Namespaces are used to separate groups of containers and pods in libpod's state.
+Set libpod namespace. Namespaces are used to separate groups of containers and pods in libpod's state.
 When namespace is set, created containers and pods will join the given namespace, and only containers and pods in the given namespace will be visible to Podman.
 
 **--root**=**value**

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -41,7 +41,7 @@ log messages above specified level: debug, info, warn, error (default), fatal or
 
 **--namespace**
 
-set namespace libpod namespace. Namespaces are used to separate groups of containers and pods in libpod's state.
+set libpod namespace. Namespaces are used to separate groups of containers and pods in libpod's state.
 When namespace is set, created containers and pods will join the given namespace, and only containers and pods in the given namespace will be visible to Podman.
 
 **--root**=**value**

--- a/libpod.conf
+++ b/libpod.conf
@@ -57,3 +57,11 @@ cni_plugin_dir = [
 	       "/usr/lib/cni",
 	       "/opt/cni/bin"
 ]
+
+# Default libpod namespace
+# If libpod is joined to a namespace, it will see only containers and pods
+# that were created in the same namespace, and will create new containers and
+# pods in that namespace.
+# The default namespace is "", which corresponds to no namespace. When no
+# namespace is set, all containers and pods are visible.
+#namespace = ""

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -443,10 +443,8 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 		return ErrCtrRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != ctr.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 	}
 
 	newState := new(containerState)
@@ -511,10 +509,8 @@ func (s *BoltState) SaveContainer(ctr *Container) error {
 		return ErrCtrRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != ctr.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 	}
 
 	stateJSON, err := json.Marshal(ctr.state)
@@ -576,10 +572,8 @@ func (s *BoltState) ContainerInUse(ctr *Container) ([]string, error) {
 		return nil, ErrCtrRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != ctr.config.Namespace {
-			return nil, errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != ctr.config.Namespace {
+		return nil, errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 	}
 
 	depCtrs := []string{}
@@ -876,10 +870,8 @@ func (s *BoltState) PodHasContainer(pod *Pod, id string) (bool, error) {
 		return false, ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return false, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return false, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	ctrID := []byte(id)
@@ -941,10 +933,8 @@ func (s *BoltState) PodContainersByID(pod *Pod) ([]string, error) {
 		return nil, ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return nil, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return nil, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1005,10 +995,8 @@ func (s *BoltState) PodContainers(pod *Pod) ([]*Container, error) {
 		return nil, ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return nil, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return nil, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1077,10 +1065,8 @@ func (s *BoltState) AddPod(pod *Pod) error {
 		return ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1203,10 +1189,8 @@ func (s *BoltState) RemovePod(pod *Pod) error {
 		return ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1301,10 +1285,8 @@ func (s *BoltState) RemovePodContainers(pod *Pod) error {
 		return ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1492,10 +1474,8 @@ func (s *BoltState) UpdatePod(pod *Pod) error {
 		return ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	newState := new(podState)
@@ -1551,10 +1531,8 @@ func (s *BoltState) SavePod(pod *Pod) error {
 		return ErrPodRemoved
 	}
 
-	if s.namespace != "" {
-		if s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
-		}
+	if s.namespace != "" && s.namespace != pod.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	stateJSON, err := json.Marshal(pod.state)

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -964,6 +964,11 @@ func (s *BoltState) AddPod(pod *Pod) error {
 	podID := []byte(pod.ID())
 	podName := []byte(pod.Name())
 
+	var podNamespace []byte
+	if pod.config.Namespace != "" {
+		podNamespace = []byte(pod.config.Namespace)
+	}
+
 	podConfigJSON, err := json.Marshal(pod.config)
 	if err != nil {
 		return errors.Wrapf(err, "error marshalling pod %s config to JSON", pod.ID())
@@ -1029,6 +1034,12 @@ func (s *BoltState) AddPod(pod *Pod) error {
 
 		if err := newPod.Put(stateKey, podStateJSON); err != nil {
 			return errors.Wrapf(err, "error storing pod %s state JSON in DB", pod.ID())
+		}
+
+		if podNamespace != nil {
+			if err := newPod.Put(namespaceKey, podNamespace); err != nil {
+				return errors.Wrapf(err, "error storing pod %s namespace in DB", pod.ID())
+			}
 		}
 
 		// Add us to the ID and names buckets

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // BoltState is a state implementation backed by a Bolt DB
@@ -28,6 +29,8 @@ func NewBoltState(path, lockDir string, runtime *Runtime) (State, error) {
 	state.runtime = runtime
 	state.namespace = ""
 	state.namespaceBytes = nil
+
+	logrus.Debugf("Initializing boltdb state at %s", path)
 
 	// Make the directory that will hold container lockfiles
 	if err := os.MkdirAll(lockDir, 0750); err != nil {
@@ -367,10 +370,10 @@ func (s *BoltState) HasContainer(id string) (bool, error) {
 			return err
 		}
 
-		ctrExists := ctrBucket.Bucket(ctrID)
-		if ctrExists != nil {
+		ctrDB := ctrBucket.Bucket(ctrID)
+		if ctrDB != nil {
 			if s.namespaceBytes != nil {
-				nsBytes := ctrBucket.Get(namespaceKey)
+				nsBytes := ctrDB.Get(namespaceKey)
 				if bytes.Equal(nsBytes, s.namespaceBytes) {
 					exists = true
 				}

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -459,7 +459,7 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 // Remove a container from the DB
 // If pod is not nil, the container is treated as belonging to a pod, and
 // will be removed from the pod as well
-func removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx, namespace string) error {
+func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error {
 	ctrID := []byte(ctr.ID())
 	ctrName := []byte(ctr.Name())
 
@@ -514,9 +514,12 @@ func removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx, namespace string) er
 
 	// Compare namespace
 	// We can't remove containers not in our namespace
-	if namespace != "" {
-		if namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, namespace)
+	if s.namespace != "" {
+		if s.namespace != ctr.config.Namespace {
+			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+		}
+		if pod != nil && s.namespace != pod.config.Namespace {
+			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q, does not match out namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 		}
 	}
 

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -266,6 +266,11 @@ func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error
 // Add a container to the DB
 // If pod is not nil, the container is added to the pod as well
 func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
+	if s.namespace != "" && s.namespace != ctr.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "cannot add container %s as it is in namespace %q and we are in namespace %q",
+			ctr.ID(), s.namespace, ctr.config.Namespace)
+	}
+
 	// JSON container structs to insert into DB
 	// TODO use a higher-performance struct encoding than JSON
 	configJSON, err := json.Marshal(ctr.config)

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -185,6 +185,8 @@ type ContainerConfig struct {
 	Name string     `json:"name"`
 	// Full ID of the pood the container belongs to
 	Pod string `json:"pod,omitempty"`
+	// Namespace the container is in
+	Namespace string `json:"namespace,omitempty"`
 
 	// TODO consider breaking these subsections up into smaller structs
 
@@ -370,6 +372,12 @@ func (c *Container) Name() string {
 // does not belong to a pod
 func (c *Container) PodID() string {
 	return c.config.Pod
+}
+
+// Namespace returns the libpod namespace the container is in.
+// Namespaces are used to logically separate containers and pods in the state.
+func (c *Container) Namespace() string {
+	return c.config.Namespace
 }
 
 // Image returns the ID and name of the image used as the container's rootfs

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -69,6 +69,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		ImageID:         config.RootfsImageID,
 		ImageName:       config.RootfsImageName,
 		ExitCommand:     config.ExitCommand,
+		Namespace:       config.Namespace,
 		Rootfs:          config.Rootfs,
 		ResolvConfPath:  resolvPath,
 		HostnamePath:    hostnamePath,

--- a/libpod/errors.go
+++ b/libpod/errors.go
@@ -63,6 +63,10 @@ var (
 	// was created by a libpod with a different config
 	ErrDBBadConfig = errors.New("database configuration mismatch")
 
+	// ErrNSMismatch indicates that the requested pod or container is in a
+	// different namespace and cannot be accessed or modified.
+	ErrNSMismatch = errors.New("target is in a different namespace")
+
 	// ErrNotImplemented indicates that the requested functionality is not
 	// yet present
 	ErrNotImplemented = errors.New("not yet implemented")

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -172,6 +172,10 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 		return errors.Wrapf(ErrInvalidArg, "cannot add a container that is in a pod with AddContainer, use AddContainerToPod")
 	}
 
+	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
+		return err
+	}
+
 	// There are potential race conditions with this
 	// But in-memory state is intended purely for testing and not production
 	// use, so this should be fine.
@@ -690,6 +694,10 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	if ctr.config.Namespace != pod.config.Namespace {
 		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
 			ctr.ID(), ctr.config.Namespace, pod.ID(), pod.config.Namespace)
+	}
+
+	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
+		return err
 	}
 
 	// Retrieve pod containers list

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -144,17 +144,11 @@ func (s *InMemoryState) HasContainer(id string) (bool, error) {
 	}
 
 	ctr, ok := s.containers[id]
-	if ok {
-		if s.namespace != "" {
-			if s.namespace != ctr.config.Namespace {
-				return false, nil
-			}
-			return true, nil
-		}
-		return true, nil
+	if !ok || (s.namespace != "" && s.namespace != ctr.config.Namespace) {
+		return false, nil
 	}
 
-	return false, nil
+	return true, nil
 }
 
 // AddContainer adds a container to the state
@@ -295,11 +289,7 @@ func (s *InMemoryState) UpdateContainer(ctr *Container) error {
 		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
 
-	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
-		return err
-	}
-
-	return nil
+	return s.checkNSMatch(ctr.ID(), ctr.Namespace())
 }
 
 // SaveContainer saves a container's state
@@ -318,11 +308,7 @@ func (s *InMemoryState) SaveContainer(ctr *Container) error {
 		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
 
-	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
-		return err
-	}
-
-	return nil
+	return s.checkNSMatch(ctr.ID(), ctr.Namespace())
 }
 
 // ContainerInUse checks if the given container is being used by other containers
@@ -441,17 +427,11 @@ func (s *InMemoryState) HasPod(id string) (bool, error) {
 	}
 
 	pod, ok := s.pods[id]
-	if ok {
-		if s.namespace != "" {
-			if s.namespace != pod.config.Namespace {
-				return false, nil
-			}
-			return true, nil
-		}
-		return true, nil
+	if !ok || (s.namespace != "" && s.namespace != pod.config.Namespace) {
+		return false, nil
 	}
 
-	return false, nil
+	return true, nil
 }
 
 // PodHasContainer checks if the given pod has a container with the given ID

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -542,6 +542,10 @@ func (s *InMemoryState) AddPod(pod *Pod) error {
 		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and cannot be added", pod.ID())
 	}
 
+	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
+		return err
+	}
+
 	if _, ok := s.pods[pod.ID()]; ok {
 		return errors.Wrapf(ErrPodExists, "pod with ID %s already exists in state", pod.ID())
 	}

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -494,6 +494,11 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 		return errors.Wrapf(ErrInvalidArg, "container %s is not in pod %s", ctr.ID(), pod.ID())
 	}
 
+	if ctr.config.Namespace != pod.config.Namespace {
+		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
+			ctr.ID(), ctr.config.Namespace, pod.ID(), pod.config.Namespace)
+	}
+
 	// Retrieve pod containers list
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -285,7 +285,6 @@ func WithCNIPluginDir(dir string) RuntimeOption {
 }
 
 // WithNamespace sets the namespace for libpod.
-// Namespace is the libpod namespace to use.
 // Namespaces are used to create scopes to separate containers and pods
 // in the state.
 // When namespace is set, libpod will only view containers and pods in

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -284,6 +284,27 @@ func WithCNIPluginDir(dir string) RuntimeOption {
 	}
 }
 
+// WithNamespace sets the namespace for libpod.
+// Namespace is the libpod namespace to use.
+// Namespaces are used to create scopes to separate containers and pods
+// in the state.
+// When namespace is set, libpod will only view containers and pods in
+// the same namespace. All containers and pods created will default to
+// the namespace set here.
+// A namespace of "", the empty string, is equivalent to no namespace,
+// and all containers and pods will be visible.
+func WithNamespace(ns string) RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return ErrRuntimeFinalized
+		}
+
+		rt.config.Namespace = ns
+
+		return nil
+	}
+}
+
 // Container Creation Options
 
 // WithShmDir sets the directory that should be mounted on /dev/shm.
@@ -963,11 +984,11 @@ func WithRootFS(rootfs string) CtrCreateOption {
 	}
 }
 
-// WithNamespace sets the namespace the container will be created in.
+// WithCtrNamespace sets the namespace the container will be created in.
 // Namespaces are used to create separate views of Podman's state - runtimes can
 // join a specific namespace and see only containers and pods in that namespace.
 // Empty string namespaces are allowed, and correspond to a lack of namespace.
-func WithNamespace(ns string) CtrCreateOption {
+func WithCtrNamespace(ns string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return ErrCtrFinalized

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -27,6 +27,8 @@ type Pod struct {
 type PodConfig struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+	// Namespace the pod is in
+	Namespace string `json:"namespace,omitempty"`
 
 	// Labels contains labels applied to the pod
 	Labels map[string]string `json:"labels"`
@@ -56,6 +58,12 @@ func (p *Pod) ID() string {
 // Name retrieves the pod's name
 func (p *Pod) Name() string {
 	return p.config.Name
+}
+
+// Namespace returns the pod's libpod namespace.
+// Namespaces are used to logically separate containers and pods in the state.
+func (p *Pod) Namespace() string {
+	return p.config.Namespace
 }
 
 // Labels returns the pod's labels

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -136,10 +136,22 @@ type RuntimeConfig struct {
 	// CNIDefaultNetwork is the network name of the default CNI network
 	// to attach pods to
 	CNIDefaultNetwork string `toml:"cni_default_network,omitempty"`
-	// HooksDirNotExistFatal switches between fatal errors and non-fatal warnings if the configured HooksDir does not exist.
+	// HooksDirNotExistFatal switches between fatal errors and non-fatal
+	// warnings if the configured HooksDir does not exist.
 	HooksDirNotExistFatal bool `toml:"hooks_dir_not_exist_fatal"`
-	// DefaultMountsFile is the path to the default mounts file for testing purposes only
+	// DefaultMountsFile is the path to the default mounts file for testing
+	// purposes only
 	DefaultMountsFile string `toml:"-"`
+	// Namespace is the libpod namespace to use.
+	// Namespaces are used to create scopes to separate containers and pods
+	// in the state.
+	// When namespace is set, libpod will only view containers and pods in
+	// the same namespace. All containers and pods created will default to
+	// the namespace set here.
+	// A namespace of "", the empty string, is equivalent to no namespace,
+	// and all containers and pods will be visible.
+	// The default namespace is "".
+	Namespace string `toml:"namespace,omitempty"`
 }
 
 var (

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -505,6 +505,11 @@ func makeRuntime(runtime *Runtime) (err error) {
 		return errors.Wrapf(ErrInvalidArg, "unrecognized state type passed")
 	}
 
+	if err := runtime.state.SetNamespace(runtime.config.Namespace); err != nil {
+		return errors.Wrapf(err, "error setting libpod namespace in state")
+	}
+	logrus.Debugf("Set libpod namespace to %q", runtime.config.Namespace)
+
 	// We now need to see if the system has restarted
 	// We check for the presence of a file in our tmp directory to verify this
 	// This check must be locked to prevent races

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -42,6 +42,12 @@ func (r *Runtime) NewContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	}
 	ctr.config.StopTimeout = CtrRemoveTimeout
 
+	// Set namespace based on current runtime namespace
+	// Do so before options run so they can override it
+	if r.config.Namespace != "" {
+		ctr.config.Namespace = r.config.Namespace
+	}
+
 	for _, option := range options {
 		if err := option(ctr); err != nil {
 			return nil, errors.Wrapf(err, "error running container create option")

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -27,6 +27,12 @@ func (r *Runtime) NewPod(options ...PodCreateOption) (*Pod, error) {
 		return nil, errors.Wrapf(err, "error creating pod")
 	}
 
+	// Set default namespace to runtime's namespace
+	// Do so before options run so they can override it
+	if r.config.Namespace != "" {
+		pod.config.Namespace = r.config.Namespace
+	}
+
 	for _, option := range options {
 		if err := option(pod); err != nil {
 			return nil, errors.Wrapf(err, "error running pod create option")

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -10,70 +10,109 @@ type State interface {
 	Refresh() error
 
 	// SetNamespace() sets the namespace for the store, and will determine
-	// what containers are retrieved with container and pod retrieval calls
+	// what containers are retrieved with container and pod retrieval calls.
+	// A namespace of "", the empty string, acts as no namespace, and
+	// containers and pods in all namespaces will be returned.
 	SetNamespace(ns string) error
 
-	// Return a container from the database from its full ID
+	// Return a container from the database from its full ID.
+	// If the container is not in the set namespace, an error will be
+	// returned.
 	Container(id string) (*Container, error)
 	// Return a container from the database by full or partial ID or full
-	// name
+	// name.
+	// Containers not in the set namespace will be ignored.
 	LookupContainer(idOrName string) (*Container, error)
-	// Check if a container with the given full ID exists in the database
+	// Check if a container with the given full ID exists in the database.
+	// If the container exists but is not in the set namespace, false will
+	// be returned.
 	HasContainer(id string) (bool, error)
-	// Adds container to state
-	// The container cannot be part of a pod
+	// Adds container to state.
+	// The container cannot be part of a pod.
 	// The container must have globally unique name and ID - pod names and
-	// IDs also conflict with container names and IDs
+	// IDs also conflict with container names and IDs.
+	// The container must be in the set namespace if a namespace has been
+	// set.
+	// All containers this container depends on must be part of the same
+	// namespace and must not be joined to a pod.
 	AddContainer(ctr *Container) error
-	// Removes container from state
-	// Containers that are part of pods must use RemoveContainerFromPod
+	// Removes container from state.
+	// Containers that are part of pods must use RemoveContainerFromPod.
+	// The container must be part of the set namespace.
 	RemoveContainer(ctr *Container) error
-	// UpdateContainer updates a container's state from the backing store
+	// UpdateContainer updates a container's state from the backing store.
+	// The container must be part of the set namespace.
 	UpdateContainer(ctr *Container) error
-	// SaveContainer saves a container's current state to the backing store
+	// SaveContainer saves a container's current state to the backing store.
+	// The container must be part of the set namespace.
 	SaveContainer(ctr *Container) error
 	// ContainerInUse checks if other containers depend upon a given
-	// container
+	// container.
 	// It returns a slice of the IDs of containers which depend on the given
 	// container. If the slice is empty, no container depend on the given
 	// container.
-	// A container cannot be removed if other containers depend on it
+	// A container cannot be removed if other containers depend on it.
+	// The container being checked must be part of the set namespace.
 	ContainerInUse(ctr *Container) ([]string, error)
-	// Retrieves all containers presently in state
+	// Retrieves all containers presently in state.
+	// If a namespace is set, only containers within the namespace will be
+	// returned.
 	AllContainers() ([]*Container, error)
 
-	// Accepts full ID of pod
+	// Accepts full ID of pod.
+	// If the pod given is not in the set namespace, an error will be
+	// returned.
 	Pod(id string) (*Pod, error)
-	// Accepts full or partial IDs (as long as they are unique) and names
+	// Accepts full or partial IDs (as long as they are unique) and names.
+	// Pods not in the set namespace are ignored.
 	LookupPod(idOrName string) (*Pod, error)
-	// Checks if a pod with the given ID is present in the state
+	// Checks if a pod with the given ID is present in the state.
+	// If the given pod is not in the set namespace, false is returned.
 	HasPod(id string) (bool, error)
-	// Check if a pod has a container with the given ID
+	// Check if a pod has a container with the given ID.
+	// The pod must be part of the set namespace.
 	PodHasContainer(pod *Pod, ctrID string) (bool, error)
-	// Get the IDs of all containers in a pod
+	// Get the IDs of all containers in a pod.
+	// The pod must be part of the set namespace.
 	PodContainersByID(pod *Pod) ([]string, error)
-	// Get all the containers in a pod
+	// Get all the containers in a pod.
+	// The pod must be part of the set namespace.
 	PodContainers(pod *Pod) ([]*Container, error)
-	// Adds pod to state
+	// Adds pod to state.
+	// The pod must be part of the set namespace.
+	// The pod's name and ID must be globally unique.
 	AddPod(pod *Pod) error
-	// Removes pod from state
-	// Only empty pods can be removed from the state
+	// Removes pod from state.
+	// Only empty pods can be removed from the state.
+	// The pod must be part of the set namespace.
 	RemovePod(pod *Pod) error
-	// Remove all containers from a pod
+	// Remove all containers from a pod.
 	// Used to simultaneously remove containers that might otherwise have
-	// dependency issues
-	// Will fail if a dependency outside the pod is encountered
+	// dependency issues.
+	// Will fail if a dependency outside the pod is encountered.
+	// The pod must be part of the set namespace.
 	RemovePodContainers(pod *Pod) error
-	// AddContainerToPod adds a container to an existing pod
-	// The container given will be added to the state and the pod
+	// AddContainerToPod adds a container to an existing pod.
+	// The container given will be added to the state and the pod.
+	// The container and its dependencies must be part of the given pod,
+	// and the given pod's namespace.
+	// The pod must be part of the set namespace.
+	// The pod must already exist in the state.
+	// The container's name and ID must be globally unique.
 	AddContainerToPod(pod *Pod, ctr *Container) error
-	// RemoveContainerFromPod removes a container from an existing pod
-	// The container will also be removed from the state
+	// RemoveContainerFromPod removes a container from an existing pod.
+	// The container will also be removed from the state.
+	// The container must be in the given pod, and the pod must be in the
+	// set namespace.
 	RemoveContainerFromPod(pod *Pod, ctr *Container) error
-	// UpdatePod updates a pod's state from the database
+	// UpdatePod updates a pod's state from the database.
+	// The pod must be in the set namespace.
 	UpdatePod(pod *Pod) error
-	// SavePod saves a pod's state to the database
+	// SavePod saves a pod's state to the database.
+	// The pod must be in the set namespace.
 	SavePod(pod *Pod) error
-	// Retrieves all pods presently in state
+	// Retrieves all pods presently in state.
+	// If a namespace has been set, only pods in that namespace will be
+	// returned.
 	AllPods() ([]*Pod, error)
 }

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -9,6 +9,10 @@ type State interface {
 	// Refresh clears container and pod states after a reboot
 	Refresh() error
 
+	// SetNamespace() sets the namespace for the store, and will determine
+	// what containers are retrieved with container and pod retrieval calls
+	SetNamespace(ns string) error
+
 	// Return a container from the database from its full ID
 	Container(id string) (*Container, error)
 	// Return a container from the database by full or partial ID or full

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -1790,6 +1790,47 @@ func TestAddPodCtrNameConflictFails(t *testing.T) {
 	})
 }
 
+func TestAddPodSameNamespaceSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod.config.Namespace = "test1"
+
+		state.SetNamespace("test1")
+
+		err = state.AddPod(testPod)
+		assert.NoError(t, err)
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(allPods))
+
+		testPodsEqual(t, testPod, allPods[0])
+		assert.Equal(t, testPod.valid, allPods[0].valid)
+	})
+}
+
+func TestAddPodDifferentNamespaceFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testPod, err := getTestPod1(lockPath)
+		assert.NoError(t, err)
+
+		testPod.config.Namespace = "test1"
+
+		state.SetNamespace("test2")
+
+		err = state.AddPod(testPod)
+		assert.Error(t, err)
+
+		state.SetNamespace("")
+
+		allPods, err := state.AllPods()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(allPods))
+	})
+}
+
 func TestRemovePodInvalidPodErrors(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
 		err := state.RemovePod(&Pod{config: &PodConfig{}})

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -634,6 +634,15 @@ func TestContainerInUseInvalidContainer(t *testing.T) {
 	})
 }
 
+func TestContainerInUseCtrNotInState(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
+		testCtr, err := getTestCtr1(lockPath)
+		assert.NoError(t, err)
+		_, err := state.ContainerInUse(testCtr)
+		assert.Error(t, err)
+	})
+}
+
 func TestContainerInUseOneContainer(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, lockPath string) {
 		testCtr1, err := getTestCtr1(lockPath)

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -169,6 +169,7 @@ type ContainerInspectData struct {
 	Dependencies    []string               `json:"Dependencies"`
 	NetworkSettings *NetworkSettings       `json:"NetworkSettings"` //TODO
 	ExitCommand     []string               `json:"ExitCommand"`
+	Namespace       string                 `json:"Namespace"`
 }
 
 // ContainerInspectState represents the state of a container.

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -1,0 +1,51 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman namespaces", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+
+	})
+
+	It("podman namespace test", func() {
+		podman1 := podmanTest.Podman([]string{"--namespace", "test1", "run", "-d", ALPINE, "echo", "hello"})
+		podman1.WaitWithDefaultTimeout()
+		Expect(podman1.ExitCode()).To(Equal(0))
+
+		podman2 := podmanTest.Podman([]string{"--namespace", "test2", "ps", "-aq"})
+		podman2.WaitWithDefaultTimeout()
+		Expect(podman2.ExitCode()).To(Equal(0))
+		output := podman2.OutputToStringArray()
+		numCtrs := 0
+		for _, outputLine := range output {
+			if outputLine != "" {
+				numCtrs = numCtrs + 1
+			}
+		}
+		Expect(numCtrs).To(Equal(0))
+
+		numberOfCtrsNoNamespace := podmanTest.NumberOfContainers()
+		Expect(numberOfCtrsNoNamespace).To(Equal(1))
+	})
+})


### PR DESCRIPTION
The latest monster of a PR I've worked up. Sorry to reviewers for the size...

This adds the concept of namespaces to libpod. A namespace is a group of containers and pods that can (optionally) be managed separately from the rest of the state. When namespace is set, only containers and pods in the same namespace will be visible, and all new containers and pods will automatically join the namespace. If namespace is not set (the empty string, internally), we can see containers and pods from all namespaces, including those with no namespace.

This is a step towards CRI-O integration, as CRI-O will not want to see any containers and pods except the ones it created itself.