### PR TITLE
Always connect to the stdout and stderr of stream

### DIFF
--- a/libpod/container_attach.go
+++ b/libpod/container_attach.go
@@ -96,11 +96,9 @@ func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSi
 	}
 
 	receiveStdoutError := make(chan error)
-	if streams.AttachOutput || streams.AttachError {
-		go func() {
-			receiveStdoutError <- redirectResponseToOutputStreams(streams.OutputStream, streams.ErrorStream, streams.AttachOutput, streams.AttachError, conn)
-		}()
-	}
+	go func() {
+		receiveStdoutError <- redirectResponseToOutputStreams(streams.OutputStream, streams.ErrorStream, streams.AttachOutput, streams.AttachError, conn)
+	}()
 
 	stdinDone := make(chan error)
 	go func() {


### PR DESCRIPTION
If the stdout and stderr are not attach, podman will at least get
a messsage that the container has completed and finish.

This fixes the
`podman run -a stdin fedora true`

Hang issue.
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>