### PR TITLE
clarify pull error message

### DIFF
--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -272,7 +272,7 @@ func (ir *Runtime) doPullImage(ctx context.Context, sc *types.SystemContext, goa
 		if goal.usedSearchRegistries && len(goal.searchedRegistries) == 0 {
 			return nil, errors.Errorf("image name provided is a short name and no search registries are defined in %s.", registryPath)
 		}
-		return nil, errors.Errorf("unable to find image in the registries defined in %q", registryPath)
+		return nil, errors.Errorf("unable to find image on registries defined in %s, or you do not have pull access", registryPath)
 	}
 	return images, nil
 }


### PR DESCRIPTION
when pulling, we can fail to find an image (i.e. it doesn't exist) or we
can not have authority/access to pull it.  the registries don't tell us
one way or another so the error message needs to cover both.

Resolves #1194

Signed-off-by: baude <bbaude@redhat.com>