### PR TITLE
Pass DESTDIR down to python Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO ?= go
+DESTDIR ?= /
 EPOCH_TEST_COMMIT ?= 7462ebe830b256e9e145d133c824de5dfd23045d
 HEAD ?= HEAD
 CHANGELOG_BASE ?= HEAD~
@@ -240,8 +241,8 @@ install.systemd:
 	install ${SELINUXOPT} -m 644 -D contrib/varlink/podman.conf ${TMPFILESDIR}/podman.conf
 
 install.python:
-	$(MAKE) -C contrib/python/podman install
-	$(MAKE) -C contrib/python/pypodman install
+	$(MAKE) DESTDIR=${DESTDIR} -C contrib/python/podman install
+	$(MAKE) DESTDIR=${DESTDIR} -C contrib/python/pypodman install
 
 uninstall:
 	for i in $(filter %.1,$(MANPAGES)); do \

--- a/contrib/python/podman/Makefile
+++ b/contrib/python/podman/Makefile
@@ -1,4 +1,5 @@
 PYTHON ?= /usr/bin/python3
+DESTDIR ?= /
 
 .PHONY: python-podman
 python-podman:
@@ -14,7 +15,7 @@ integration:
 
 .PHONY: install
 install:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --root ${DESTDIR}
 
 .PHONY: clobber
 clobber: uninstall clean

--- a/contrib/python/pypodman/Makefile
+++ b/contrib/python/pypodman/Makefile
@@ -1,4 +1,5 @@
 PYTHON ?= /usr/bin/python3
+DESTDIR := /
 
 .PHONY: python-pypodman
 python-pypodman:
@@ -14,7 +15,7 @@ integration:
 
 .PHONY: install
 install:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --root ${DESTDIR}
 
 .PHONY: clobber
 clobber: uninstall clean


### PR DESCRIPTION
In order to get a cleaner build out of the rpms we should
pass down the DESTDIR to the python Makefiles.  Then we
can use them instead of hard coding other inteligence into
the spec files.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>