### PR TITLE
Use REGISTRIES_CONFIG_PATH for all tests

### DIFF
--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		udsPath := filepath.Join(udsDir, "fifo")
 		syscall.Mkfifo(udsPath, 0600)
 
-		_, pid := podmanTest.PodmanPID([]string{"run", "-it", "-v", fmt.Sprintf("%s:/h", udsDir), fedoraMinimal, "bash", "-c", sigCatch})
+		_, pid := podmanTest.PodmanPID([]string{"run", "-it", "-v", fmt.Sprintf("%s:/h:Z", udsDir), fedoraMinimal, "bash", "-c", sigCatch})
 
 		uds, _ := os.OpenFile(udsPath, os.O_RDONLY, 0600)
 		defer uds.Close()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -562,7 +562,7 @@ USER mail`
 		err = os.MkdirAll(vol2, 0755)
 		Expect(err).To(BeNil())
 
-		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:ro", "--volume", vol2 + ":/myvol2", ALPINE, "touch", "/myvol2/foo.txt"})
+		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:z", "--volume", vol2 + ":/myvol2:z", ALPINE, "touch", "/myvol2/foo.txt"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -2,9 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	. "github.com/onsi/ginkgo"
@@ -177,10 +175,7 @@ var _ = Describe("Podman search", func() {
 		Expect(push.ExitCode()).To(Equal(0))
 
 		// registries.conf set up
-		regFileBytes := []byte(regFileContents)
-		outfile := filepath.Join(podmanTest.TempDir, "registries.conf")
-		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
-		ioutil.WriteFile(outfile, regFileBytes, 0644)
+		podmanTest.setRegistriesConfigEnv([]byte(regFileContents))
 
 		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine"})
 		search.WaitWithDefaultTimeout()
@@ -191,7 +186,7 @@ var _ = Describe("Podman search", func() {
 		Expect(search.ErrorToString()).Should(BeEmpty())
 
 		// cleanup
-		os.Setenv("REGISTRIES_CONFIG_PATH", "")
+		resetRegistriesConfigEnv()
 	})
 
 	It("podman search doesn't attempt HTTP if force secure is true", func() {
@@ -208,10 +203,7 @@ var _ = Describe("Podman search", func() {
 		Expect(push.ExitCode()).To(Equal(0))
 
 		// registries.conf set up
-		regFileBytes := []byte(regFileContents)
-		outfile := filepath.Join(podmanTest.TempDir, "registries.conf")
-		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
-		ioutil.WriteFile(outfile, regFileBytes, 0644)
+		podmanTest.setRegistriesConfigEnv([]byte(regFileContents))
 
 		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine", "--tls-verify=true"})
 		search.WaitWithDefaultTimeout()
@@ -222,7 +214,7 @@ var _ = Describe("Podman search", func() {
 		Expect(match).Should(BeTrue())
 
 		// cleanup
-		os.Setenv("REGISTRIES_CONFIG_PATH", "")
+		resetRegistriesConfigEnv()
 	})
 
 	It("podman search doesn't attempt HTTP if registry is not listed as insecure", func() {
@@ -239,10 +231,7 @@ var _ = Describe("Podman search", func() {
 		Expect(push.ExitCode()).To(Equal(0))
 
 		// registries.conf set up
-		regFileBytes := []byte(badRegFileContents)
-		outfile := filepath.Join(podmanTest.TempDir, "registries.conf")
-		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
-		ioutil.WriteFile(outfile, regFileBytes, 0644)
+		podmanTest.setRegistriesConfigEnv([]byte(badRegFileContents))
 
 		search := podmanTest.Podman([]string{"search", "localhost:5000/my-alpine"})
 		search.WaitWithDefaultTimeout()
@@ -253,7 +242,7 @@ var _ = Describe("Podman search", func() {
 		Expect(match).Should(BeTrue())
 
 		// cleanup
-		os.Setenv("REGISTRIES_CONFIG_PATH", "")
+		resetRegistriesConfigEnv()
 	})
 
 	It("podman search doesn't attempt HTTP if one registry is not listed as insecure", func() {
@@ -278,10 +267,7 @@ var _ = Describe("Podman search", func() {
 		Expect(push.ExitCode()).To(Equal(0))
 
 		// registries.conf set up
-		regFileBytes := []byte(regFileContents2)
-		outfile := filepath.Join(podmanTest.TempDir, "registries.conf")
-		os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
-		ioutil.WriteFile(outfile, regFileBytes, 0644)
+		podmanTest.setRegistriesConfigEnv([]byte(regFileContents2))
 
 		search := podmanTest.Podman([]string{"search", "my-alpine"})
 		search.WaitWithDefaultTimeout()
@@ -292,6 +278,6 @@ var _ = Describe("Podman search", func() {
 		Expect(match).Should(BeTrue())
 
 		// cleanup
-		os.Setenv("REGISTRIES_CONFIG_PATH", "")
+		resetRegistriesConfigEnv()
 	})
 })

--- a/test/registries.conf
+++ b/test/registries.conf
@@ -1,5 +1,5 @@
 [registries.search]
-registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
+registries = ['docker.io', 'quay.io']
 
 [registries.insecure]
 registries = []


### PR DESCRIPTION
We should not be using the test systems registries.conf file for integration
tests. We should always use a constructed file created specifically for the
integration tests or we stand to have unpredictable results.  The beforeTest
function now sets an environment variable pointing to a registries.conf file
in the test's tempdir.  That file will container docker.io as a default.

The afterTest function then clears the environment variable.

Signed-off-by: baude <bbaude@redhat.com>