### PR TITLE
Fix error handling in pod start/stop.

### DIFF
--- a/cmd/podman/pod_start.go
+++ b/cmd/podman/pod_start.go
@@ -78,19 +78,20 @@ func podStartCmd(c *cli.Context) error {
 	ctx := getContext()
 	for _, pod := range pods {
 		ctr_errs, err := pod.Start(ctx)
-		if err != nil {
-			if lastError != nil {
-				logrus.Errorf("%q", lastError)
-			}
-			lastError = errors.Wrapf(err, "unable to start pod %q", pod.ID())
-			continue
-		} else if ctr_errs != nil {
+		if ctr_errs != nil {
 			for ctr, err := range ctr_errs {
 				if lastError != nil {
 					logrus.Errorf("%q", lastError)
 				}
 				lastError = errors.Wrapf(err, "unable to start container %q on pod %q", ctr, pod.ID())
 			}
+			continue
+		}
+		if err != nil {
+			if lastError != nil {
+				logrus.Errorf("%q", lastError)
+			}
+			lastError = errors.Wrapf(err, "unable to start pod %q", pod.ID())
 			continue
 		}
 		fmt.Println(pod.ID())

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -79,19 +79,20 @@ func podStopCmd(c *cli.Context) error {
 	for _, pod := range pods {
 		// set cleanup to true to clean mounts and namespaces
 		ctr_errs, err := pod.Stop(true)
-		if err != nil {
-			if lastError != nil {
-				logrus.Errorf("%q", lastError)
-			}
-			lastError = errors.Wrapf(err, "unable to stop pod %q", pod.ID())
-			continue
-		} else if ctr_errs != nil {
+		if ctr_errs != nil {
 			for ctr, err := range ctr_errs {
 				if lastError != nil {
 					logrus.Errorf("%q", lastError)
 				}
 				lastError = errors.Wrapf(err, "unable to stop container %q on pod %q", ctr, pod.ID())
 			}
+			continue
+		}
+		if err != nil {
+			if lastError != nil {
+				logrus.Errorf("%q", lastError)
+			}
+			lastError = errors.Wrapf(err, "unable to stop pod %q", pod.ID())
 			continue
 		}
 		fmt.Println(pod.ID())


### PR DESCRIPTION
Before, errors in containers would never be printed, and a generic error would only be shown.

Signed-off-by: haircommander <pehunt@redhat.com>