### PR TITLE
Only test apparmor if kernel support is detected

### DIFF
--- a/hack/apparmor_tag.sh
+++ b/hack/apparmor_tag.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if pkg-config libapparmor 2> /dev/null ; then
 	# Travis CI does not support AppArmor, so we cannot run tests there.
-	if [ -z "$TRAVIS" ]; then
+	if [ -z "$TRAVIS" ] && [ -d "/sys/module/apparmor" ] ; then
 		echo apparmor
 	fi
 fi


### PR DESCRIPTION
In containerized tests running on Ubuntu, we are running the apparmor tests unconditionally, even when they're running on a kernel with no support. Gate them on kernel support being found in /sys.