### PR TITLE
Fix ambiguity in adding localhost to podman save

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -258,7 +258,7 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 	}
 	// if the image is saved with the repository localhost, searching with localhost prepended is necessary
 	// We don't need to strip the sha because we have already determined it is not an ID
-	img, err = i.imageruntime.getImage(DefaultLocalRepo + "/" + i.InputName)
+	img, err = i.imageruntime.getImage(fmt.Sprintf("%s/%s", DefaultLocalRegistry, i.InputName))
 	if err == nil {
 		return img.image, err
 	}
@@ -465,7 +465,7 @@ func normalizeTag(tag string) (string, error) {
 	}
 	// If the input doesn't specify a registry, set the registry to localhost
 	if !decomposedTag.hasRegistry {
-		tag = fmt.Sprintf("%s/%s", DefaultLocalRepo, tag)
+		tag = fmt.Sprintf("%s/%s", DefaultLocalRegistry, tag)
 	}
 	return tag, nil
 }

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -43,9 +43,9 @@ var (
 	// and because syntaxes of image names are transport-dependent, the prefix is not really interchangeable;
 	// each user implicitly assumes the appended string is a Docker-like reference.
 	DefaultTransport = DockerTransport + "://"
-	// DefaultLocalRepo is the default local repository for local image operations
+	// DefaultLocalRegistry is the default local registry for local image operations
 	// Remote pulls will still use defined registries
-	DefaultLocalRepo = "localhost"
+	DefaultLocalRegistry = "localhost"
 )
 
 // pullRefPair records a pair of prepared image references to pull.
@@ -74,12 +74,12 @@ func singlePullRefPairGoal(rp pullRefPair) *pullGoal {
 }
 
 func (ir *Runtime) getPullRefPair(srcRef types.ImageReference, destName string) (pullRefPair, error) {
-	imgPart, err := decompose(destName)
-	if err == nil && !imgPart.hasRegistry {
+	decomposedDest, err := decompose(destName)
+	if err == nil && !decomposedDest.hasRegistry {
 		// If the image doesn't have a registry, set it as the default repo
-		imgPart.registry = DefaultLocalRepo
-		imgPart.hasRegistry = true
-		destName = imgPart.assemble()
+		decomposedDest.registry = DefaultLocalRegistry
+		decomposedDest.hasRegistry = true
+		destName = decomposedDest.assemble()
 	}
 
 	reference := destName
@@ -179,11 +179,9 @@ func (ir *Runtime) pullGoalFromImageReference(ctx context.Context, srcRef types.
 	case DirTransport:
 		path := srcRef.StringWithinTransport()
 		image := path
-		// remove leading "/"
 		if image[:1] == "/" {
-			// Instead of removing the leading /, set localhost as the registry
-			// so docker.io isn't prepended, and the path becomes the repository
-			image = DefaultLocalRepo + image
+			// Set localhost as the registry so docker.io isn't prepended, and the path becomes the repository
+			image = DefaultLocalRegistry + image
 		}
 		return ir.getSinglePullRefPairGoal(srcRef, image)
 


### PR DESCRIPTION
... As well as some naming decisions.
This change ensures podman save doesn't incorrectly prepend localhost when saving an image.

Followup PR for discussion in #1103 

Requesting comments because there needs to be discussion on how localhost will function in libpod. Is it going to be treated as a registry or a repository?
Further, if imageParts.hasRegistry is broken, what is a better way to check if pieces of an image name is a registry vs repository?

Signed-off-by: haircommander <pehunt@redhat.com>