### PR TITLE
podman rmi shouldn't delete named referenced images

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -363,7 +363,7 @@ func (i *Image) Remove(force bool) error {
 		}
 		// Do not remove if image is a base image and is not untagged, or if
 		// the image has more children.
-		if (nextParent == nil && len(parent.Names()) > 0) || len(children) > 0 {
+		if len(children) > 0 || len(parent.Names()) > 0 {
 			return nil
 		}
 		id := parent.ID()

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -141,6 +141,41 @@ var _ = Describe("Podman rmi", func() {
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
+	It("podman rmi image that is created from another named imaged", func() {
+		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--name", "c_test1", ALPINE, "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"commit", "-q", "c_test1", "test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--name", "c_test2", "test1", "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"commit", "-q", "c_test2", "test2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"rm", "-a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"rmi", "test2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"images", "-q"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
+	})
+
 	It("podman rmi with cached images", func() {
 		session := podmanTest.Podman([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
If an image is created from another and it is deleted,
only delete the actual image and not the parent images
if the parent images have names/references.

Fixes https://github.com/projectatomic/libpod/issues/1154

Signed-off-by: umohnani8 <umohnani@redhat.com>