### PR TITLE
Add Runc and Conmon versions to Podman Version

### DIFF
--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -26,19 +26,22 @@ Change output format to "json" or a Go template.
 
 ## EXAMPLE
 
+Run podman info with plain text response:
 ```
 $ podman info
 host:
-  MemFree: 7822168064
-  MemTotal: 33080606720
-  SwapFree: 34357637120
+  MemFree: 28464242688
+  MemTotal: 33147686912
+  OCIRuntimeVersion: 'runc version spec: 1.0.0'
+  SwapFree: 34359734272
   SwapTotal: 34359734272
   arch: amd64
+  conmonVersion: 'conmon version 1.11.0-dev, commit: 42209340c7abcab66f47e9161fa0f1b16ea8c134'
   cpus: 8
   hostname: localhost.localdomain
-  kernel: 4.13.16-300.fc27.x86_64
+  kernel: 4.17.9-200.fc28.x86_64
   os: linux
-  uptime: 142h 13m 55.64s (Approximately 5.92 days)
+  uptime: 47m 34.95s
 insecure registries:
   registries: []
 registries:
@@ -48,7 +51,7 @@ registries:
   - registry.access.redhat.com
 store:
   ContainerStore:
-    number: 7
+    number: 40
   GraphDriverName: overlay
   GraphOptions:
   - overlay.override_kernel_check=true
@@ -61,32 +64,56 @@ store:
     number: 10
   RunRoot: /var/run/containers/storage
 ```
+Run podman info with JSON formatted response:
 ```
 $ podman info --debug --format json
 {
     "host": {
-        "MemFree": 7506157568,
-        "MemTotal": 33080606720,
-        "SwapFree": 34357637120,
+        "MemFree": 28421324800,
+        "MemTotal": 33147686912,
+        "OCIRuntimeVersion": "runc version spec: 1.0.0",
+        "SwapFree": 34359734272,
         "SwapTotal": 34359734272,
         "arch": "amd64",
+        "conmonVersion": "conmon version 1.11.0-dev, commit: 42209340c7abcab66f47e9161fa0f1b16ea8c134",
         "cpus": 8,
         "hostname": "localhost.localdomain",
-        "kernel": "4.13.16-300.fc27.x86_64",
+        "kernel": "4.17.9-200.fc28.x86_64",
         "os": "linux",
-        "uptime": "142h 17m 17.04s (Approximately 5.92 days)"
-
-        ... removed for brevity
-
+        "uptime": "50m 20.27s"
+    },
+    "insecure registries": {
+        "registries": []
+    },
+    "registries": {
+        "registries": [
+            "docker.io",
+            "registry.fedoraproject.org",
+            "registry.access.redhat.com",
+        ]
+    },
+    "store": {
+        "ContainerStore": {
+            "number": 40
+        },
+        "GraphDriverName": "overlay",
+        "GraphOptions": [
+            "overlay.override_kernel_check=true"
+        ],
+        "GraphRoot": "/var/lib/containers/storage",
+        "GraphStatus": {
+            "Backing Filesystem": "extfs",
+            "Native Overlay Diff": "true",
+            "Supports d_type": "true"
+        },
         "ImageStore": {
             "number": 10
         },
         "RunRoot": "/var/run/containers/storage"
     }
 }
-
 ```
-
+Run podman info and only get the registries information.
 ```
 $ podman info --format={{".registries"}}
 map[registries:[docker.io registry.fedoraproject.org registry.access.redhat.com]]


### PR DESCRIPTION
It will be handy to know the runc and conmon versions as our
code gets into the wild.

Signed-off-by: baude <bbaude@redhat.com>