### PR TITLE
varlink ImageRemove should always return image ID

### DIFF
--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -382,11 +382,11 @@ func (i *LibpodAPI) RemoveImage(call ioprojectatomicpodman.VarlinkCall, name str
 	if err != nil {
 		return call.ReplyImageNotFound(name)
 	}
-	imageID, err := runtime.RemoveImage(ctx, newImage, force)
+	_, err = runtime.RemoveImage(ctx, newImage, force)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	return call.ReplyRemoveImage(imageID)
+	return call.ReplyRemoveImage(newImage.ID())
 }
 
 // SearchImage searches all registries configured in /etc/containers/registries.conf for an image


### PR DESCRIPTION
When removing an image via varlink, we should always return the
ID of the image even in the case where the image has multiple
repository names and one was only untagged.

Reported by jhonce during integration testing.

Signed-off-by: baude <bbaude@redhat.com>