### PR TITLE
removeContainer: fix deadlock

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -174,7 +174,7 @@ func (r *Runtime) RemoveContainer(ctx context.Context, c *Container, force bool)
 // Locks the container, but does not lock the runtime
 func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool) error {
 	if !c.valid {
-		if ok, _ := r.HasContainer(c.ID()); !ok {
+		if ok, _ := r.state.HasContainer(c.ID()); !ok {
 			// Container probably already removed
 			// Or was never in the runtime to begin with
 			return nil


### PR DESCRIPTION
When checking if the container has already been removed, use
c.state.HasContainer() instead of the runtime's API to avoid
trying to take the already acquired lock.

Fixes: #1245
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>