### PR TITLE
Check for missing arguments in /proc/self/cmdline

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -64,6 +64,8 @@ get_cmd_line_args (pid_t pid)
   for (i = 0; i < used; i++)
     if (buffer[i] == '\0')
       argc++;
+  if (argc == 0)
+    return NULL;
 
   argv = malloc (sizeof (char *) * (argc + 1));
   if (argv == NULL)


### PR DESCRIPTION
Avoids segfault, when argc is zero

Issue #1189