### PR TITLE
Update container Mounted() and Mountpoint() functions

### DIFF
--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -105,13 +105,15 @@ func mountCmd(c *cli.Context) error {
 			return errors.Wrapf(err2, "error reading list of all containers")
 		}
 		for _, container := range containers {
-			mountPoint, err := container.Mountpoint()
+			mounted, mountPoint, err := container.Mounted()
 			if err != nil {
 				return errors.Wrapf(err, "error getting mountpoint for %q", container.ID())
 			}
-			if mountPoint == "" {
+
+			if !mounted {
 				continue
 			}
+
 			if json {
 				jsonMountPoints = append(jsonMountPoints, jsonMountPoint{ID: container.ID(), Names: []string{container.Name()}, MountPoint: mountPoint})
 				continue

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -263,6 +263,22 @@ func (r *storageService) MountedContainerImage(idOrName string) (int, error) {
 	return mounted, nil
 }
 
+func (r *storageService) GetMountpoint(id string) (string, error) {
+	container, err := r.store.Container(id)
+	if err != nil {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
+			return "", ErrNoSuchCtr
+		}
+		return "", err
+	}
+	layer, err := r.store.Layer(container.LayerID)
+	if err != nil {
+		return "", err
+	}
+
+	return layer.MountPoint, nil
+}
+
 func (r *storageService) GetWorkDir(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {


### PR DESCRIPTION
Addresses a regression in `podman mount` due to our mount changes to allow concurrency by letting c/storage handle mounting and unmounting.

Combine Mounted() and Mountpoint() into one function and query c/storage directly to ensure we get accurate information.

Fixes: #1143