### PR TITLE
Fix varlink API usage of psgo

### DIFF
--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -110,7 +110,7 @@ func (i *LibpodAPI) ListContainerProcesses(call ioprojectatomicpodman.VarlinkCal
 		return call.ReplyErrorOccurred(fmt.Sprintf("container %s is not running", name))
 	}
 	var psArgs []string
-	psOpts := []string{"-o", "uid,pid,ppid,c,stime,tname,time,cmd"}
+	psOpts := []string{"user", "pid", "ppid", "pcpu", "etime", "tty", "time", "comm"}
 	if len(opts) > 1 {
 		psOpts = opts
 	}


### PR DESCRIPTION
"API" changed and this code was missed.

Signed-off-by: Jhon Honce <jhonce@redhat.com>