### PR TITLE
Refactored method of getting pods

### DIFF
--- a/cmd/podman/pod_start.go
+++ b/cmd/podman/pod_start.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
-	"github.com/projectatomic/libpod/libpod"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -42,38 +41,14 @@ func podStartCmd(c *cli.Context) error {
 
 	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
-		return errors.Wrapf(err, "error creating libpod runtime")
+		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
 
-	args := c.Args()
-	var pods []*libpod.Pod
-	var lastError error
-
-	if c.Bool("all") {
-		pods, err = runtime.Pods()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get running pods")
-		}
-	}
-	if c.Bool("latest") {
-		pod, err := runtime.GetLatestPod()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get latest pod")
-		}
-		pods = append(pods, pod)
-	}
-	for _, i := range args {
-		pod, err := runtime.LookupPod(i)
-		if err != nil {
-			if lastError != nil {
-				logrus.Errorf("%q", lastError)
-			}
-			lastError = errors.Wrapf(err, "unable to find pod %s", i)
-			continue
-		}
-		pods = append(pods, pod)
-	}
+	// getPodsFromContext returns an error when a requested pod
+	// isn't found. The only fatal error scenerio is when there are no pods
+	// in which case the following loop will be skipped.
+	pods, lastError := getPodsFromContext(c, runtime)
 
 	ctx := getContext()
 	for _, pod := range pods {

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/cmd/podman/libpodruntime"
-	"github.com/projectatomic/libpod/libpod"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -45,36 +44,10 @@ func podStopCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	args := c.Args()
-	var pods []*libpod.Pod
-	var lastError error
-
-	if c.Bool("all") {
-		pods, err = runtime.Pods()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get running pods")
-		}
-	}
-
-	if c.Bool("latest") {
-		pod, err := runtime.GetLatestPod()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get latest pod")
-		}
-		pods = append(pods, pod)
-	}
-
-	for _, i := range args {
-		pod, err := runtime.LookupPod(i)
-		if err != nil {
-			if lastError != nil {
-				logrus.Errorf("%q", lastError)
-			}
-			lastError = errors.Wrapf(err, "unable to find pod %s", i)
-			continue
-		}
-		pods = append(pods, pod)
-	}
+	// getPodsFromContext returns an error when a requested pod
+	// isn't found. The only fatal error scenerio is when there are no pods
+	// in which case the following loop will be skipped.
+	pods, lastError := getPodsFromContext(c, runtime)
 
 	for _, pod := range pods {
 		// set cleanup to true to clean mounts and namespaces


### PR DESCRIPTION
Now, for commands that have --latest and --all, the context flags are checked, and pods are grabbed in a single function

Signed-off-by: haircommander <pehunt@redhat.com>