### PR TITLE
search name should include registry

### DIFF
--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -264,7 +264,7 @@ func getSearchOutput(term string, regAndSkipTLS map[string]bool, opts searchOpts
 			if len(description) > 44 && !opts.noTrunc {
 				description = description[:descriptionTruncLength] + "..."
 			}
-			name := index + "/" + results[i].Name
+			name := reg + "/" + results[i].Name
 			if index == "docker.io" && !strings.Contains(results[i].Name, "/") {
 				name = index + "/library/" + results[i].Name
 			}


### PR DESCRIPTION
When doing a podman search, the so-called NAME should be the image's
fully qualified name (not index plus shortname).

```
$ sudo podman search rhel7
INDEX        NAME                                                            DESCRIPTION                                       STARS   OFFICIAL   AUTOMATED
redhat.com   registry.access.redhat.com/rhel7/rhel                           This platform image provides a minimal runti...   0
redhat.com   registry.access.redhat.com/rhel7.0                              This platform image provides a minimal runti...   0
redhat.com   registry.access.redhat.com/rhel7                                This platform image provides a minimal runti...   0
....
```

Resolves: #1208
Resolves: Bugz #1614710

Signed-off-by: baude <bbaude@redhat.com>