### PR TITLE
apparmor: respect "unconfined" setting

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -231,7 +231,7 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 			logrus.Infof("Sucessfully loaded AppAmor profile '%s'", profile)
 			config.ApparmorProfile = profile
 		}
-	} else if config.ApparmorProfile != "" {
+	} else if config.ApparmorProfile != "" && config.ApparmorProfile != "unconfined" {
 		if !apparmor.IsEnabled() {
 			return fmt.Errorf("profile specified but AppArmor is disabled on the host")
 		}


### PR DESCRIPTION
The "unconfined" profile must be treated specially to turn off apparmor
confinement and to avoid applying any other profile.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>