### PR TITLE
Add load test for xz compressed images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     python3-dateutil \
     python3-setuptools \
+    xz-utils \
     --no-install-recommends \
     && apt-get clean
 

--- a/Dockerfile.CentOS
+++ b/Dockerfile.CentOS
@@ -24,6 +24,7 @@ RUN yum -y install btrfs-progs-devel \
               which\
               golang-github-cpuguy83-go-md2man \
               nmap-ncat \
+              xz \
               iptables && yum clean all
 
 # Install CNI plugins

--- a/Dockerfile.Fedora
+++ b/Dockerfile.Fedora
@@ -26,6 +26,7 @@ RUN dnf -y install btrfs-progs-devel \
               golang-github-cpuguy83-go-md2man \
               procps-ng \
               nmap-ncat \
+              xz \
               iptables && dnf clean all
 
 # Install CNI plugins

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -217,4 +217,23 @@ var _ = Describe("Podman load", func() {
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())
 	})
+
+	It("podman load xz compressed image", func() {
+		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
+
+		save := podmanTest.Podman([]string{"save", "-o", outfile, ALPINE})
+		save.WaitWithDefaultTimeout()
+		Expect(save.ExitCode()).To(Equal(0))
+		session := podmanTest.SystemExec("xz", []string{outfile})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
+		rmi.WaitWithDefaultTimeout()
+		Expect(rmi.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"load", "-i", outfile + ".xz"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
The auto decompression functionality was already vendored in
with containers/image. Adding a test for it.

Fixes https://github.com/projectatomic/libpod/issues/472

Signed-off-by: umohnani8 <umohnani@redhat.com>