### PR TITLE
[RFC][WIP][DO NOT MERGE!] rootless networking

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -389,6 +389,8 @@ Set the Network mode for the container
                 'container:<name|id>': reuse another container's network stack
                 'host': use the podman host network stack.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
                 '<network-name>|<network-id>': connect to a user-defined network
+                'ns:<path>' path to a network namespace to join
+
 
 **--network-alias**=[]
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -403,6 +403,7 @@ Set the Network mode for the container:
 - `container:<name|id>`: reuse another container's network stack
 - `host`: use the podman host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 - `<network-name>|<network-id>`: connect to a user-defined network
+- `ns:<path>` path to a network namespace to join
 
 **--network-alias**=[]
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -236,6 +236,7 @@ type ContainerConfig struct {
 	UserNsCtr   string `json:"userNsCtr,omitempty"`
 	UTSNsCtr    string `json:"utsNsCtr,omitempty"`
 	CgroupNsCtr string `json:"cgroupNsCtr,omitempty"`
+	NetNs       string `json:"netNs,omitempty"`
 
 	// IDs of dependency containers.
 	// These containers must be started before this container is started.

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -184,6 +184,11 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			return nil, err
 		}
 	}
+	if c.config.NetNs != "" {
+		if err := c.addNamespacePath(&g, NetNS, c.config.NetNs, spec.NetworkNamespace); err != nil {
+			return nil, err
+		}
+	}
 	if c.config.PIDNsCtr != "" {
 		if err := c.addNamespaceContainer(&g, PIDNS, c.config.PIDNsCtr, string(spec.PIDNamespace)); err != nil {
 			return nil, err
@@ -264,6 +269,15 @@ func (c *Container) addNamespaceContainer(g *generate.Generator, ns LinuxNS, ctr
 		return err
 	}
 
+	if err := g.AddOrReplaceLinuxNamespace(specNS, nsPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Add an existing namespace to the spec
+func (c *Container) addNamespacePath(g *generate.Generator, ns LinuxNS, nsPath string, specNS string) error {
 	if err := g.AddOrReplaceLinuxNamespace(specNS, nsPath); err != nil {
 		return err
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -557,10 +557,15 @@ func WithMountNSFrom(nsCtr *Container) CtrCreateOption {
 // of the given container.
 // If the container has joined a pod, it can only join the namespaces of
 // containers in the same pod.
-func WithNetNSFrom(nsCtr *Container) CtrCreateOption {
+func WithNetNSFrom(ns string, nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return ErrCtrFinalized
+		}
+
+		if ns != "" {
+			ctr.config.NetNs = ns
+			return nil
 		}
 
 		if !nsCtr.valid {

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -379,7 +379,9 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime) ([]lib
 		if err != nil {
 			return nil, errors.Wrapf(err, "container %q not found", c.NetMode.ConnectedContainer())
 		}
-		options = append(options, libpod.WithNetNSFrom(connectedCtr))
+		options = append(options, libpod.WithNetNSFrom("", connectedCtr))
+	} else if c.NetMode.IsNS() {
+		options = append(options, libpod.WithNetNSFrom(c.NetMode.NS(), nil))
 	} else if !c.NetMode.IsHost() && !c.NetMode.IsNone() {
 		postConfigureNetNS := (len(c.IDMappings.UIDMap) > 0 || len(c.IDMappings.GIDMap) > 0) && !c.UsernsMode.IsHost()
 		options = append(options, libpod.WithNetNS(portBindings, postConfigureNetNS, networks))

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -3,6 +3,7 @@ package createconfig
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -371,8 +372,20 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime) ([]lib
 	}
 
 	if rootless.IsRootless() {
+		f, err := os.Create("/tmp/net")
+		if err != nil {
+			return nil, err
+		}
+		f.Close()
+
+		cmd := exec.Command("slirp-forwarder", "/tmp/net")
+		cmd.Env = append(cmd.Env, "LD_LIBRARY_PATH=/usr/local/lib")
+		cmd.Env = append(cmd.Env, "CONFIGURE_NETWORK=1")
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
 		if !c.NetMode.IsHost() && !c.NetMode.IsNone() {
-			options = append(options, libpod.WithNetNS(portBindings, true, networks))
+			options = append(options, libpod.WithNetNSFrom("/tmp/net", nil))
 		}
 	} else if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -346,6 +346,9 @@ func addNetNS(config *CreateConfig, g *generate.Generator) error {
 	} else if netMode.IsContainer() {
 		logrus.Debug("Using container netmode")
 		return nil
+	} else if netMode.IsNS() {
+		logrus.Debug("Using ns netmode")
+		return nil
 	} else if netMode.IsUserDefined() {
 		logrus.Debug("Using user defined netmode")
 		return nil

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -345,6 +345,7 @@ func addNetNS(config *CreateConfig, g *generate.Generator) error {
 		return nil
 	} else if netMode.IsContainer() {
 		logrus.Debug("Using container netmode")
+		return nil
 	} else if netMode.IsUserDefined() {
 		logrus.Debug("Using user defined netmode")
 		return nil

--- a/vendor/github.com/docker/docker/api/types/container/host_config.go
+++ b/vendor/github.com/docker/docker/api/types/container/host_config.go
@@ -92,13 +92,28 @@ func (n NetworkMode) IsContainer() bool {
 	return len(parts) > 1 && parts[0] == "container"
 }
 
-// ConnectedContainer is the id of the container which network this container is connected to.
-func (n NetworkMode) ConnectedContainer() string {
+// IsNS indicates whether container uses a specific network namespace.
+func (n NetworkMode) IsNS() bool {
 	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "ns"
+}
+
+func getSecondPart(s string) string {
+	parts := strings.SplitN(s, ":", 2)
 	if len(parts) > 1 {
 		return parts[1]
 	}
 	return ""
+}
+
+// NS is the path to the namespace to join.
+func (n NetworkMode) NS() string {
+	return getSecondPart(string(n))
+}
+
+// ConnectedContainer is the id of the container which network this container is connected to.
+func (n NetworkMode) ConnectedContainer() string {
+	return getSecondPart(string(n))
 }
 
 //UserDefined indicates user-created network


### PR DESCRIPTION
not ready to be used, this is to start a discussion around an usermode network configuration.

It is based on this tool: https://github.com/giuseppe/slirp-forwarder

It internally uses libslirp, we might want to use the version from qemu, but that requires more work.

Also I discovered there is already another attempt at creating a slirp tool for rootless networks: https://github.com/AkihiroSuda/slirp4netns and we can probably collaborate together for it.

this is how a container looks like, there is nothing requiring root privileges or suid applications to configure the network:

``console
$ bin/podman run --rm -ti alpine ifconfig -a
lo        Link encap:Local Loopback  
          LOOPBACK  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

tap0      Link encap:Ethernet  HWaddr 36:FF:87:4E:54:26  
          inet6 addr: fe80::34ff:87ff:fe4e:5426/64 Scope:Link
          UP BROADCAST RUNNING  MTU:1500  Metric:1
          RX packets:2 errors:0 dropped:0 overruns:0 frame:0
          TX packets:6 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:1180 (1.1 KiB)  TX bytes:992 (992.0 B)

$ pkill dhclient; pkill slirp-forwarder; rm /tmp/net # delete any leftover
```