### PR TITLE
Speed up test results

### DIFF
--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -216,6 +216,9 @@ func WaitForContainer(p *PodmanTest) bool {
 // Cleanup cleans up the temporary store
 func (p *PodmanTest) Cleanup() {
 	// Remove all containers
+	stopall := p.Podman([]string{"stop", "-a", "--timeout", "0"})
+	stopall.WaitWithDefaultTimeout()
+
 	session := p.Podman([]string{"rm", "-fa"})
 	session.Wait(90)
 	// Nuke tempdir

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Podman wait", func() {
 	})
 
 	It("podman wait on a sleeping container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "sleep", "10"})
+		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "sleep", "1"})
 		session.Wait(20)
 		cid := session.OutputToString()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -57,7 +57,7 @@ var _ = Describe("Podman wait", func() {
 	})
 
 	It("podman wait on latest container", func() {
-		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "sleep", "10"})
+		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "sleep", "1"})
 		session.Wait(20)
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"wait", "-l"})


### PR DESCRIPTION
Stop all containers with a zero timeout prior to trying to rm -fa.  This results
in quicker teardown times by not waiting for timeouts.

Also, with wait tests, no need to wait the full 10 second sleep.  1 will do.

Signed-off-by: baude <bbaude@redhat.com>