### PR TITLE
Make errors during refresh nonfatal

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -628,16 +628,14 @@ func (r *Runtime) refresh(alivePath string) error {
 	for _, ctr := range ctrs {
 		ctr.lock.Lock()
 		if err := ctr.refresh(); err != nil {
-			ctr.lock.Unlock()
-			return err
+			logrus.Errorf("Error refreshing container %s: %v", ctr.ID(), err)
 		}
 		ctr.lock.Unlock()
 	}
 	for _, pod := range pods {
 		pod.lock.Lock()
 		if err := pod.refresh(); err != nil {
-			pod.lock.Unlock()
-			return err
+			logrus.Errorf("Error refreshing pod %s: %v", pod.ID(), err)
 		}
 		pod.lock.Unlock()
 	}


### PR DESCRIPTION
During refresh, we cannot hard-fail, as that would mean leaving a partially-configured state behind, leaving libpod unable to start without manual intervention.

Instead, log errors refreshing individual containers and pods and continue. Individual containers and pods may be unusable and need to be removed manually, but libpod itself will continue to
function.

Fixes #1098 