### PR TITLE
Clear variables used to store options after parsing for every volume

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -147,8 +147,13 @@ func (c *CreateConfig) CreateBlockIO() (*spec.LinuxBlockIO, error) {
 //GetVolumeMounts takes user provided input for bind mounts and creates Mount structs
 func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, error) {
 	var m []spec.Mount
-	var options []string
 	for _, i := range c.Volumes {
+		var (
+			options                          []string
+			foundrw, foundro, foundz, foundZ bool
+			rootProp                         string
+		)
+
 		// We need to handle SELinux options better here, specifically :Z
 		spliti := strings.Split(i, ":")
 		if len(spliti) > 2 {
@@ -158,8 +163,6 @@ func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, e
 			continue
 		}
 		options = append(options, "rbind")
-		var foundrw, foundro, foundz, foundZ bool
-		var rootProp string
 		for _, opt := range options {
 			switch opt {
 			case "rw":

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -547,4 +547,17 @@ USER mail`
 		Expect(session.OutputToString()).To(ContainSubstring("data"))
 
 	})
+
+	It("podman run --volumes flag with multiple volumes", func() {
+		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).To(BeNil())
+		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
+		err = os.MkdirAll(vol2, 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:ro", "--volume", vol2 + ":/myvol2", ALPINE, "touch", "/myvol2/foo.txt"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
If more than one volume was mounted using the --volume flag in
podman run, the second and onwards volumes were picking up options
of the previous volume mounts defined. Found out that the options were
not be cleared out after every volume was parsed.

Fixes https://github.com/projectatomic/libpod/issues/1129

Signed-off-by: umohnani8 <umohnani@redhat.com>