### PR TITLE
Cleanup man pages.

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -207,11 +207,19 @@ that the IPC namespace in which `buildah` itself is being run should be reused,
 or it can be the path to an IPC namespace which is already in use by
 another process.
 
-**--isolation** [Not Supported]
+**--isolation** *type*
 
-Podman is not currently supported on Windows, and does not have a daemon.
-If you want to override the container isolation you can choose a different
-OCI Runtime, using the --runtime flag.
+Controls what type of isolation is used for running processes as part of `RUN`
+instructions.  Recognized types include *oci* (OCI-compatible runtime, the
+default), *rootless* (OCI-compatible runtime invoked using a modified
+configuration and its --rootless flag enabled, with *--no-new-keyring
+--no-pivot* added to its *create* invocation, with network and UTS namespaces
+disabled, and IPC, PID, and user namespaces enabled; the default for
+unprivileged users), and *chroot* (an internal wrapper that leans more toward
+chroot(1) than container technology).
+
+Note: You can also override the default isolation type by setting the
+BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
 **--label** *label*
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -658,9 +658,6 @@ will convert /foo into a `shared` mount point. Alternatively one can directly
 change propagation properties of source mount. Say `/` is source mount for
 `/foo`, then use `mount --make-shared /` to convert `/` into a `shared` mount.
 
-To disable automatic copying of data from the container path to the volume, use
-the `nocopy` flag. The `nocopy` flag can be set on bind mounts and named volumes.
-
 **--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
 
 Mount volumes from the specified container(s).

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -690,9 +690,6 @@ will convert /foo into a `shared` mount point. Alternatively one can directly
 change propagation properties of source mount. Say `/` is source mount for
 `/foo`, then use `mount --make-shared /` to convert `/` into a `shared` mount.
 
-To disable automatic copying of data from the container path to the volume, use
-the `nocopy` flag. The `nocopy` flag can be set on bind mounts and named volumes.
-
 **--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
 
 Mount volumes from the specified container(s).


### PR DESCRIPTION
podman does not support nocopy so we need to remove it from man pages.
podman build now supports --isolation, so we need to document it.

https://bugzilla.redhat.com/show_bug.cgi?id=1613074 points this out.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>