### PR TITLE
Fix handling of Linux network namespaces

### DIFF
--- a/libpod/container_linux.go
+++ b/libpod/container_linux.go
@@ -21,9 +21,10 @@ func (ctr *Container) setNamespace(netNSPath string, newState *containerState) e
 		if ctr.state.NetNS != nil && netNSPath == ctr.state.NetNS.Path() {
 			newState.NetNS = ctr.state.NetNS
 		} else {
-			// Tear down the existing namespace
-			if err := ctr.runtime.teardownNetNS(ctr); err != nil {
-				logrus.Warnf(err.Error())
+			// Close the existing namespace.
+			// Whoever removed it from the database already tore it down.
+			if err := ctr.runtime.closeNetNS(ctr); err != nil {
+				return err
 			}
 
 			// Open the new network namespace
@@ -37,9 +38,10 @@ func (ctr *Container) setNamespace(netNSPath string, newState *containerState) e
 		}
 	} else {
 		// The container no longer has a network namespace
-		// Tear down the old one
-		if err := ctr.runtime.teardownNetNS(ctr); err != nil {
-			logrus.Warnf(err.Error())
+		// Close the old one, whoever removed it from the DB should have
+		// cleaned it up already.
+		if err := ctr.runtime.closeNetNS(ctr); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -1,0 +1,161 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file was originally a part of the containernetworking/plugins
+// repository.
+// It was copied here and modified for local use by the libpod maintainers.
+
+package netns
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"golang.org/x/sys/unix"
+)
+
+const nsRunDir = "/var/run/netns"
+
+// Creates a new persistent (bind-mounted) network namespace and returns an object
+// representing that namespace, without switching to it.
+func NewNS() (ns.NetNS, error) {
+
+	b := make([]byte, 16)
+	_, err := rand.Reader.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random netns name: %v", err)
+	}
+
+	// Create the directory for mounting network namespaces
+	// This needs to be a shared mountpoint in case it is mounted in to
+	// other namespaces (containers)
+	err = os.MkdirAll(nsRunDir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remount the namespace directory shared. This will fail if it is not
+	// already a mountpoint, so bind-mount it on to itself to "upgrade" it
+	// to a mountpoint.
+	err = unix.Mount("", nsRunDir, "none", unix.MS_SHARED|unix.MS_REC, "")
+	if err != nil {
+		if err != unix.EINVAL {
+			return nil, fmt.Errorf("mount --make-rshared %s failed: %q", nsRunDir, err)
+		}
+
+		// Recursively remount /var/run/netns on itself. The recursive flag is
+		// so that any existing netns bindmounts are carried over.
+		err = unix.Mount(nsRunDir, nsRunDir, "none", unix.MS_BIND|unix.MS_REC, "")
+		if err != nil {
+			return nil, fmt.Errorf("mount --rbind %s %s failed: %q", nsRunDir, nsRunDir, err)
+		}
+
+		// Now we can make it shared
+		err = unix.Mount("", nsRunDir, "none", unix.MS_SHARED|unix.MS_REC, "")
+		if err != nil {
+			return nil, fmt.Errorf("mount --make-rshared %s failed: %q", nsRunDir, err)
+		}
+
+	}
+
+	nsName := fmt.Sprintf("cni-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+
+	// create an empty file at the mount point
+	nsPath := path.Join(nsRunDir, nsName)
+	mountPointFd, err := os.Create(nsPath)
+	if err != nil {
+		return nil, err
+	}
+	mountPointFd.Close()
+
+	// Ensure the mount point is cleaned up on errors; if the namespace
+	// was successfully mounted this will have no effect because the file
+	// is in-use
+	defer os.RemoveAll(nsPath)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// do namespace work in a dedicated goroutine, so that we can safely
+	// Lock/Unlock OSThread without upsetting the lock/unlock state of
+	// the caller of this function
+	go (func() {
+		defer wg.Done()
+		runtime.LockOSThread()
+		// Don't unlock. By not unlocking, golang will kill the OS thread when the
+		// goroutine is done (for go1.10+)
+
+		var origNS ns.NetNS
+		origNS, err = ns.GetNS(getCurrentThreadNetNSPath())
+		if err != nil {
+			return
+		}
+		defer origNS.Close()
+
+		// create a new netns on the current thread
+		err = unix.Unshare(unix.CLONE_NEWNET)
+		if err != nil {
+			return
+		}
+
+		// Put this thread back to the orig ns, since it might get reused (pre go1.10)
+		defer origNS.Set()
+
+		// bind mount the netns from the current thread (from /proc) onto the
+		// mount point. This causes the namespace to persist, even when there
+		// are no threads in the ns.
+		err = unix.Mount(getCurrentThreadNetNSPath(), nsPath, "none", unix.MS_BIND, "")
+		if err != nil {
+			err = fmt.Errorf("failed to bind mount ns at %s: %v", nsPath, err)
+		}
+	})()
+	wg.Wait()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	return ns.GetNS(nsPath)
+}
+
+// UnmountNS unmounts the NS held by the netns object
+func UnmountNS(ns ns.NetNS) error {
+	nsPath := ns.Path()
+	// Only unmount if it's been bind-mounted (don't touch namespaces in /proc...)
+	if strings.HasPrefix(nsPath, nsRunDir) {
+		if err := unix.Unmount(nsPath, unix.MNT_DETACH); err != nil {
+			return fmt.Errorf("failed to unmount NS: at %s: %v", nsPath, err)
+		}
+
+		if err := os.Remove(nsPath); err != nil {
+			return fmt.Errorf("failed to remove ns path %s: %v", nsPath, err)
+		}
+	}
+
+	return nil
+}
+
+// getCurrentThreadNetNSPath copied from pkg/ns
+func getCurrentThreadNetNSPath() string {
+	// /proc/self/ns/net returns the namespace of the main thread, not
+	// of whatever thread this goroutine is running on.  Make sure we
+	// use the thread's net namespace since the thread is switching around
+	return fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+}

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -33,8 +33,8 @@ import (
 
 const nsRunDir = "/var/run/netns"
 
-// Creates a new persistent (bind-mounted) network namespace and returns an object
-// representing that namespace, without switching to it.
+// NewNS creates a new persistent (bind-mounted) network namespace and returns
+// an object representing that namespace, without switching to it.
 func NewNS() (ns.NetNS, error) {
 
 	b := make([]byte, 16)

--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@ github.com/buger/goterm 2f8dfbc7dbbff5dd1d391ed91482c24df243b2d3
 github.com/containerd/cgroups 77e628511d924b13a77cebdc73b757a47f6d751b
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.7.0-alpha1
-github.com/containernetworking/plugins 1fb94a4222eafc6f948eacdca9c9f2158b427e53
+github.com/containernetworking/plugins 1562a1e60ed101aacc5e08ed9dbeba8e9f3d4ec1
 github.com/containers/image c6e0eee0f8eb38e78ae2e44a9aeea0576f451617
 github.com/containers/storage afdedba2d2ad573350aee35033d4e0c58fdbd57b
 github.com/containers/psgo 382fc951fe0a8aba62043862ce1a56f77524db87

--- a/vendor/github.com/containernetworking/plugins/README.md
+++ b/vendor/github.com/containernetworking/plugins/README.md
@@ -4,12 +4,14 @@
 # plugins
 Some CNI network plugins, maintained by the containernetworking team. For more information, see the individual READMEs.
 
+Read [CONTRIBUTING](CONTRIBUTING.md) for build and test instructions.
+
 ## Plugins supplied:
 ### Main: interface-creating
 * `bridge`: Creates a bridge, adds the host and the container to it.
-* `ipvlan`: Adds an [ipvlan](https://www.kernel.org/doc/Documentation/networking/ipvlan.txt) interface in the container
-* `loopback`: Creates a loopback interface
-* `macvlan`: Creates a new MAC address, forwards all traffic to that to the container
+* `ipvlan`: Adds an [ipvlan](https://www.kernel.org/doc/Documentation/networking/ipvlan.txt) interface in the container.
+* `loopback`: Set the state of loopback interface to up.
+* `macvlan`: Creates a new MAC address, forwards all traffic to that to the container.
 * `ptp`: Creates a veth pair.
 * `vlan`: Allocates a vlan device.
 

--- a/vendor/github.com/containernetworking/plugins/pkg/ns/README.md
+++ b/vendor/github.com/containernetworking/plugins/pkg/ns/README.md
@@ -12,10 +12,6 @@ For example, you cannot rely on the `ns.Set()` namespace being the current names
 The `ns.Do()` method provides **partial** control over network namespaces for you by implementing these strategies. All code dependent on a particular network namespace (including the root namespace) should be wrapped in the `ns.Do()` method to ensure the correct namespace is selected for the duration of your code.  For example:
 
 ```go
-targetNs, err := ns.NewNS()
-if err != nil {
-    return err
-}
 err = targetNs.Do(func(hostNs ns.NetNS) error {
 	dummy := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
@@ -26,11 +22,16 @@ err = targetNs.Do(func(hostNs ns.NetNS) error {
 })
 ```
 
-Note this requirement to wrap every network call is very onerous - any libraries you call might call out to network services such as DNS, and all such calls need to be protected after you call `ns.Do()`. The CNI plugins all exit very soon after calling `ns.Do()` which helps to minimize the problem.
+Note this requirement to wrap every network call is very onerous - any libraries you call might call out to network services such as DNS, and all such calls need to be protected after you call `ns.Do()`. All goroutines spawned from within the `ns.Do` will not inherit the new namespace. The CNI plugins all exit very soon after calling `ns.Do()` which helps to minimize the problem.
 
-Also:  If the runtime spawns a new OS thread, it will inherit the network namespace of the parent thread, which may have been temporarily switched, and thus the new OS thread will be permanently "stuck in the wrong namespace".
+When a new thread is spawned in Linux, it inherits the namepaces of its parent. In versions of go **prior to 1.10**, if the runtime spawns a new OS thread, it picks the parent randomly. If the chosen parent thread has been moved to a new namespace (even temporarily), the new OS thread will be permanently "stuck in the wrong namespace", and goroutines will non-deterministically switch namespaces as they are rescheduled.
 
-In short, **there is no safe way to change network namespaces from within a long-lived, multithreaded Go process**.  If your daemon process needs to be namespace aware, consider spawning a separate process (like a CNI plugin) for each namespace.
+In short, **there was no safe way to change network namespaces, even temporarily, from within a long-lived, multithreaded Go process**. If you wish to do this, you must use go 1.10 or greater. 
+
+
+### Creating network namespaces
+Earlier versions of this library managed namespace creation, but as CNI does not actually utilize this feature (and it was essentialy unmaintained), it was removed. If you're writing a container runtime, you should implement namespace management yourself. However, there are some gotchas when doing so, especially around handling `/var/run/netns`. A reasonably correct reference implementation, borrowed from `rkt`, can be found in `pkg/testutils/netns_linux.go` if you're in need of a source of inspiration.
+
 
 ### Further Reading
  - https://github.com/golang/go/wiki/LockOSThread

--- a/vendor/github.com/containernetworking/plugins/pkg/ns/ns_linux.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/ns/ns_linux.go
@@ -15,10 +15,8 @@
 package ns
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os"
-	"path"
 	"runtime"
 	"sync"
 	"syscall"
@@ -38,82 +36,6 @@ func getCurrentThreadNetNSPath() string {
 	return fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
 }
 
-// Creates a new persistent network namespace and returns an object
-// representing that namespace, without switching to it
-func NewNS() (NetNS, error) {
-	const nsRunDir = "/var/run/netns"
-
-	b := make([]byte, 16)
-	_, err := rand.Reader.Read(b)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate random netns name: %v", err)
-	}
-
-	err = os.MkdirAll(nsRunDir, 0755)
-	if err != nil {
-		return nil, err
-	}
-
-	// create an empty file at the mount point
-	nsName := fmt.Sprintf("cni-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
-	nsPath := path.Join(nsRunDir, nsName)
-	mountPointFd, err := os.Create(nsPath)
-	if err != nil {
-		return nil, err
-	}
-	mountPointFd.Close()
-
-	// Ensure the mount point is cleaned up on errors; if the namespace
-	// was successfully mounted this will have no effect because the file
-	// is in-use
-	defer os.RemoveAll(nsPath)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	// do namespace work in a dedicated goroutine, so that we can safely
-	// Lock/Unlock OSThread without upsetting the lock/unlock state of
-	// the caller of this function
-	var fd *os.File
-	go (func() {
-		defer wg.Done()
-		runtime.LockOSThread()
-
-		var origNS NetNS
-		origNS, err = GetNS(getCurrentThreadNetNSPath())
-		if err != nil {
-			return
-		}
-		defer origNS.Close()
-
-		// create a new netns on the current thread
-		err = unix.Unshare(unix.CLONE_NEWNET)
-		if err != nil {
-			return
-		}
-		defer origNS.Set()
-
-		// bind mount the new netns from the current thread onto the mount point
-		err = unix.Mount(getCurrentThreadNetNSPath(), nsPath, "none", unix.MS_BIND, "")
-		if err != nil {
-			return
-		}
-
-		fd, err = os.Open(nsPath)
-		if err != nil {
-			return
-		}
-	})()
-	wg.Wait()
-
-	if err != nil {
-		unix.Unmount(nsPath, unix.MNT_DETACH)
-		return nil, fmt.Errorf("failed to create namespace: %v", err)
-	}
-
-	return &netNS{file: fd, mounted: true}, nil
-}
-
 func (ns *netNS) Close() error {
 	if err := ns.errorIfClosed(); err != nil {
 		return err
@@ -123,16 +45,6 @@ func (ns *netNS) Close() error {
 		return fmt.Errorf("Failed to close %q: %v", ns.file.Name(), err)
 	}
 	ns.closed = true
-
-	if ns.mounted {
-		if err := unix.Unmount(ns.file.Name(), unix.MNT_DETACH); err != nil {
-			return fmt.Errorf("Failed to unmount namespace %s: %v", ns.file.Name(), err)
-		}
-		if err := os.RemoveAll(ns.file.Name()); err != nil {
-			return fmt.Errorf("Failed to clean up namespace %s: %v", ns.file.Name(), err)
-		}
-		ns.mounted = false
-	}
 
 	return nil
 }
@@ -180,9 +92,8 @@ type NetNS interface {
 }
 
 type netNS struct {
-	file    *os.File
-	mounted bool
-	closed  bool
+	file   *os.File
+	closed bool
 }
 
 // netNS implements the NetNS interface


### PR DESCRIPTION
The CNI plugins upstream removed their network namespace creation code, making it a test package only. Copy it into our repository and slightly modify it for our use (most notably, use MNT_DETACH when unmounting namespaces).
    
This new CNI code splits closing and unmounting network namespaces, which allows us to greatly reduce the number of occasions on which we call teardownNetwork() and make more errors in that function fatal instead of warnings. Instead, we can call Close() and just close the open file descriptor in cases where the namespace has already been cleaned up.