### PR TITLE
enabled copr epel builds again

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -64,7 +64,11 @@ Requires: containers-common
 Requires: containernetworking-cni >= 0.6.0-3
 Requires: iptables
 Requires: oci-systemd-hook
+%if 0%{?fedora}
 Recommends: container-selinux
+%else
+Requires: container-selinux
+%endif
 
 # vendored libraries
 # awk '{print "Provides: bundled(golang("$1")) = "$2}' vendor.conf | sort


### PR DESCRIPTION
centos/epel does not understand the Recommends tag

Signed-off-by: baude <bbaude@redhat.com>